### PR TITLE
Match file dialog buffer capacity to its contents

### DIFF
--- a/ActivityDoc.cpp
+++ b/ActivityDoc.cpp
@@ -91,7 +91,7 @@ void CActivityDoc::OnFileOpen()
                  NULL);        // parent window
 
 	dlgFile.m_ofn.lpstrTitle = title;
-	dlgFile.m_ofn.lpstrFile = fileName.GetBuffer(_MAX_PATH);
+	SetFileDialogFileName (dlgFile, fileName, "");
 
   // use default world file directory
   dlgFile.m_ofn.lpstrInitialDir = Make_Absolute_Path (App.m_strDefaultWorldFileDirectory);

--- a/TextDocument.cpp
+++ b/TextDocument.cpp
@@ -341,7 +341,7 @@ void CTextDocument::OnFileOpen()
                  NULL);        // parent window
 
 	dlgFile.m_ofn.lpstrTitle = title;
-	dlgFile.m_ofn.lpstrFile = fileName.GetBuffer(_MAX_PATH);
+	SetFileDialogFileName (dlgFile, fileName, "");
   ChangeToFileBrowsingDirectory ();
 	int nResult = dlgFile.DoModal();
   ChangeToStartupDirectory ();

--- a/Utilities.cpp
+++ b/Utilities.cpp
@@ -236,6 +236,15 @@ int i;
 
 } // end of FixupEscapeSequences
 
+void SetFileDialogFileName (CFileDialog & dialog, CString & buffer,
+                            const CString & initialName)
+  {
+  buffer = initialName;
+  int iBufferLength = MAX (_MAX_PATH, buffer.GetLength () + 1);
+  dialog.m_ofn.nMaxFile = iBufferLength;
+  dialog.m_ofn.lpstrFile = buffer.GetBuffer (iBufferLength);
+  }
+
 
 
 

--- a/dialogs/global_prefs/GlobalPrefs.cpp
+++ b/dialogs/global_prefs/GlobalPrefs.cpp
@@ -905,15 +905,15 @@ CString suggested_name = "Default",
                        this);  // parent window
 
   filedlg.m_ofn.lpstrTitle = title;
-  filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
   if (App.platform == VER_PLATFORM_WIN32s)
-    strcpy (filedlg.m_ofn.lpstrFile, "");
+    SetFileDialogFileName (filedlg, filename, "");
   else
-    strcpy (filedlg.m_ofn.lpstrFile, suggested_name);
+    SetFileDialogFileName (filedlg, filename, suggested_name);
 
   ChangeToFileBrowsingDirectory ();
 	int nResult = filedlg.DoModal();
   ChangeToStartupDirectory ();
+  filename.ReleaseBuffer ();
 
   if (nResult != IDOK)
     return true;    // cancelled dialog

--- a/dialogs/world_prefs/prefspropertypages.cpp
+++ b/dialogs/world_prefs/prefspropertypages.cpp
@@ -5172,12 +5172,12 @@ DWORD length;
                        NULL);  // parent window
 
   filedlg.m_ofn.lpstrTitle = "File to load notes from";
-  filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
-  strcpy (filedlg.m_ofn.lpstrFile, "");
+  SetFileDialogFileName (filedlg, filename, "");
 
   ChangeToFileBrowsingDirectory ();
   int nResult = filedlg.DoModal();
   ChangeToStartupDirectory ();
+  filename.ReleaseBuffer ();
 
   if (nResult != IDOK)
     return;    // cancelled dialog
@@ -5242,15 +5242,15 @@ CString str;
                        NULL);  // parent window
 
   filedlg.m_ofn.lpstrTitle = "File to save notes into";
-  filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
   if (App.platform == VER_PLATFORM_WIN32s)
-    strcpy (filedlg.m_ofn.lpstrFile, "");
+    SetFileDialogFileName (filedlg, filename, "");
   else
-    strcpy (filedlg.m_ofn.lpstrFile, suggested_name);
+    SetFileDialogFileName (filedlg, filename, suggested_name);
 
   ChangeToFileBrowsingDirectory ();
   int nResult = filedlg.DoModal();
   ChangeToStartupDirectory ();
+  filename.ReleaseBuffer ();
 
   if (nResult != IDOK)
     return;    // cancelled dialog
@@ -6069,13 +6069,12 @@ CString filename;
                        this);  // parent window
 
   filedlg.m_ofn.lpstrTitle = "Select sound to play";
-  filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
-
-  strcpy (filedlg.m_ofn.lpstrFile, m_strBeepSound);
+  SetFileDialogFileName (filedlg, filename, m_strBeepSound);
     
   ChangeToFileBrowsingDirectory ();
   int nResult = filedlg.DoModal();
   ChangeToStartupDirectory ();
+  filename.ReleaseBuffer ();
 
   if (nResult != IDOK)
     return;    // cancelled dialog
