### PR TITLE
Preserve search state when preparation fails

### DIFF
--- a/Finding.cpp
+++ b/Finding.cpp
@@ -85,20 +85,46 @@ CFindDlg dlg (FindInfo.m_strFindStringList);
     if (dlg.DoModal () != IDOK)
       return false;
 
-    FindInfo.m_bMatchCase    = dlg.m_bMatchCase;
-    FindInfo.m_bForwards     = dlg.m_bForwards;
-    FindInfo.m_bRegexp       = dlg.m_bRegexp;
+    // Validate and compile before changing the live find state.
+    std::unique_ptr<t_regexp> newRegexp;
+    if (dlg.m_bRegexp)
+      {
+      CString strRegexp = dlg.m_strFindText;
+      if (strRegexp.IsEmpty () && !FindInfo.m_strFindStringList.IsEmpty ())
+        strRegexp = FindInfo.m_strFindStringList.GetHead ();
+      newRegexp.reset (regcomp (strRegexp,
+        (dlg.m_bMatchCase ? 0 : PCRE_CASELESS) | (FindInfo.m_bUTF8 ? PCRE_UTF8 : 0)));
+      }
 
-    // re-initiate the search - this will set up the POSITION parameter, if it wants to
-    // we need to do it here to get the current line number for subsequent calculations
+    CFindInfo stagedFindInfo;
+    stagedFindInfo.m_bMatchCase = dlg.m_bMatchCase;
+    stagedFindInfo.m_bForwards = dlg.m_bForwards;
+    stagedFindInfo.m_bRegexp = dlg.m_bRegexp;
+    stagedFindInfo.m_bAgain = FindInfo.m_bAgain;
+    stagedFindInfo.m_bUTF8 = FindInfo.m_bUTF8;
+    stagedFindInfo.m_iStartColumn = -1;
+    stagedFindInfo.m_iEndColumn = FindInfo.m_iEndColumn;
+    stagedFindInfo.m_nTotalLines = FindInfo.m_nTotalLines;
+    stagedFindInfo.m_nCurrentLine = FindInfo.m_nCurrentLine;
+    stagedFindInfo.m_pFindPosition = FindInfo.m_pFindPosition;
+    stagedFindInfo.m_iControlColumns = FindInfo.m_iControlColumns;
 
-    (*pInitiateSearch) (pObject, FindInfo);
+    // Prepare the new search position without changing the live find state.
+    (*pInitiateSearch) (pObject, stagedFindInfo);
 
     // add find string to head of list, provided it is not empty, and not the same as before
     if (!dlg.m_strFindText.IsEmpty () &&
         (FindInfo.m_strFindStringList.IsEmpty () ||
         FindInfo.m_strFindStringList.GetHead () != dlg.m_strFindText))
       FindInfo.m_strFindStringList.AddHead (dlg.m_strFindText);
+
+    FindInfo.m_bMatchCase = stagedFindInfo.m_bMatchCase;
+    FindInfo.m_bForwards = stagedFindInfo.m_bForwards;
+    FindInfo.m_bRegexp = stagedFindInfo.m_bRegexp;
+    FindInfo.m_iStartColumn = stagedFindInfo.m_iStartColumn;
+    FindInfo.m_iEndColumn = stagedFindInfo.m_iEndColumn;
+    FindInfo.m_nTotalLines = stagedFindInfo.m_nTotalLines;
+    FindInfo.m_pFindPosition = stagedFindInfo.m_pFindPosition;
 
     if (FindInfo.m_bForwards)
        FindInfo.m_nCurrentLine = 0;
@@ -108,13 +134,8 @@ CFindDlg dlg (FindInfo.m_strFindStringList);
     FindInfo.m_bAgain = false;
     FindInfo.m_MatchesOnLine.clear ();
 
