### PR TITLE
Preserve command history during updates

### DIFF
--- a/dialogs/cmdhist.cpp
+++ b/dialogs/cmdhist.cpp
@@ -139,7 +139,13 @@ str = m_msgListSnapshot.GetAt (pos);
 
 // check they want to wipe out their typing
 
-if (m_sendview->CheckTyping (m_pDoc, str))
+const bool bKeepTyping = m_sendview->CheckTyping (m_pDoc, str);
+if (!IsContextLive ())
+  {
+  CDialog::OnCancel ();
+  return;
+  }
+if (bKeepTyping)
   return;
 
 m_sendview->SetCommand (str);

--- a/dialogs/cmdhist.cpp
+++ b/dialogs/cmdhist.cpp
@@ -30,6 +30,28 @@ CCmdHistory::CCmdHistory(CWnd* pParent /*=NULL*/)
 }
 
 
+// Copy settings without sharing a cursor, match list, or owned search resources.
+static void CopyFindSettings (CFindInfo & destination, const CFindInfo & source)
+  {
+  destination.m_strTitle = source.m_strTitle;
+  destination.m_bCanGoBackwards = source.m_bCanGoBackwards;
+  destination.m_bForwards = source.m_bForwards;
+  destination.m_bMatchCase = source.m_bMatchCase;
+  destination.m_bRegexp = source.m_bRegexp;
+  destination.m_bUTF8 = source.m_bUTF8;
+  destination.m_iControlColumns = source.m_iControlColumns;
+  destination.m_bRepeatOnSameLine = source.m_bRepeatOnSameLine;
+  destination.m_strFindStringList.RemoveAll ();
+  for (POSITION pos = source.m_strFindStringList.GetHeadPosition (); pos; )
+    destination.m_strFindStringList.AddTail (source.m_strFindStringList.GetNext (pos));
+  }
+
+void CCmdHistory::SetFindInfo (const std::shared_ptr<CFindInfo> & pFindInfo)
+  {
+  m_pHistoryFindInfo = pFindInfo;
+  CopyFindSettings (m_HistoryFindInfo, *pFindInfo);
+  }
+
 void CCmdHistory::DoDataExchange(CDataExchange* pDX)
 {
 	CDialog::DoDataExchange(pDX);
@@ -187,14 +209,21 @@ if (!IsContextLive ())
   return;
   }
 
-m_pHistoryFindInfo->m_bAgain = bAgain;
-m_pHistoryFindInfo->m_nTotalLines = m_msgListSnapshot.GetCount ();
+m_HistoryFindInfo.m_bAgain = bAgain;
+m_HistoryFindInfo.m_nTotalLines = m_msgListSnapshot.GetCount ();
 int selection = pList->GetCurSel ();
 if (selection != LB_ERR)
-  m_pHistoryFindInfo->m_nCurrentLine = selection;
+  m_HistoryFindInfo.m_nCurrentLine = selection;
+
+// Find Next can use saved settings before this dialog has compiled the pattern.
+if (bAgain && m_HistoryFindInfo.m_bRegexp &&
+    !m_HistoryFindInfo.m_regexp && !m_HistoryFindInfo.m_strFindStringList.IsEmpty ())
+  m_HistoryFindInfo.m_regexp = regcomp (m_HistoryFindInfo.m_strFindStringList.GetHead (),
+      (m_HistoryFindInfo.m_bMatchCase ? 0 : PCRE_CASELESS) |
+      (m_HistoryFindInfo.m_bUTF8 ? PCRE_UTF8 : 0));
 
 bool found = FindRoutine (&m_msgListSnapshot,    // passed back to callback routines
-                          *m_pHistoryFindInfo,   // finding structure
+                          m_HistoryFindInfo,     // finding structure
                           InitiateSearch,        // how to re-initiate a find
                           GetNextLine);          // get the next line
 
@@ -205,14 +234,15 @@ if (!IsContextLive ())
   return;
   }
 
-m_pHistoryFindInfo->m_pFindPosition = NULL;
+m_HistoryFindInfo.m_pFindPosition = NULL;
+CopyFindSettings (*m_pHistoryFindInfo, m_HistoryFindInfo);
 
 // Get the control again after the nested message loops.
 pList = (CListBox*) GetDlgItem (IDC_COMMANDS);
 ASSERT (pList);
 	
   if (found)