@@ -9004,19 +9003,15 @@ CString filename;
                        this);  // parent window
 
   filedlg.m_ofn.lpstrTitle = "Select sound to play";
-  filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
-
-  if (App.platform == VER_PLATFORM_WIN32s)
-    strcpy (filedlg.m_ofn.lpstrFile, "");
-  else
-    strcpy (filedlg.m_ofn.lpstrFile, m_sound_pathname);
-
-  if (m_sound_pathname == NOSOUNDLIT)
-    strcpy (filedlg.m_ofn.lpstrFile, "");
+  CString strInitialSound = m_sound_pathname;
+  if (App.platform == VER_PLATFORM_WIN32s || m_sound_pathname == NOSOUNDLIT)
+    strInitialSound.Empty ();
+  SetFileDialogFileName (filedlg, filename, strInitialSound);
     
   ChangeToFileBrowsingDirectory ();
   int nResult = filedlg.DoModal();
   ChangeToStartupDirectory ();
+  filename.ReleaseBuffer ();
 
   if (nResult != IDOK)
     return;    // cancelled dialog

--- a/dialogs/world_prefs/triggdlg.cpp
+++ b/dialogs/world_prefs/triggdlg.cpp
@@ -413,19 +413,15 @@ CString filename;
                        this);  // parent window
 
   filedlg.m_ofn.lpstrTitle = "Select sound to play";
-  filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
-
-  if (App.platform == VER_PLATFORM_WIN32s)
-    strcpy (filedlg.m_ofn.lpstrFile, "");
-  else
-    strcpy (filedlg.m_ofn.lpstrFile, m_sound_pathname);
-
-  if (m_sound_pathname == NOSOUNDLIT)
-    strcpy (filedlg.m_ofn.lpstrFile, "");
+  CString strInitialSound = m_sound_pathname;
+  if (App.platform == VER_PLATFORM_WIN32s || m_sound_pathname == NOSOUNDLIT)
+    strInitialSound.Empty ();
+  SetFileDialogFileName (filedlg, filename, strInitialSound);
     
   ChangeToFileBrowsingDirectory ();
   int nResult = filedlg.DoModal();
   ChangeToStartupDirectory ();
+  filename.ReleaseBuffer ();
 
   if (nResult != IDOK)
     return;    // cancelled dialog

--- a/doc.cpp
+++ b/doc.cpp
@@ -2961,15 +2961,15 @@ if (!m_bLogRaw)
 
 
   filedlg.m_ofn.lpstrTitle = "Log file name";
-  filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
   if (App.platform == VER_PLATFORM_WIN32s)
-    strcpy (filedlg.m_ofn.lpstrFile, "");
+    SetFileDialogFileName (filedlg, filename, "");
   else
-    strcpy (filedlg.m_ofn.lpstrFile, suggested_name);
+    SetFileDialogFileName (filedlg, filename, suggested_name);
 
   ChangeToFileBrowsingDirectory ();
 	int nResult = filedlg.DoModal();
   ChangeToStartupDirectory ();
+  filename.ReleaseBuffer ();
 
   if (nResult != IDOK)
     return;
@@ -3780,12 +3780,12 @@ CString filename;
   str = "File to paste into ";
   str += m_mush_name;
   filedlg.m_ofn.lpstrTitle = str;
-  filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
-  strcpy (filedlg.m_ofn.lpstrFile, "");
+  SetFileDialogFileName (filedlg, filename, "");
 
   ChangeToFileBrowsingDirectory ();
 	int nResult = filedlg.DoModal();
   ChangeToStartupDirectory ();
+  filename.ReleaseBuffer ();
 
   if (nResult != IDOK)
     return;    // cancelled dialog

--- a/evaluate.cpp
+++ b/evaluate.cpp
@@ -579,15 +579,15 @@ if (strFileName.IsEmpty ())
                          parent_window);  // parent window
 
     filedlg.m_ofn.lpstrTitle = title;
-    filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
     if (App.platform == VER_PLATFORM_WIN32s)
-      strcpy (filedlg.m_ofn.lpstrFile, "");
+      SetFileDialogFileName (filedlg, filename, "");
     else
-      strcpy (filedlg.m_ofn.lpstrFile, suggested_name);
+      SetFileDialogFileName (filedlg, filename, suggested_name);
 
     ChangeToFileBrowsingDirectory ();
     int nResult = filedlg.DoModal();
     ChangeToStartupDirectory ();
+    filename.ReleaseBuffer ();
 
     if (nResult!= IDOK)
       return TRUE;    // cancelled dialog
@@ -745,15 +745,15 @@ CString filename;
     suggested_name = suggested_name.Left (i) + suggested_name.Mid (i + 1);
 
   filedlg.m_ofn.lpstrTitle = title;