-    delete FindInfo.m_regexp;    // get rid of earlier regular expression
-    FindInfo.m_regexp = NULL;
-
-    // compile regular expression if needed
-    if (FindInfo.m_bRegexp )
-      FindInfo.m_regexp = regcomp (FindInfo.m_strFindStringList.GetHead (),
-      (FindInfo.m_bMatchCase ? 0 :  PCRE_CASELESS) | (FindInfo.m_bUTF8 ? PCRE_UTF8 : 0));
+    delete FindInfo.m_regexp;
+    FindInfo.m_regexp = newRegexp.release ();
 
     }   // end of not starting a new find
   else
@@ -166,20 +187,29 @@ CString strStatus = TFormat ("Finding: %s", (LPCTSTR) FindInfo.m_strFindStringLi
 
   if (nToGo > 500)
     {
-    FindInfo.m_pProgressDlg = new CProgressDlg;
-    FindInfo.m_pProgressDlg->Create ();
-    FindInfo.m_pProgressDlg->SetStatus (strStatus);
-    FindInfo.m_pProgressDlg->SetRange (0, FindInfo.m_nTotalLines);     
-    FindInfo.m_pProgressDlg->SetWindowText (Translate ("Finding..."));                              
+    try
+      {
+      std::unique_ptr<CProgressDlg> progressDlg (new CProgressDlg);
+      if (!progressDlg->Create ())
+        AfxThrowResourceException ();
+      progressDlg->SetStatus (strStatus);
+      progressDlg->SetRange (0, FindInfo.m_nTotalLines);
+      progressDlg->SetWindowText (Translate ("Finding..."));
+      FindInfo.m_pProgressDlg = progressDlg.release ();
+      }
+    catch (...)
+      {
+      Frame.SetStatusNormal ();
+      throw;
+      }
     }   // end of having enough lines to warrant a progress bar
-
-// if case-insensitive search wanted, force "text to find" to lower case
-
-  if (!FindInfo.m_bMatchCase)
-    strFindString.MakeLower ();
 
   try
     {
+    // if case-insensitive search wanted, force "text to find" to lower case
+    if (!FindInfo.m_bMatchCase)
+      strFindString.MakeLower ();
+
     int iMilestone = 0;
 
     while (true)     // until match
@@ -309,6 +339,11 @@ CString strStatus = TFormat ("Finding: %s", (LPCTSTR) FindInfo.m_strFindStringLi
       e->ReportError ();
       e->Delete ();
       return NotFound (FindInfo);
+      }
+    catch (...)
+      {
+      WrapUpFind (FindInfo);
+      throw;
       }
 
   } // end of FindRoutine

--- a/Finding.cpp
+++ b/Finding.cpp
@@ -134,7 +134,7 @@ CFindDlg dlg (FindInfo.m_strFindStringList);
     FindInfo.m_bAgain = false;
     FindInfo.m_MatchesOnLine.clear ();
 
-    delete FindInfo.m_regexp;
+    delete FindInfo.m_regexp;    // get rid of earlier regular expression
     FindInfo.m_regexp = newRegexp.release ();
 
     }   // end of not starting a new find

--- a/dialogs/world_prefs/configuration.cpp
+++ b/dialogs/world_prefs/configuration.cpp
@@ -2429,32 +2429,34 @@ int CMUSHclientDoc::RecompileRegularExpressions ()
     CTrigger * pTrigger;
     GetTriggerMap ().GetNextAssoc (pos, strName, pTrigger);
 
-    if (pTrigger->regexp)
-      {
-      delete pTrigger->regexp;    // get rid of old one
-      if (pTrigger->bRegexp)
-        strRegexp = pTrigger->trigger;
-      else
-        strRegexp = ConvertToRegularExpression (pTrigger->trigger);
-      }
+    if (pTrigger->bRegexp)
+      strRegexp = pTrigger->trigger;
+    else
+      strRegexp = ConvertToRegularExpression (pTrigger->trigger);
 
       // compile regular expression