-    pList->SetCurSel (m_pHistoryFindInfo->m_nCurrentLine);
+    pList->SetCurSel (m_HistoryFindInfo.m_nCurrentLine);
   else
     pList->SetCurSel (-1);
 

--- a/dialogs/cmdhist.cpp
+++ b/dialogs/cmdhist.cpp
@@ -209,7 +209,9 @@ if (!IsContextLive ())
   return;
   }
 
-m_HistoryFindInfo.m_bAgain = bAgain;
+// Find Next needs a new search when no search text is saved.
+m_HistoryFindInfo.m_bAgain = bAgain &&
+    !m_HistoryFindInfo.m_strFindStringList.IsEmpty ();
 m_HistoryFindInfo.m_nTotalLines = m_msgListSnapshot.GetCount ();
 int selection = pList->GetCurSel ();
 if (selection != LB_ERR)

--- a/dialogs/cmdhist.cpp
+++ b/dialogs/cmdhist.cpp
@@ -22,6 +22,12 @@ CCmdHistory::CCmdHistory(CWnd* pParent /*=NULL*/)
 {
 	//{{AFX_DATA_INIT(CCmdHistory)
 	//}}AFX_DATA_INIT
+  m_msgList = NULL;
+  m_sendview = NULL;
+  m_pHistoryFindInfo = NULL;
+  m_pDoc = NULL;
+  m_iDocumentNumber = 0;
+  m_hSendView = NULL;
 }
 
 
@@ -40,6 +46,7 @@ int count = 0;
 
    pList->SetRedraw (FALSE);
    pList->ResetContent ();
+   m_msgListSnapshot.RemoveAll ();
 
   CString str;
   POSITION pos = m_msgList->GetHeadPosition ();
@@ -47,21 +54,24 @@ int count = 0;
   while (pos)
     {
     int nItem;
-    POSITION itemPos = pos;
     str = m_msgList->GetNext (pos);
+    CString strDisplay = str;
 
     // truncate long strings or we might get a nasty crash with long strings
 
-    if (str.GetLength () > 500)
+    if (strDisplay.GetLength () > 500)
       {
-      str = str.Left (500);
-      str += " ...";
+      strDisplay = strDisplay.Left (500);
+      strDisplay += " ...";
       }
 
-    nItem = pList->AddString(str);  // add to list (truncate to 500 chars)
+    nItem = pList->AddString(strDisplay);  // add to list (truncate to 500 chars)
     if (nItem != LB_ERR  && nItem != LB_ERRSPACE)
-      pList->SetItemData (nItem, (DWORD) itemPos);   // remember all about this string
-    count++;
+      {
+      POSITION itemPos = m_msgListSnapshot.AddTail (str);
+      pList->SetItemData (nItem, (DWORD) itemPos);
+      count++;
+      }
     }
 
    pList->SetCurSel(count - 1);
@@ -70,6 +80,27 @@ int count = 0;
     }   // end of loading the dialog
 
 }
