### PR TITLE
Expose command window desired height

### DIFF
--- a/doc.cpp
+++ b/doc.cpp
@@ -628,6 +628,7 @@ BEGIN_DISPATCH_MAP(CMUSHclientDoc, CDocument)
 	DISP_PROPERTY_PARAM(CMUSHclientDoc, "CustomColourBackground", GetCustomColourBackground, SetCustomColourBackground, VT_I4, VTS_I2)
 	DISP_FUNCTION(CMUSHclientDoc, "GetCommandCursorPosition", GetCommandCursorPosition, VT_I4, VTS_NONE)
 	DISP_FUNCTION(CMUSHclientDoc, "GetCommandLineCount", GetCommandLineCount, VT_I4, VTS_NONE)
+	DISP_FUNCTION(CMUSHclientDoc, "GetCommandWindowDesiredHeight", GetCommandWindowDesiredHeight, VT_I4, VTS_I4)
 	DISP_FUNCTION(CMUSHclientDoc, "SetCommandWindowAutoResizeSuppressed", SetCommandWindowAutoResizeSuppressed, VT_I4, VTS_BOOL)
 	//}}AFX_DISPATCH_MAP
 END_DISPATCH_MAP()

--- a/doc.h
+++ b/doc.h
@@ -2558,6 +2558,7 @@ public:
 	afx_msg BSTR GetCommand();
 	afx_msg long GetCommandCursorPosition();
 	afx_msg long GetCommandLineCount();
+	afx_msg long GetCommandWindowDesiredHeight(long CurrentHeight);
 	afx_msg long AddTriggerEx(LPCTSTR TriggerName, LPCTSTR MatchText, LPCTSTR ResponseText, long Flags, short Colour, short Wildcard, LPCTSTR SoundFileName, LPCTSTR ScriptName, short SendTo, short Sequence);
 	afx_msg VARIANT GetQueue();
 	afx_msg long DeleteTemporaryTriggers();

--- a/mushclient.cnt
+++ b/mushclient.cnt
@@ -314,6 +314,7 @@
 3 GetCommandCursorPosition=FNC_GetCommandCursorPosition
 3 GetCommandLineCount=FNC_GetCommandLineCount
 3 GetCommandList=FNC_GetCommandList 
+3 GetCommandWindowDesiredHeight=FNC_GetCommandWindowDesiredHeight
 3 GetConnectDuration=FNC_GetConnectDuration 
 3 GetCurrentValue=FNC_GetCurrentValue 
 3 GetCustomColourName=FNC_GetCustomColourName

--- a/mushclient.odl
+++ b/mushclient.odl
@@ -449,6 +449,7 @@ library MUSHclient
 			[id(419)] long GetCommandCursorPosition();
 			[id(420)] long GetCommandLineCount();
 			[id(421)] long SetCommandWindowAutoResizeSuppressed(BOOL Suppressed);
+			[id(422)] long GetCommandWindowDesiredHeight(long CurrentHeight);
 			//}}AFX_ODL_METHOD
 
 	};

--- a/scripting/functionlist.cpp
+++ b/scripting/functionlist.cpp
@@ -172,6 +172,7 @@ tInternalFunctionsTable InternalFunctionsTable [] = {
 { "GetCommandCursorPosition" ,   "( )" } ,
 { "GetCommandLineCount" ,        "( )" } ,
 { "GetCommandList" ,             "( Count )" } ,
+{ "GetCommandWindowDesiredHeight" , "( CurrentHeight )" } ,
 { "GetConnectDuration" ,         "( )" } ,
 { "GetCurrentValue" ,            "( OptionName )" } ,
 { "GetCustomColourName" ,        "( WhichColour )" } ,

--- a/scripting/lua_methods.cpp
+++ b/scripting/lua_methods.cpp
@@ -2802,6 +2802,17 @@ static int L_GetCommandLineCount (lua_State *L)
 
 
 //----------------------------------------
+//  world.GetCommandWindowDesiredHeight
+//----------------------------------------
+static int L_GetCommandWindowDesiredHeight (lua_State *L)
+  {
+  lua_pushnumber (L, doc (L)->GetCommandWindowDesiredHeight (
+                    my_checknumber (L, 1)));
+  return 1;  // number of result fields
+  } // end of L_GetCommandWindowDesiredHeight
+
+
+//----------------------------------------
 //  world.GetCommandList
 //----------------------------------------
 static int L_GetCommandList (lua_State *L)
@@ -6906,6 +6917,7 @@ static const struct luaL_Reg worldlib [] =
   {"GetCommandCursorPosition", L_GetCommandCursorPosition},
   {"GetCommandLineCount", L_GetCommandLineCount},
   {"GetCommandList", L_GetCommandList},
+  {"GetCommandWindowDesiredHeight", L_GetCommandWindowDesiredHeight},
   {"GetConnectDuration", L_GetConnectDuration},
   {"GetCurrentValue", L_GetCurrentValue},
   {"GetCustomColourName", L_GetCustomColourName},

--- a/scripting/methods/methods_commands.cpp
+++ b/scripting/methods/methods_commands.cpp
@@ -18,6 +18,7 @@
 //    GetCommand
 //    GetCommandCursorPosition
 //    GetCommandLineCount
+//    GetCommandWindowDesiredHeight
 //    GetCommandList
 //    GetInternalCommandsList
 //    GetQueue
@@ -521,6 +522,21 @@ long CMUSHclientDoc::GetCommandLineCount()
 
   return pCommandView->GetEditCtrl().GetLineCount ();
 }   // end of CMUSHclientDoc::GetCommandLineCount