+      std::unique_ptr<t_regexp> newRegexp;
       try 
         {
-        pTrigger->regexp = regcomp (strRegexp, (pTrigger->ignore_case ? PCRE_CASELESS : 0) |
-                                               (pTrigger->bMultiLine  ? PCRE_MULTILINE : 0) |
-                                               (m_bUTF_8 ? PCRE_UTF8 : 0)
-                                               );
+        newRegexp.reset (regcomp (strRegexp, (pTrigger->ignore_case ? PCRE_CASELESS : 0) |
+                                             (pTrigger->bMultiLine  ? PCRE_MULTILINE : 0) |
+                                             (m_bUTF_8 ? PCRE_UTF8 : 0)
+                                             ));
         }   // end of try
       catch(CException* e)
         {
+        delete pTrigger->regexp;
         pTrigger->regexp = NULL;
         e->Delete ();
         iTriggerErrors++;
         ColourNote ("red", "", 
                      TFormat ("In %s, could not recompile trigger (%s) matching on: %s.",
                               (LPCTSTR) sPluginName, (LPCTSTR) pTrigger->strInternalName, (LPCTSTR) strRegexp));
+        continue;
         } // end of catch
+
+      delete pTrigger->regexp;
+      pTrigger->regexp = newRegexp.release ();
     }  // end of for each trigger
 
 #if ALIASES_USE_UTF8
@@ -2464,31 +2466,33 @@ int CMUSHclientDoc::RecompileRegularExpressions ()
     CAlias * pAlias;
     GetAliasMap ().GetNextAssoc (pos, strName, pAlias);
 
-    if (pAlias->regexp)
-      {
-      delete pAlias->regexp;    // get rid of old one
-      if (pAlias->bRegexp)
-        strRegexp = pAlias->name;
-      else
-        strRegexp = ConvertToRegularExpression (pAlias->name);
-      }
+    if (pAlias->bRegexp)
+      strRegexp = pAlias->name;
+    else
+      strRegexp = ConvertToRegularExpression (pAlias->name);
 
       // compile regular expression
+      std::unique_ptr<t_regexp> newRegexp;
       try 
         {
-        pAlias->regexp = regcomp (strRegexp, (pAlias->bIgnoreCase ? PCRE_CASELESS : 0) |
-                                               (m_bUTF_8 ? PCRE_UTF8 : 0)
-                                               );
+        newRegexp.reset (regcomp (strRegexp, (pAlias->bIgnoreCase ? PCRE_CASELESS : 0) |
+                                             (m_bUTF_8 ? PCRE_UTF8 : 0)
+                                             ));
         }   // end of try
       catch(CException* e)
         {
+        delete pAlias->regexp;
         pAlias->regexp = NULL;
         e->Delete ();
         iAliasErrors++;
         ColourNote ("red", "", 
                      TFormat ("In %s, could not recompile alias  (%s) matching on: %s.",
                               (LPCTSTR) sPluginName, (LPCTSTR) pAlias->strInternalName, (LPCTSTR) strRegexp));
+        continue;
         } // end of catch
+
+      delete pAlias->regexp;
+      pAlias->regexp = newRegexp.release ();
     }  // end of for each alias
 
 #endif // ALIASES_USE_UTF8