+
+bool CCmdHistory::IsContextLive (void) const
+  {
+  if (!m_pDoc || !m_sendview || !m_hSendView)
+    return false;
+
+  bool bDocumentLive = false;
+  for (POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition(); pos; )
+    {
+    CMUSHclientDoc * pDoc =
+      (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (pos);
+    if (pDoc == m_pDoc && pDoc->m_iUniqueDocumentNumber == m_iDocumentNumber)
+      {
+      bDocumentLive = true;
+      break;
+      }
+    }
+
+  return bDocumentLive && ::IsWindow (m_hSendView) &&
+         CWnd::FromHandlePermanent (m_hSendView) == m_sendview;
+  }
 
 
 BEGIN_MESSAGE_MAP(CCmdHistory, CDialog)
@@ -98,8 +129,14 @@ CString str;
 if (selection == LB_ERR)
   return;
 
+if (!IsContextLive ())
+  {
+  CDialog::OnCancel ();
+  return;
+  }
+
 POSITION pos = (POSITION) pList->GetItemData (selection);
-str = m_msgList->GetAt (pos);
+str = m_msgListSnapshot.GetAt (pos);
 
 // check they want to wipe out their typing
 
@@ -139,13 +176,24 @@ void CCmdHistory::DoFind (bool bAgain)
 CListBox* pList = (CListBox*) GetDlgItem (IDC_COMMANDS);
 ASSERT (pList);
 
-m_pHistoryFindInfo->m_bAgain = bAgain;
-m_pHistoryFindInfo->m_nTotalLines = m_msgList->GetCount ();
+if (!IsContextLive ())
+  {
+  CDialog::OnCancel ();
+  return;
+  }
 
-bool found = FindRoutine (m_msgList,             // passed back to callback routines
+m_pHistoryFindInfo->m_bAgain = bAgain;
+m_pHistoryFindInfo->m_nTotalLines = m_msgListSnapshot.GetCount ();
+int selection = pList->GetCurSel ();
+if (selection != LB_ERR)
+  m_pHistoryFindInfo->m_nCurrentLine = selection;
+
+bool found = FindRoutine (&m_msgListSnapshot,    // passed back to callback routines
                           *m_pHistoryFindInfo,   // finding structure
                           InitiateSearch,        // how to re-initiate a find
                           GetNextLine);          // get the next line
+
+m_pHistoryFindInfo->m_pFindPosition = NULL;
 	
   if (found)
     pList->SetCurSel (m_pHistoryFindInfo->m_nCurrentLine);
@@ -221,8 +269,14 @@ CString str;
 if (selection == LB_ERR)
   return;
 
+if (!IsContextLive ())
+  {
+  CDialog::OnCancel ();
+  return;
+  }
+
 POSITION pos = (POSITION) pList->GetItemData (selection);
-str = m_msgList->GetAt (pos);
+str = m_msgListSnapshot.GetAt (pos);
 
 m_sendview->SendCommand (str, TRUE);
 	
@@ -238,8 +292,14 @@ CString str;
   if (selection == LB_ERR)
     return;
 
+  if (!IsContextLive ())
+    {
+    CDialog::OnCancel ();
+    return;
+    }
+
   POSITION pos = (POSITION) pList->GetItemData (selection);
-  str = m_msgList->GetAt (pos);
+  str = m_msgListSnapshot.GetAt (pos);
 
   // edit current input window
   CreateTextWindow ((LPCTSTR) str,     // command

--- a/dialogs/cmdhist.cpp
+++ b/dialogs/cmdhist.cpp
@@ -24,7 +24,6 @@ CCmdHistory::CCmdHistory(CWnd* pParent /*=NULL*/)
 	//}}AFX_DATA_INIT
   m_msgList = NULL;
   m_sendview = NULL;
-  m_pHistoryFindInfo = NULL;
   m_pDoc = NULL;
   m_iDocumentNumber = 0;
   m_hSendView = NULL;
@@ -193,7 +192,18 @@ bool found = FindRoutine (&m_msgListSnapshot,    // passed back to callback rout
                           InitiateSearch,        // how to re-initiate a find
                           GetNextLine);          // get the next line
 
+// FindRoutine can process messages that close the world or destroy the send view.
+if (!IsContextLive ())
+  {
+  CDialog::OnCancel ();
+  return;
+  }
+
 m_pHistoryFindInfo->m_pFindPosition = NULL;
+
+// Get the control again after the nested message loops.
+pList = (CListBox*) GetDlgItem (IDC_COMMANDS);
+ASSERT (pList);
 	
   if (found)
     pList->SetCurSel (m_pHistoryFindInfo->m_nCurrentLine);

--- a/dialogs/cmdhist.h
+++ b/dialogs/cmdhist.h
@@ -13,7 +13,7 @@ public:
   CStringList * m_msgList;
   CStringList m_msgListSnapshot;
   CSendView * m_sendview;
-  CFindInfo * m_pHistoryFindInfo;
+  std::shared_ptr<CFindInfo> m_pHistoryFindInfo;
   CMUSHclientDoc* m_pDoc;
   __int64 m_iDocumentNumber;
   HWND m_hSendView;

--- a/dialogs/cmdhist.h
+++ b/dialogs/cmdhist.h
@@ -11,9 +11,12 @@ public:
 	CCmdHistory(CWnd* pParent = NULL);   // standard constructor
 
   CStringList * m_msgList;
+  CStringList m_msgListSnapshot;
   CSendView * m_sendview;
   CFindInfo * m_pHistoryFindInfo;
   CMUSHclientDoc* m_pDoc;
+  __int64 m_iDocumentNumber;
+  HWND m_hSendView;
 
 // Dialog Data
 	//{{AFX_DATA(CCmdHistory)
@@ -43,6 +46,7 @@ protected:
                            CString & strLine);
 
   void DoFind (bool bAgain);
+  bool IsContextLive (void) const;
 
 
   // Generated message map functions

--- a/dialogs/cmdhist.h
+++ b/dialogs/cmdhist.h
@@ -14,9 +14,12 @@ public:
   CStringList m_msgListSnapshot;
   CSendView * m_sendview;
   std::shared_ptr<CFindInfo> m_pHistoryFindInfo;
+  CFindInfo m_HistoryFindInfo;
   CMUSHclientDoc* m_pDoc;
   __int64 m_iDocumentNumber;
   HWND m_hSendView;
+
+  void SetFindInfo (const std::shared_ptr<CFindInfo> & pFindInfo);
 
 // Dialog Data
 	//{{AFX_DATA(CCmdHistory)

--- a/scripting/methods/methods_commands.cpp
+++ b/scripting/methods/methods_commands.cpp
@@ -232,9 +232,9 @@ void CMUSHclientDoc::DeleteCommandHistory()
       pmyView->m_HistoryPosition = NULL;
       pmyView->m_iHistoryStatus = eAtBottom;
       pmyView->m_inputcount = 0;
-      pmyView->m_HistoryFindInfo.m_pFindPosition = NULL;
-      pmyView->m_HistoryFindInfo.m_nCurrentLine = 0;
-      pmyView->m_HistoryFindInfo.m_bAgain = FALSE;  
+      pmyView->m_pHistoryFindInfo->m_pFindPosition = NULL;
+      pmyView->m_pHistoryFindInfo->m_nCurrentLine = 0;
+      pmyView->m_pHistoryFindInfo->m_bAgain = FALSE;
       pmyView->m_strPartialCommand.Empty ();
       pmyView->m_last_command.Empty ();
 

--- a/scripting/methods/methods_commands.cpp
+++ b/scripting/methods/methods_commands.cpp
@@ -228,8 +228,9 @@ void CMUSHclientDoc::DeleteCommandHistory()
 		  CSendView* pmyView = (CSendView*)pView;
 
       // OK, do it ...
-	    pmyView->m_msgList.RemoveAll ();
+      pmyView->m_msgList.RemoveAll ();
       pmyView->m_HistoryPosition = NULL;
+      pmyView->m_iHistoryStatus = eAtBottom;
       pmyView->m_inputcount = 0;
       pmyView->m_HistoryFindInfo.m_pFindPosition = NULL;
       pmyView->m_HistoryFindInfo.m_nCurrentLine = 0;

--- a/scripting/methods/methods_sending.cpp
+++ b/scripting/methods/methods_sending.cpp
@@ -68,27 +68,9 @@ long CMUSHclientDoc::SendNoEcho(LPCTSTR Message)
 
 void CMUSHclientDoc::AddToCommandHistory (LPCTSTR Message)
   {
-
   CSendView * pmyView = GetCommandView ();
   if (pmyView)
-    {
-
-      if (strlen (Message) > 0 && strcmp (Message, pmyView->m_last_command) != 0)
-        {
-        if (pmyView->m_inputcount >= m_nHistoryLines)
-          {
-          pmyView->m_msgList.RemoveHead ();   // keep max of "m_nHistoryLines" previous commands
-          pmyView->m_HistoryFindInfo.m_nCurrentLine--;     // adjust for a "find again"
-          if (pmyView->m_HistoryFindInfo.m_nCurrentLine < 0)
-            pmyView->m_HistoryFindInfo.m_nCurrentLine = 0;
-          }   // end of buffer full
-        else
-          pmyView->m_inputcount++;
-        pmyView->m_msgList.AddTail (Message);
-        pmyView->m_last_command = Message;
-        } // end of different from last one
-
-    }
+    pmyView->AddToCommandHistory (Message, false, false);
 
   } // end of CMUSHclientDoc::AddToCommandHistory
 

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -256,10 +256,11 @@ END_MESSAGE_MAP()
 // CSendView construction/destruction
 
 CSendView::CSendView()
+  : m_pHistoryFindInfo (new CFindInfo)
 {
   m_HistoryPosition = NULL;
   m_inputcount = 0;
-  m_HistoryFindInfo.m_strTitle = "Find in command history...";
+  m_pHistoryFindInfo->m_strTitle = "Find in command history...";
   m_iHistoryStatus = eAtBottom;
   m_backbr = NULL;
 }
@@ -859,7 +860,7 @@ CCmdHistory dlg;
 
   dlg.m_msgList = &m_msgList;
   dlg.m_sendview = this;
-  dlg.m_pHistoryFindInfo = &m_HistoryFindInfo;    // for finding
+  dlg.m_pHistoryFindInfo = m_pHistoryFindInfo;    // for finding
   dlg.m_pDoc = pDoc;            // for confirming replacement of typing
   dlg.m_iDocumentNumber = pDoc->m_iUniqueDocumentNumber;
   dlg.m_hSendView = GetSafeHwnd ();
@@ -2138,9 +2139,9 @@ void CSendView::OnDisplayClearCommandHistory()
   m_HistoryPosition = NULL;
   m_iHistoryStatus = eAtBottom;
   m_inputcount = 0;
-  m_HistoryFindInfo.m_pFindPosition = NULL;
-  m_HistoryFindInfo.m_nCurrentLine = 0;
-  m_HistoryFindInfo.m_bAgain = FALSE;  
+  m_pHistoryFindInfo->m_pFindPosition = NULL;
+  m_pHistoryFindInfo->m_nCurrentLine = 0;
+  m_pHistoryFindInfo->m_bAgain = FALSE;
   m_strPartialCommand.Empty ();
   m_last_command.Empty ();
   
@@ -2410,12 +2411,12 @@ ASSERT_VALID(pDoc);
         m_HistoryPosition = NULL;
         m_iHistoryStatus = eAtTop;
         }
-      if (m_HistoryFindInfo.m_pFindPosition == oldHead)
-        m_HistoryFindInfo.m_pFindPosition = NULL;
+      if (m_pHistoryFindInfo->m_pFindPosition == oldHead)
+        m_pHistoryFindInfo->m_pFindPosition = NULL;
       m_msgList.RemoveHead ();   // keep max of "m_nHistoryLines" previous commands
-      m_HistoryFindInfo.m_nCurrentLine--;     // adjust for a "find again"
-      if (m_HistoryFindInfo.m_nCurrentLine < 0)
-        m_HistoryFindInfo.m_nCurrentLine = 0;
+      m_pHistoryFindInfo->m_nCurrentLine--;     // adjust for a "find again"
+      if (m_pHistoryFindInfo->m_nCurrentLine < 0)
+        m_pHistoryFindInfo->m_nCurrentLine = 0;
       }
     else
       m_inputcount++;

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -875,7 +875,7 @@ CCmdHistory dlg;
 
   dlg.m_msgList = &m_msgList;
   dlg.m_sendview = this;
