### PR TITLE
Treat nil as "" for ColourTell and ColourNote

### DIFF
--- a/scripting/lua_methods.cpp
+++ b/scripting/lua_methods.cpp
@@ -1575,14 +1575,14 @@ static int L_ColourNote (lua_State *L)
     {
     if ((i + 2) < n)    // not end of line yet
       pDoc->ColourTell (
-            my_checkstring (L, i),       // TextColour
-            my_checkstring (L, i + 1),   // BackgroundColour
+            my_optstring (L, i, ""),       // TextColour
+            my_optstring (L, i + 1, ""),   // BackgroundColour
             my_checkstring (L, i + 2)    // Text
                           );
     else
       pDoc->ColourNote (
-            my_checkstring (L, i),       // TextColour
-            my_checkstring (L, i + 1),   // BackgroundColour
+            my_optstring (L, i, ""),       // TextColour
+            my_optstring (L, i + 1, ""),   // BackgroundColour
             my_checkstring (L, i + 2)    // Text
                           );
     }
@@ -1601,8 +1601,8 @@ static int L_ColourTell (lua_State *L)
   int i;
   for (i=1; i<=n; i += 3) 
     pDoc->ColourTell (
-          my_checkstring (L, i),       // TextColour
-          my_checkstring (L, i + 1),   // BackgroundColour
+          my_optstring (L, i, ""),       // TextColour
+          my_optstring (L, i + 1, ""),   // BackgroundColour
           my_checkstring (L, i + 2)    // Text
                       );
   return 0;  // number of result fields


### PR DESCRIPTION
We don't need these to be strings and it fixes a funny third party backwards compatibility issue on my end.