--- a/doc.cpp
+++ b/doc.cpp
@@ -5000,15 +5000,23 @@ CString CMUSHclientDoc::RecallText (const CString strSearchString,   // what to 
                                     const CString strRecallLinePreamble)
     {
 CString strMessage;
-t_regexp * regexp = NULL;          // compiled regular expression
+std::unique_ptr<t_regexp> regexp;   // compiled regular expression
 int iCurrentLine;
 
   // compile regular expression if needed
   if (bRegexp)
-    regexp = regcomp (strSearchString, (bMatchCase ? 0 : PCRE_CASELESS) | (m_bUTF_8 ? PCRE_UTF8 : 0));
+    regexp.reset (regcomp (strSearchString,
+                           (bMatchCase ? 0 : PCRE_CASELESS) |
+                           (m_bUTF_8 ? PCRE_UTF8 : 0)));
 
 CString strFindString = strSearchString;
 CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
+
+  class CRecallStatusGuard
+    {
+    public:
+      ~CRecallStatusGuard () { Frame.SetStatusNormal (); }
+    } statusGuard;
 
   Frame.SetStatusMessageNow (strStatus);
 
@@ -5017,12 +5025,13 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
   long nToGo = m_LineList.GetCount ();
   iCurrentLine = 0;
   
-  CProgressDlg * pProgressDlg = NULL;// progress dialog
+  std::unique_ptr<CProgressDlg> pProgressDlg; // progress dialog
 
   if (nToGo > 500)
     {
-    pProgressDlg = new CProgressDlg;
-    pProgressDlg->Create ();
+    pProgressDlg.reset (new CProgressDlg);
+    if (!pProgressDlg->Create ())
+      AfxThrowResourceException ();
     pProgressDlg->SetStatus (strStatus);
     pProgressDlg->SetRange (0, nToGo);     
     pProgressDlg->SetWindowText (Translate ("Recalling..."));                              
@@ -5116,7 +5125,7 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
         {
   // if case-insensitive search wanted, force this line to lower case
 
-        if (regexec (regexp, strSearchLine))
+        if (regexec (regexp.get (), strSearchLine))
           {
           if (!strRecallLinePreamble.IsEmpty ())
             {
@@ -5158,11 +5167,7 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
 
   Frame.SetStatusNormal (); 
 
-  if (pProgressDlg)
-    {
-    delete pProgressDlg;
-    pProgressDlg = NULL;
-    }
+  pProgressDlg.reset ();
 
 
   if (strMessage.IsEmpty ())

--- a/doc.cpp
+++ b/doc.cpp
@@ -5015,7 +5015,13 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
   class CRecallStatusGuard
     {
     public:
-      ~CRecallStatusGuard () { Frame.SetStatusNormal (); }
+      // Prepare the translated text before cleanup can run.
+      CRecallStatusGuard () : m_strNormalStatus (Translate ("Ready")) {}
+      ~CRecallStatusGuard () { Restore (); }
+      void Restore () const { Frame.SetStatusMessageNow (m_strNormalStatus); }
+
+    private:
+      const CString m_strNormalStatus;
     } statusGuard;
 
   Frame.SetStatusMessageNow (strStatus);
@@ -5165,7 +5171,7 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
     }
 
 
-  Frame.SetStatusNormal (); 
+  statusGuard.Restore ();
 
   pProgressDlg.reset ();
 

--- a/regexp.cpp
+++ b/regexp.cpp
@@ -19,34 +19,22 @@ t_regexp * regcomp(const char *exp, const int options)
   {
 const char *error;
 int erroroffset;
-t_regexp * re;
-pcre * program;
-pcre_extra * extra;
+std::unique_ptr<t_regexp> re (new t_regexp);
 
-  program = pcre_compile(exp, options, &error, &erroroffset, NULL);
+  re->m_program = pcre_compile(exp, options, &error, &erroroffset, NULL);
 
-  if (!program)
+  if (!re->m_program)
     ThrowErrorException("Failed: %s at offset %d", Translate (error), erroroffset);
 
   // study it for speed purposes
-  extra =  pcre_study(program, 0, &error);        
+  re->m_extra = pcre_study(re->m_program, 0, &error);
 
   if (error)
-    {
-    pcre_free (program);
     ThrowErrorException("Regexp study failed: %s", error);
-    }
 
-  // we need to allocate memory for the substring offsets
-  re = new t_regexp;
-
-  // remember program and extra stuff
-  re->m_program = program;
-  re->m_extra = extra;
   re->m_iExecutionError = 0; // no error now
 
-
-  return re;
+  return re.release ();
   }
 
 int regexec(register t_regexp *prog, 


### PR DESCRIPTION
Prepare search expressions and buffers before replacing active state. Restore the search position and release temporary resources when a search or expression rebuild fails.

Related change set: #6.