-  dlg.m_pHistoryFindInfo = m_pHistoryFindInfo;    // for finding
+  dlg.SetFindInfo (m_pHistoryFindInfo);    // saved search settings
   dlg.m_pDoc = pDoc;            // for confirming replacement of typing
   dlg.m_iDocumentNumber = pDoc->m_iUniqueDocumentNumber;
   dlg.m_hSendView = GetSafeHwnd ();

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -513,7 +513,9 @@ void CSendView::OnKeysPrevcommand()
   if (m_HistoryPosition &&   
       !strCommand.IsEmpty () &&
       pDoc->m_bAutoRepeat && 
-      m_iHistoryStatus == eAtBottom)
+      m_iHistoryStatus == eAtBottom &&
+      !m_bChanged &&
+      strCommand == m_msgList.GetAt (m_HistoryPosition))
     m_msgList.GetPrev (m_HistoryPosition);
 
   if (m_HistoryPosition)
@@ -859,6 +861,8 @@ CCmdHistory dlg;
   dlg.m_sendview = this;
   dlg.m_pHistoryFindInfo = &m_HistoryFindInfo;    // for finding
   dlg.m_pDoc = pDoc;            // for confirming replacement of typing
+  dlg.m_iDocumentNumber = pDoc->m_iUniqueDocumentNumber;
+  dlg.m_hSendView = GetSafeHwnd ();
 
   dlg.DoModal ();
 