+
+
+// world.GetCommandWindowDesiredHeight - applies command auto-resize policy to the supplied current height
+
+long CMUSHclientDoc::GetCommandWindowDesiredHeight(long CurrentHeight)
+{
+  if (CurrentHeight < 0)
+    return 0;
+
+  CSendView * pCommandView = GetCommandView ();
+  if (pCommandView == NULL)
+    return 0;
+
+  return pCommandView->GetCommandWindowDesiredHeight (CurrentHeight);
+}   // end of CMUSHclientDoc::GetCommandWindowDesiredHeight
 
 
 

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -2893,6 +2893,35 @@ void CSendView::OnSysCommand(UINT nID, LPARAM lParam)
 }
 
 
+int CSendView::GetCommandWindowDesiredHeight (const int iCurrentHeight)
+  {
+	CMUSHclientDoc* pDoc = GetDocument();
+	ASSERT_VALID(pDoc);
+
+  if (!pDoc->m_bAutoResizeCommandWindow)
+    return iCurrentHeight;
+
+  // find how many lines in command window
+  int iLines = GetEditCtrl().GetLineCount ();
+
+  // if too small, make the minimum
+  if (iLines < pDoc->m_iAutoResizeMinimumLines)
+    iLines = pDoc->m_iAutoResizeMinimumLines;
+
+  if (iLines > pDoc->m_iAutoResizeMaximumLines)
+    {
+    // if very large, let them manage it (that is, if they have already resized it to be larger than the maximum)
+    if (iCurrentHeight > (pDoc->m_InputFontHeight * pDoc->m_iAutoResizeMaximumLines + 4))
+      return iCurrentHeight;
+
+    // otherwise, take the maximum
+    iLines = pDoc->m_iAutoResizeMaximumLines;
+    }
+
+  return pDoc->m_InputFontHeight * iLines + 4;
+  }
+
+
 // auto resizing of command window based on amount of content
 void CSendView::AdjustCommandWindowSize (void)
   {
@@ -2904,29 +2933,12 @@ void CSendView::AdjustCommandWindowSize (void)
       pDoc->m_bSuppressCommandWindowAutoResize)
     return;
 
-  // find how many lines in command window
-  int iLines = GetEditCtrl().GetLineCount ();
-
-  // if too small, make the minimum
-  if (iLines < pDoc->m_iAutoResizeMinimumLines)
-    iLines = pDoc->m_iAutoResizeMinimumLines;
-
   CRect rect;
   GetClientRect (&rect);
 
-  if (iLines > pDoc->m_iAutoResizeMaximumLines)
-    {
-    // if very large, let them manage it (that is, if they have already resized it to be larger than the maximum)
-    if ((rect.bottom - rect.top) > (pDoc->m_InputFontHeight * pDoc->m_iAutoResizeMaximumLines + 4))
-      return;
-
-    // otherwise, take the maximum
-    iLines = pDoc->m_iAutoResizeMaximumLines;
-    }
-
   // resize - seem to need an extra 4 pixels or things go a bit strange
-  m_owner_frame->SetCommandWindowHeight (pDoc->m_InputFontHeight * iLines + 4);
-
+  m_owner_frame->SetCommandWindowHeight (
+      GetCommandWindowDesiredHeight (rect.bottom - rect.top));
   }
 
 // if we have a selection here, drop the selection in the output window

--- a/sendvw.h
+++ b/sendvw.h
@@ -77,6 +77,7 @@ public:
 
   void AddToCommandHistory (const CString & strCommand);
 
+  int GetCommandWindowDesiredHeight (const int iCurrentHeight);
   void AdjustCommandWindowSize (void);
   void CheckForSelectionChange (void);
   void CancelSelection (void);


### PR DESCRIPTION
Expose the command window auto-resize calculation through scripting so a synthetic input bar can match the native input height while preserving the existing native resize behavior.