-  filedlg.m_ofn.lpstrFile = filename.GetBuffer (_MAX_PATH); // needed!! (for Win32s)  
   if (App.platform == VER_PLATFORM_WIN32s)
-    strcpy (filedlg.m_ofn.lpstrFile, "");
+    SetFileDialogFileName (filedlg, filename, "");
   else
-    strcpy (filedlg.m_ofn.lpstrFile, suggested_name);
+    SetFileDialogFileName (filedlg, filename, suggested_name);
 
   ChangeToFileBrowsingDirectory ();
   int nResult = filedlg.DoModal();
   ChangeToStartupDirectory ();
+  filename.ReleaseBuffer ();
 
   if (nResult != IDOK)
     return TRUE;    // cancelled dialog

--- a/mainfrm.cpp
+++ b/mainfrm.cpp
@@ -1752,7 +1752,7 @@ void CMainFrame::DoFileOpen (void)
                  NULL);        // parent window
 
 	dlgFile.m_ofn.lpstrTitle = title;
-	dlgFile.m_ofn.lpstrFile = fileName.GetBuffer(_MAX_PATH);
+	SetFileDialogFileName (dlgFile, fileName, strSuggestedName);
 
   // use default world file directory
   dlgFile.m_ofn.lpstrInitialDir = Make_Absolute_Path (App.m_strDefaultWorldFileDirectory);

--- a/stdafx.h
+++ b/stdafx.h
@@ -86,7 +86,6 @@
 #include <map>
 #include <set>
 #include <list>
-#include <memory>
 #include <algorithm>
 #include <functional>
 #include <iostream>
@@ -366,6 +365,27 @@ void FixFont (ptrCFont & pFont,
 
 // for escaping out things like \r in a trigger
 CString FixupEscapeSequences (const CString & strSource);
+void SetFileDialogFileName (CFileDialog & dialog, CString & buffer,
+                            const CString & initialName);
+
+class CBoolStateGuard
+  {
+  public:
+  CBoolStateGuard (bool & bValue, const bool bNewValue)
+    : m_bValue (bValue), m_bSavedValue (bValue)
+    {
+    m_bValue = bNewValue;
+    }
+
+  ~CBoolStateGuard ()
+    {
+    m_bValue = m_bSavedValue;
+    }
+
+  private:
+  bool & m_bValue;
+  bool m_bSavedValue;
+  };
 
 template <class T>
 class CValueStateGuard
@@ -391,25 +411,6 @@ class CValueStateGuard
 
 // translates "send to" numbers
 CString GetSendToString (const unsigned short iWhere);
-
-class CBoolStateGuard
-  {
-  public:
-  CBoolStateGuard (bool & bValue, const bool bNewValue)
-    : m_bValue (bValue), m_bSavedValue (bValue)
-    {
-    m_bValue = bNewValue;
-    }
-
-  ~CBoolStateGuard ()
-    {
-    m_bValue = m_bSavedValue;
-    }
-
-  private:
-  bool & m_bValue;
-  bool m_bSavedValue;
-  };
 
 // translates connection status to text
 CString GetConnectionStatus (const int iStatus);

--- a/stdafx.h
+++ b/stdafx.h
@@ -86,6 +86,7 @@
 #include <map>
 #include <set>
 #include <list>
+#include <memory>
 #include <algorithm>
 #include <functional>
 #include <iostream>
@@ -368,25 +369,6 @@ CString FixupEscapeSequences (const CString & strSource);
 void SetFileDialogFileName (CFileDialog & dialog, CString & buffer,
                             const CString & initialName);
 
-class CBoolStateGuard
-  {
-  public:
-  CBoolStateGuard (bool & bValue, const bool bNewValue)
-    : m_bValue (bValue), m_bSavedValue (bValue)
-    {
-    m_bValue = bNewValue;
-    }
-
-  ~CBoolStateGuard ()
-    {
-    m_bValue = m_bSavedValue;
-    }
-
-  private:
-  bool & m_bValue;
-  bool m_bSavedValue;
-  };
-
 template <class T>
 class CValueStateGuard
   {
@@ -411,6 +393,25 @@ class CValueStateGuard
 
 // translates "send to" numbers
 CString GetSendToString (const unsigned short iWhere);
+
+class CBoolStateGuard
+  {
+  public:
+  CBoolStateGuard (bool & bValue, const bool bNewValue)
+    : m_bValue (bValue), m_bSavedValue (bValue)
+    {
+    m_bValue = bNewValue;
+    }
+
+  ~CBoolStateGuard ()
+    {
+    m_bValue = m_bSavedValue;
+    }
+
+  private:
+  bool & m_bValue;
+  bool m_bSavedValue;
+  };
 
 // translates connection status to text
 CString GetConnectionStatus (const int iStatus);


### PR DESCRIPTION
Set file dialog buffers and their declared capacities together. Preserve the initial file name and release CString buffers after the dialog returns.

Related change set: #6.