@@ -1347,20 +1351,7 @@ CString strCurrent;
 
   // do not record null commands, or ones identical to the previous one
 
-    if (!str.IsEmpty () && str != m_last_command)
-      {
-      if (m_inputcount >= pDoc->m_nHistoryLines)
-        {
-        m_msgList.RemoveHead ();   // keep max of "m_nHistoryLines" previous commands
-        m_HistoryFindInfo.m_nCurrentLine--;     // adjust for a "find again"
-        if (m_HistoryFindInfo.m_nCurrentLine < 0)
-          m_HistoryFindInfo.m_nCurrentLine = 0;
-        }
-      else
-        m_inputcount++;
-      m_msgList.AddTail (str);
-      m_last_command = str;
-      }  // end command different
+    AddToCommandHistory (str, false, false);
     }     // end if save deleted command
 
   return false;
@@ -1634,20 +1625,7 @@ ASSERT_VALID(pDoc);
 
     // do not record null commands, or ones identical to the previous one
 
-      if (!str.IsEmpty () && str != m_last_command)
-        {
-        if (m_inputcount >= pDoc->m_nHistoryLines)
-          {
-          m_msgList.RemoveHead ();   // keep max of "m_nHistoryLines" previous commands
-          m_HistoryFindInfo.m_nCurrentLine--;     // adjust for a "find again"
-          if (m_HistoryFindInfo.m_nCurrentLine < 0)
-            m_HistoryFindInfo.m_nCurrentLine = 0;
-          }
-        else
-          m_inputcount++;
-        m_msgList.AddTail (str);
-        m_last_command = str;
-        }
+      AddToCommandHistory (str, false, false);
       }
 
   	GetEditCtrl().SetWindowText ("");
@@ -2158,6 +2136,7 @@ void CSendView::OnDisplayClearCommandHistory()
   // OK, do it ...
 	m_msgList.RemoveAll ();
   m_HistoryPosition = NULL;
+  m_iHistoryStatus = eAtBottom;
   m_inputcount = 0;
   m_HistoryFindInfo.m_pFindPosition = NULL;
   m_HistoryFindInfo.m_nCurrentLine = 0;
@@ -2408,7 +2387,9 @@ ASSERT_VALID(pDoc);
 }   // end of CSendView::OnEditCtrlZ
 
 
-void CSendView::AddToCommandHistory (const CString & strCommand)
+void CSendView::AddToCommandHistory (const CString & strCommand,
+                                     const bool bRespectNoEcho,
+                                     const bool bResetHistoryPosition)
   {
 CMUSHclientDoc* pDoc = GetDocument();
 ASSERT_VALID(pDoc);
@@ -2418,10 +2399,19 @@ ASSERT_VALID(pDoc);
 
   if (!strCommand.IsEmpty () && 
       strCommand != m_last_command &&
-      !(pDoc->m_bNoEcho && !pDoc->m_bAlwaysRecordCommandHistory)) 
+      (!bRespectNoEcho ||
+       !(pDoc->m_bNoEcho && !pDoc->m_bAlwaysRecordCommandHistory)))
     {
     if (m_inputcount >= pDoc->m_nHistoryLines)
       {
+      POSITION oldHead = m_msgList.GetHeadPosition ();
+      if (m_HistoryPosition == oldHead)
+        {
+        m_HistoryPosition = NULL;
+        m_iHistoryStatus = eAtTop;
+        }
+      if (m_HistoryFindInfo.m_pFindPosition == oldHead)
+        m_HistoryFindInfo.m_pFindPosition = NULL;
       m_msgList.RemoveHead ();   // keep max of "m_nHistoryLines" previous commands
       m_HistoryFindInfo.m_nCurrentLine--;     // adjust for a "find again"
       if (m_HistoryFindInfo.m_nCurrentLine < 0)
@@ -2433,9 +2423,12 @@ ASSERT_VALID(pDoc);
     m_last_command = strCommand;
     }
 
-  // history starts at bottom of list again - especially as we may have discarded lines
-  m_HistoryPosition = NULL;
-  m_iHistoryStatus = eAtBottom;
+  // Sending a command starts history at the bottom. Appending alone does not.
+  if (bResetHistoryPosition)
+    {
+    m_HistoryPosition = NULL;
+    m_iHistoryStatus = eAtBottom;
+    }
 
   } // end of  CSendView::AddToCommandHistory 
 

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -39,6 +39,19 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 
 static CString RandomString();
 
+static bool IsWorldDocumentLive (const CMUSHclientDoc * pExpectedDoc,
+                                 const __int64 iDocumentNumber)
+  {
+  for (POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition(); pos; )
+    {
+    CMUSHclientDoc * pDoc =
+      (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (pos);
+    if (pDoc == pExpectedDoc && pDoc->m_iUniqueDocumentNumber == iDocumentNumber)
+      return true;
+    }
+  return false;
+  }
+
 /////////////////////////////////////////////////////////////////////////////
 // CSendView
 
@@ -754,6 +767,7 @@ void CSendView::SendMacro (int whichone)
 
 // turn auto-say off, they obviously don't want to say west, QUIT, etc.
 
+  const __int64 iDocumentNumber = pDoc->m_iUniqueDocumentNumber;
   BOOL bSavedAutoSay = pDoc->m_bEnableAutoSay;
   pDoc->m_bEnableAutoSay = FALSE;
 
@@ -791,7 +805,8 @@ void CSendView::SendMacro (int whichone)
 
 // restore auto-say
 
-  pDoc->m_bEnableAutoSay = bSavedAutoSay;
+  if (IsWorldDocumentLive (pDoc, iDocumentNumber))
+    pDoc->m_bEnableAutoSay = bSavedAutoSay;
 
   } // end of SendMacro
 
@@ -1291,7 +1306,7 @@ ASSERT_VALID(pDoc);
   pCmdUI->Enable (pDoc->m_iConnectPhase == eConnectConnectedToMud);    // not if session closed
 }
 
-// returns true if they don't want their typing replaced
+// Returns true if typing must not be replaced, including when its context has closed.
 
 bool CSendView::CheckTyping (CMUSHclientDoc* pDoc, CString strReplacement)
   {
@@ -1332,8 +1347,18 @@ CString strCurrent;
     CString strMsg;
     strMsg = TFormat ("Replace your typing of\n\n\"%s\"\n\nwith\n\n\"%s\"?",
                    (LPCTSTR) strCurrent, (LPCTSTR) strReplacement);
-    if (::UMessageBox (strMsg, MB_OKCANCEL | MB_ICONQUESTION | MB_DEFBUTTON2)
-        == IDCANCEL)
+    const __int64 iDocumentNumber = pDoc->m_iUniqueDocumentNumber;
+    const HWND hSendView = GetSafeHwnd ();
+    const int iResult = ::UMessageBox (strMsg,
+                         MB_OKCANCEL | MB_ICONQUESTION | MB_DEFBUTTON2);
+
+    // The confirmation can process messages that destroy the document or this view.
+    if (!IsWorldDocumentLive (pDoc, iDocumentNumber) ||
+        !::IsWindow (hSendView) ||
+        CWnd::FromHandlePermanent (hSendView) != this)
+      return true;
+
+    if (iResult == IDCANCEL)
       {
         m_iHistoryStatus = eAtBottom;   // we are still at bottom therefore
         m_HistoryPosition = NULL;

--- a/sendvw.h
+++ b/sendvw.h
@@ -52,7 +52,8 @@ public:
 
 // stuff for finding in the input buffer
 
-  CFindInfo m_HistoryFindInfo;
+  // Keep search state alive while a history dialog is open.
+  std::shared_ptr<CFindInfo> m_pHistoryFindInfo;
 
 // Operations
 public:

--- a/sendvw.h
+++ b/sendvw.h
@@ -52,7 +52,7 @@ public:
 
 // stuff for finding in the input buffer
 
-  // Keep search state alive while a history dialog is open.
+  // Keep saved search settings alive while a history dialog is open.
   std::shared_ptr<CFindInfo> m_pHistoryFindInfo;
 
 // Operations

--- a/sendvw.h
+++ b/sendvw.h
@@ -75,7 +75,9 @@ public:
 
   void NotifyPluginCommandChanged ();
 
-  void AddToCommandHistory (const CString & strCommand);
+  void AddToCommandHistory (const CString & strCommand,
+                            const bool bRespectNoEcho = true,
+                            const bool bResetHistoryPosition = true);
 
   int GetCommandWindowDesiredHeight (const int iCurrentHeight);
   void AdjustCommandWindowSize (void);

--- a/stdafx.h
+++ b/stdafx.h
@@ -86,6 +86,7 @@
 #include <map>
 #include <set>
 #include <list>
+#include <memory>
 #include <algorithm>
 #include <functional>
 #include <iostream>


### PR DESCRIPTION
Keep history navigation and search cursors valid during append, eviction, and clear operations. Give the history dialog a stable snapshot and validate its world and view before actions, while preserving append-only navigation and the existing command recording rules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-history reliability when documents or views change during searches, command execution, and sending.
  * Preserved command-history search settings while the history window is open.
  * Fixed history navigation to avoid skipping the current automatically repeated command.
  * Improved handling of deleted commands and history position tracking.
  * Prevented invalid contexts from affecting macro execution and typing-replacement dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->