### PR TITLE
Defer document notifications and preserve progress operations

### DIFF
--- a/.github/workflows/latest-dev-build.yml
+++ b/.github/workflows/latest-dev-build.yml
@@ -32,6 +32,15 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
+    - name: Check progress message dispatch
+      shell: cmd
+      run: |
+        for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do call "%%i\VC\Auxiliary\Build\vcvars32.bat"
+        if errorlevel 1 exit /b %errorlevel%
+        set "CXX=cl /MD /DNDEBUG"
+        if "${{ matrix.configuration }}"=="Debug" set "CXX=cl /MDd /D_DEBUG"
+        python tests/check_progress_messages.py --native-windows
+
     - name: Build solution
       run: msbuild /m /p:Configuration=${{ matrix.configuration }} /p:Platform=Win32 /p:PreferredToolArchitecture=x86 /p:BuildProjectReferences=true /verbosity:normal /p:PRE_RELEASE=PRE_RELEASE ${{ env.SOLUTION_FILE_PATH }}
 

--- a/MUSHclient.cpp
+++ b/MUSHclient.cpp
@@ -9,6 +9,7 @@
 #include "doc.h"
 #include "ActivityDoc.h"
 #include "TextDocument.h"
+#include "dialogs\ProgDlg.h"
 
 #include "mainfrm.h"
 #include "childfrm.h"
@@ -1014,12 +1015,124 @@ BOOL CMUSHclientApp::SaveAllModified()
 	return CWinApp::SaveAllModified();
 }
 
+void CMUSHclientApp::DeferMessageUntilIdle (const MSG & msg,
+                                            __int64 iDocumentNumber,
+                                            HANDLE hLookup,
+                                            unsigned long iGeneration,
+                                            long iChatID)
+{
+  if (msg.message == WM_CLOSE)
+    for (deque<CDeferredMessage>::const_iterator it = m_DeferredMessages.begin ();
+         it != m_DeferredMessages.end (); ++it)
+      if (it->m_msg.message == WM_CLOSE && it->m_msg.hwnd == msg.hwnd &&
+          it->m_iDocumentNumber == iDocumentNumber)
+        return;
+
+  CDeferredMessage deferred;
+  deferred.m_msg = msg;
+  deferred.m_iDocumentNumber = iDocumentNumber;
+  deferred.m_hLookup = hLookup;
+  deferred.m_iGeneration = iGeneration;
+  deferred.m_iChatID = iChatID;
+  m_DeferredMessages.push_back (deferred);
+}
+
+void CMUSHclientApp::DeferTextDocumentClose (__int64 iDocumentNumber)
+{
+  m_DeferredTextDocumentCloses.push_back (iDocumentNumber);
+}
+
+void CMUSHclientApp::DeferWorldDocumentClose (__int64 iDocumentNumber)
+{
+  m_DeferredWorldDocumentCloses.push_back (iDocumentNumber);
+}
+
+bool CMUSHclientApp::HasActiveDocumentOperations () const
+{
+  if (m_pWorldDocTemplate)
+    for (POSITION pos = m_pWorldDocTemplate->GetFirstDocPosition (); pos; )
+      if (((CMUSHclientDoc *) m_pWorldDocTemplate->GetNextDoc (pos))->m_iActiveProgressOperations != 0)
+        return true;
+  if (m_pNormalDocTemplate)
+    for (POSITION pos = m_pNormalDocTemplate->GetFirstDocPosition (); pos; )
+      if (((CTextDocument *) m_pNormalDocTemplate->GetNextDoc (pos))->m_iActiveOperations != 0)
+        return true;
+  return false;
+}
+
 BOOL CMUSHclientApp::OnIdle(LONG lCount) 
 {
+  if (CProgressDlg::IsPumpingMessages () || HasActiveDocumentOperations ())
+    return FALSE;
+
+  CollectMonitoringThreads ();
 	
 	if (CWinApp::OnIdle(lCount))
     return 1;
 
+  if (!m_DeferredWorldDocumentCloses.empty ())
+    {
+    const __int64 iDocumentNumber = m_DeferredWorldDocumentCloses.front ();
+    for (POSITION pos = m_pWorldDocTemplate->GetFirstDocPosition (); pos; )
+      {
+      CMUSHclientDoc * pDoc =
+        (CMUSHclientDoc *) m_pWorldDocTemplate->GetNextDoc (pos);
+      if (pDoc->m_iUniqueDocumentNumber == iDocumentNumber)
+        {
+        if (pDoc->m_iActiveProgressOperations != 0)
+          return FALSE;
+        m_DeferredWorldDocumentCloses.pop_front ();
+        pDoc->m_bWorldCloseQueued = false;
+        pDoc->OnCloseDocument ();
+        return TRUE;
+        }
+      }
+    m_DeferredWorldDocumentCloses.pop_front ();
+    return TRUE;
+    }
+
+  // A text document can request its own close from a nested modal loop.
+  // Close it only after the active document operation has returned.
+  if (!m_DeferredTextDocumentCloses.empty ())
+    {
+    __int64 iDocumentNumber = m_DeferredTextDocumentCloses.front ();
+
+    for (POSITION pos = m_pNormalDocTemplate->GetFirstDocPosition(); pos; )
+      {
+      CTextDocument * pDoc =
+        (CTextDocument *) m_pNormalDocTemplate->GetNextDoc (pos);
+
+      if (pDoc->m_iTextDocumentNumber == iDocumentNumber)
+        {
+        if (pDoc->m_iActiveOperations != 0)
+          return FALSE;
+        m_DeferredTextDocumentCloses.pop_front ();
+        pDoc->m_bCloseQueued = false;
+        pDoc->OnCloseDocument ();
+        return TRUE;
+        }
+      }
+
+    m_DeferredTextDocumentCloses.pop_front ();
+    return 1;
+    }
+
+  // Process one application notification only after the main message loop
+  // reaches this safe point.
+  if (!m_DeferredMessages.empty ())
+    {
+    CDeferredMessage msg = m_DeferredMessages.front ();
+    m_DeferredMessages.pop_front ();
+
+    if ((msg.m_msg.hwnd == Frame.GetSafeHwnd () || msg.m_msg.message == WM_CLOSE) &&
+        ::IsWindow (msg.m_msg.hwnd))
+      Frame.ProcessDeferredMessage (msg);
+
+    return 1;
+    }
+
+  // Script file notifications can arrive inside nested modal loops. Reload
+  // only after the main message loop reaches this safe point.
   POSITION pos = m_pWorldDocTemplate->GetFirstDocPosition();
 
   while (pos)
@@ -1034,11 +1147,35 @@ BOOL CMUSHclientApp::OnIdle(LONG lCount)
       return 1;
       }
 
+    if (pDoc->m_bScriptFileChangedPending &&
+        !pDoc->m_bInScriptFileChanged)
+      {
+      pDoc->m_bScriptFileChangedPending = false;
+      pDoc->OnScriptFileChanged ();
+      return 1;
+      }
     }
 
-CWnd* wnd = Frame.GetForegroundWindow( );
+  // Text file notifications can also arrive inside nested modal loops.
+  // Ask about the reload only after the main message loop reaches this point.
+  pos = m_pNormalDocTemplate->GetFirstDocPosition();
 
-  if (!wnd)
+  while (pos)
+    {
+    CTextDocument* pDoc =
+      (CTextDocument*) m_pNormalDocTemplate->GetNextDoc(pos);
+
+    if (pDoc->m_bFileChangedPending && !pDoc->m_bInFileChanged)
+      {
+      pDoc->m_bFileChangedPending = false;
+      pDoc->OnFileChanged ();
+      return 1;
+      }
+    }
+
+HWND hwndForeground = ::GetForegroundWindow( );
+
+  if (!hwndForeground)
     return 0;
 
 // update activity window if required
@@ -1057,9 +1194,9 @@ CWnd* wnd = Frame.GetForegroundWindow( );
 
 // See if the front window is our main frame
 
-	if (wnd->IsKindOf(RUNTIME_CLASS(CMainFrame)))
+	if (hwndForeground == Frame.GetSafeHwnd ())
     {
-    CMainFrame * frame = (CMainFrame *) wnd;
+    CMainFrame * frame = &Frame;
 
 // find the active view
 
@@ -1100,6 +1237,11 @@ void CMUSHclientApp::OnGameMinimiseprogram()
 
 BOOL CMUSHclientApp::PreTranslateMessage(MSG* pMsg)
 {
+	// A queued message can outlive its target window. Do not let MFC look up a
+	// stale permanent CWnd for a message that Windows can no longer deliver.
+	if (pMsg->hwnd != NULL && !::IsWindow(pMsg->hwnd))
+		return TRUE;
+
 	// CG: The following lines were added by the Splash Screen component.
 	if (CSplashWnd::PreTranslateAppMessage(pMsg))
 		return TRUE;
@@ -1944,7 +2086,7 @@ CTextDocument * pTextDoc = NULL;
   for (POSITION docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
       docPos != NULL; )
     {
-    pTextDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+    pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
     // ignore related worlds
     if (pTextDoc->m_pRelatedWorld == NULL &&

--- a/MUSHclient.h
+++ b/MUSHclient.h
@@ -46,6 +46,15 @@ class CTextDocument;
 
 extern COLORREF xterm_256_colours [256];
 
+struct CDeferredMessage
+  {
+  MSG m_msg;
+  __int64 m_iDocumentNumber;
+  HANDLE m_hLookup;
+  unsigned long m_iGeneration;
+  long m_iChatID;
+  };
+
 class CMUSHclientApp : public CWinApp
 {
 public:
@@ -67,6 +76,18 @@ public:
 #endif // PANE
 	CMultiDocTemplate* m_pActivityDocTemplate;
 	CMultiDocTemplate* m_pNormalDocTemplate;    // text document
+
+  deque<CDeferredMessage> m_DeferredMessages;
+  deque<__int64> m_DeferredTextDocumentCloses;
+  deque<__int64> m_DeferredWorldDocumentCloses;
+  void DeferMessageUntilIdle (const MSG & msg,
+                              __int64 iDocumentNumber = 0,
+                              HANDLE hLookup = NULL,
+                              unsigned long iGeneration = 0,
+                              long iChatID = 0);
+  void DeferTextDocumentClose (__int64 iDocumentNumber);
+  void DeferWorldDocumentClose (__int64 iDocumentNumber);
+  bool HasActiveDocumentOperations () const;
 
   CAtomicElementMap  m_ElementMap;   // MXP elements we know of (eg. <b> )
   CMapStringToString m_EntityMap;    // MXP entities we know of (eg. &lt; )

--- a/TextDocument.cpp
+++ b/TextDocument.cpp
@@ -10,8 +10,10 @@ Copyright (c) 2000 Nick Gammon.
 #include "stdafx.h"
 #include "MUSHclient.h"
 #include "TextDocument.h"
+#include "dialogs\ProgDlg.h"
 #include "TextView.h"
 #include "MainFrm.h"
+#include <errno.h>
 #include <process.h>    
 #include "doc.h"
 
@@ -32,13 +34,17 @@ void ListAccelerators (CDocument * pDoc, const int iType);
 IMPLEMENT_DYNCREATE(CTextDocument, CDocument)
 
 CTextDocument::CTextDocument()
-  :	m_eventFileChanged(FALSE, TRUE)
 {
   m_bInFileChanged = false;
-  m_pThread = NULL;
+  m_bFileChangedPending = false;
+  m_iActiveOperations = 0;
+  m_bClosePending = false;
+  m_bCloseQueued = false;
+  m_iMonitorToken = 0;
   m_pRelatedWorld = NULL;
 
   m_iUniqueDocumentNumber = 0;
+  m_iTextDocumentNumber = App.GetUniqueNumber ();
   m_strFontName = App.m_strDefaultInputFont;
   m_iFontSize = App.m_iDefaultInputFontHeight;
   m_iFontWeight = App.m_iDefaultInputFontWeight;
@@ -72,13 +78,15 @@ BOOL CTextDocument::OnNewDocument()
 {
 	if (!CDocument::OnNewDocument())
 		return FALSE;
-  KillThread (m_pThread, m_eventFileChanged);
+  StopMonitoringThread (m_iMonitorToken);
+  m_bFileChangedPending = false;
 	return TRUE;
 }
 
 CTextDocument::~CTextDocument()
 {
-  KillThread (m_pThread, m_eventFileChanged);
+  StopMonitoringThread (m_iMonitorToken);
+  m_bFileChangedPending = false;
 
   if (!bWine)
   	AfxOleUnlockApp();        // not needed?
@@ -139,106 +147,297 @@ void CTextDocument::OnUpdateStatusModified(CCmdUI* pCmdUI)
 
 void CTextDocument::OnCloseDocument() 
 {
-  KillThread (m_pThread, m_eventFileChanged);
+  if (m_iActiveOperations > 0 || CProgressDlg::IsPumpingMessages ())
+    {
+    if (!m_bCloseQueued)
+      {
+      App.DeferTextDocumentClose (m_iTextDocumentNumber);
+      m_bCloseQueued = true;
+      }
+    m_bClosePending = true;
+    return;
+    }
+
+  StopMonitoringThread (m_iMonitorToken);
+  m_bFileChangedPending = false;
 	CDocument::OnCloseDocument();
 }
 
+void CTextDocument::BeginOperation (void)
+  {
+  m_iActiveOperations++;
+  }
+
+void CTextDocument::EndOperation (void)
+  {
+  ASSERT (m_iActiveOperations > 0);
+  m_iActiveOperations--;
+
+  }
 
 // ------------------- file change monitoring thread -------------------------
 
-void ThreadFunc(LPVOID pParam)
-{
-  CThreadData*	pData = (CThreadData*) pParam;
-	char * strDir = pData->m_strFilename;
-  DWORD pDoc = pData->m_pDoc;
-	char * p = strrchr (strDir, '\\');
-	if (!p)
-		p = strrchr (strDir, ':');   // why?
+// Only the UI thread changes the registry. A worker owns no document data.
+// Keep the registry alive until process exit: a blocked worker can outlive App.
+struct CMonitorContext
+  {
+  CMonitorContext * next;
+  char * filename;
+  HWND window;
+  UINT message;
+  __int64 document;
+  __int64 token;
+  HANDLE stopEvent;
+  HANDLE thread;
+  HANDLE change;
+  volatile LONG stopped;
+  unsigned reported;
+  unsigned pending;
+  const char * operations[9];
+  DWORD errors[9];
+  // The first transient post error is published while the worker is live.
+  DWORD postError;
+  volatile LONG postErrorReady;
+  // Terminal error fields are read only after confirmed worker exit.
+  const char * workerOperation;
+  DWORD workerError;
+  };
+
+static CMonitorContext * monitors = NULL;
+
+static void RecordMonitorError (CMonitorContext * context, unsigned slot,
+                                const char * operation, DWORD error)
+  {
+  const unsigned bit = 1U << slot;
+  if (!(context->reported & bit))
+    {
+    context->reported |= bit;
+    context->pending |= bit;
+    context->operations[slot] = operation;
+    context->errors[slot] = error;
+    }
+  }
+
+static void RecordMonitorWorkerError (CMonitorContext * context,
+                                      const char * operation, DWORD error)
+  {
+  context->workerOperation = operation;
+  context->workerError = error;
+  }
+
+static bool MonitorStopped (CMonitorContext * context)
+  {
+  return InterlockedCompareExchange (&context->stopped, 0, 0) != 0;
+  }
+
+static unsigned __stdcall MonitorThread (void * parameter)
+  {
+  CMonitorContext * context = (CMonitorContext *) parameter;
+  if (MonitorStopped (context))
+    return 0;
+
+  char * p = strrchr (context->filename, '\\');
+  if (!p)
+    p = strrchr (context->filename, ':');
   if (p)
     *p = 0;
-	HWND	hWnd = pData->m_hWnd;
-	HANDLE	hEvent = pData->m_hEvent;
 
-	delete pData;
+  context->change = FindFirstChangeNotification
+    (context->filename, TRUE, FILE_NOTIFY_CHANGE_LAST_WRITE);
+  if (context->change == INVALID_HANDLE_VALUE)
+    {
+    RecordMonitorWorkerError (context, "FindFirstChangeNotification", GetLastError ());
+    return 0;
+    }
 
-  // Get a handle to a file change notification object.
-  HANDLE	hChange = ::FindFirstChangeNotification(strDir, TRUE, FILE_NOTIFY_CHANGE_LAST_WRITE);
+  HANDLE handles[2] = { context->stopEvent, context->change };
+  while (!MonitorStopped (context))
+    {
+    // The finite wait also observes stopped if SetEvent fails.
+    DWORD result = WaitForMultipleObjects (2, handles, FALSE, 250);
+    if (MonitorStopped (context) || result == WAIT_OBJECT_0)
+      break;
+    if (result == WAIT_TIMEOUT)
+      continue;
+    if (result != WAIT_OBJECT_0 + 1)
+      {
+      RecordMonitorWorkerError (context, "WaitForMultipleObjects", GetLastError ());
+      break;
+      }
 
-  delete [] strDir;
+    CFileChangeNotification * notification = NULL;
+    try
+      {
+      notification = new CFileChangeNotification;
+      }
+    catch (CException * e)
+      {
+      e->Delete ();
+      RecordMonitorWorkerError (context, "notification allocation", ERROR_NOT_ENOUGH_MEMORY);
+      return 0;
+      }
+    catch (...)
+      {
+      RecordMonitorWorkerError (context, "notification allocation", ERROR_NOT_ENOUGH_MEMORY);
+      return 0;
+      }
+    notification->m_iDocumentNumber = context->document;
+    notification->m_iMonitorToken = context->token;
+    if (MonitorStopped (context))
+      {
+      delete notification;
+      break;
+      }
+    if (!PostMessage (context->window, context->message, (WPARAM) notification, 0))
+      {
+      DWORD error = GetLastError ();
+      if (!InterlockedCompareExchange (&context->postErrorReady, 0, 0))
+        {
+        context->postError = error;
+        InterlockedExchange (&context->postErrorReady, 1);
+        }
+      delete notification;
+      }
+    if (MonitorStopped (context))
+      break;
+    if (!FindNextChangeNotification (context->change))
+      {
+      RecordMonitorWorkerError (context, "FindNextChangeNotification", GetLastError ());
+      break;
+      }
+    }
+  // Only the collector closes handles, after confirming thread exit.
+  return 0;
+  }
 
-  // Return now if ::FindFirstChangeNotification failed.
-  if (hChange == INVALID_HANDLE_VALUE)
-    return;
-
-	HANDLE	aHandles[2];
-	aHandles[0] = hChange;
-	aHandles[1] = hEvent;
-	BOOL	bContinue = TRUE;
-
-    // Sleep until a file change notification wakes this thread or
-    // m_eventScriptFileChanged becomes set indicating it's time for the thread to end.
-    while (bContinue)
-	{
-		switch ((::WaitForMultipleObjects(2, aHandles, FALSE, INFINITE)))
-		{
-		case 0:
-			// Respond to a change notification.
-			::PostMessage(hWnd, WM_USER_FILE_CONTENTS_CHANGED, (WPARAM) pDoc, 0);
-			::FindNextChangeNotification(hChange);
-			break;
-
-		default:
-			// Kill this thread (m_event became signaled).
-            bContinue = FALSE;
-			break;
-		}
-	}
-
-	// Close the file change notification handle and return.
-	::FindCloseChangeNotification(hChange);
-	return;
-}
-
-void KillThread (HANDLE & pThread, CEvent & eventFileChanged)
+void StopMonitoringThread (__int64 & token)
   {
-	// Kill the file change notification thread
-	if (pThread)
-	  {
-    // setting this event *should* cause the thread to wrapup gracefully
-		eventFileChanged.SetEvent();
+  const __int64 oldToken = token;
+  token = 0;
+  if (!oldToken)
+    return;
+  for (CMonitorContext * context = monitors; context; context = context->next)
+    if (context->token == oldToken)
+      {
+      InterlockedExchange (&context->stopped, 1);
+      if (context->thread && context->stopEvent && !SetEvent (context->stopEvent))
+        RecordMonitorError (context, 0, "SetEvent", GetLastError ());
+      return;
+      }
+  }
 
-    // wait for thread to go away, or 10 seconds, whichever is sooner
-		DWORD waitstatus = ::WaitForSingleObject(pThread, 10000L);
+void CollectMonitoringThreads ()
+  {
+  const char * reportOperation = NULL;
+  DWORD reportError = 0;
+  CMonitorContext ** link = &monitors;
+  while (*link)
+    {
+    CMonitorContext * context = *link;
+    bool exited = context->thread == NULL;
+    if (context->thread)
+      {
+      DWORD result = WaitForSingleObject (context->thread, 0);
+      exited = result == WAIT_OBJECT_0;
+      if (!exited && result != WAIT_TIMEOUT)
+        RecordMonitorError (context, 1, "WaitForSingleObject", GetLastError ());
+      }
+    if (InterlockedCompareExchange (&context->postErrorReady, 0, 0))
+      RecordMonitorError (context, 7, "PostMessage", context->postError);
+    if (exited)
+      {
+      if (context->workerOperation)
+        RecordMonitorError (context, 8, context->workerOperation, context->workerError);
+      // No thread means startup failed, or its handle was already closed.
+      // Retain every failed-close handle for a later idle pass.
+      if (context->change && context->change != INVALID_HANDLE_VALUE)
+        {
+        if (FindCloseChangeNotification (context->change))
+          context->change = NULL;
+        else
+          RecordMonitorError (context, 2, "FindCloseChangeNotification", GetLastError ());
+        }
+      if (context->stopEvent)
+        {
+        if (CloseHandle (context->stopEvent))
+          context->stopEvent = NULL;
+        else
+          RecordMonitorError (context, 3, "CloseHandle(stop event)", GetLastError ());
+        }
+      if (context->thread)
+        {
+        if (CloseHandle (context->thread))
+          context->thread = NULL;
+        else
+          RecordMonitorError (context, 4, "CloseHandle(thread)", GetLastError ());
+        }
+      }
+    if (!reportOperation && context->pending)
+      for (unsigned slot = 0; slot < 9; ++slot)
+        if (context->pending & (1U << slot))
+          {
+          reportOperation = context->operations[slot];  // Static literal.
+          reportError = context->errors[slot];
+          context->pending &= ~(1U << slot);
+          break;
+          }
+    if (!exited || context->thread || context->stopEvent || context->pending ||
+        (context->change && context->change != INVALID_HANDLE_VALUE))
+      {
+      link = &context->next;
+      continue;
+      }
+    *link = context->next;
+    free (context->filename);
+    free (context);
+    }
+  // A modal callback can stop/start monitors or enter this collector again.
+  // All registry access is complete, and these values do not refer to a context.
+  if (reportOperation)
+    {
+    char message[192];
+    snprintf (message, sizeof message, "File monitor: %s failed (error %lu).", reportOperation, reportError);
+    ::MessageBoxA (NULL, message, "File monitor error", MB_OK | MB_ICONERROR | MB_TASKMODAL);
+    }
+  }
 
-    // if unable to terminate thread properly, get rid of the blasted thing
-    if (waitstatus == WAIT_TIMEOUT || waitstatus == WAIT_FAILED)   
-      TerminateThread (pThread, 1);
-
-		pThread = NULL;
-	  }
-  } // end of KillThread
-
-// Create script source file monitoring thread
-//
-HANDLE CreateMonitoringThread(const char * sName, DWORD pDoc, CEvent & eventFileChanged)
-{
-  HANDLE pThread;
-
-	CThreadData*	pData = new CThreadData;
-	pData->m_strFilename = new char [strlen (sName) + 1];
-  strcpy (pData->m_strFilename, sName);
-	pData->m_hWnd = Frame.GetSafeHwnd ();
-	pData->m_hEvent = eventFileChanged;
-  pData->m_pDoc = pDoc;
-	eventFileChanged.ResetEvent();
-
-	pThread = (HANDLE) _beginthread (ThreadFunc, 0, pData);
-  SetThreadPriority (pThread, THREAD_PRIORITY_IDLE);
-
-  return pThread;
-
-	// Thread will delete data object
-}
+__int64 CreateMonitoringThread (const char * name, __int64 document, UINT message)
+  {
+  CMonitorContext * context = (CMonitorContext *) calloc (1, sizeof *context);
+  if (!context)
+    AfxThrowResourceException ();
+  context->filename = (char *) malloc (strlen (name) + 1);
+  if (!context->filename)
+    {
+    free (context);
+    AfxThrowResourceException ();
+    }
+  strcpy (context->filename, name);
+  context->document = document;
+  context->token = App.GetUniqueNumber ();
+  if (!context->token)
+    context->token = App.GetUniqueNumber ();
+  context->window = Frame.GetSafeHwnd ();
+  context->message = message;
+  // Register before acquiring handles so failed startup cannot lose ownership.
+  context->next = monitors;
+  monitors = context;
+  context->stopEvent = CreateEvent (NULL, TRUE, FALSE, NULL);
+  if (!context->stopEvent)
+    {
+    RecordMonitorError (context, 5, "CreateEvent", GetLastError ());
+    AfxThrowResourceException ();
+    }
+  context->thread = (HANDLE) _beginthreadex (NULL, 0, MonitorThread, context, 0, NULL);
+  if (!context->thread)
+    {
+    RecordMonitorError (context, 5, "_beginthreadex (errno)", errno);
+    AfxThrowResourceException ();
+    }
+  if (!SetThreadPriority (context->thread, THREAD_PRIORITY_IDLE))
+    RecordMonitorError (context, 6, "SetThreadPriority", GetLastError ());
+  return context->token;
+  }
 
 
 // ------------------- handle change to file -------------------------
@@ -250,7 +449,8 @@ void CTextDocument::OnFileChanged(void)
 	if (m_bInFileChanged)
 		return;
 
-  m_bInFileChanged = true;
+	CTextDocumentOperationGuard operationGuard (this);
+	CBoolStateGuard fileChangedGuard (m_bInFileChanged, true);
 
 	// Check if this file has changed
 	CFileStatus	status;
@@ -265,7 +465,12 @@ void CTextDocument::OnFileChanged(void)
 		CString	strText;
     strText = TFormat ("The file \"%s\" has been modified. Do you wish to reload it?",
       (LPCTSTR) GetPathName ());
-    if (::TMessageBox (strText, MB_YESNO | MB_ICONQUESTION) == IDYES)
+    int iAnswer = ::TMessageBox (strText, MB_YESNO | MB_ICONQUESTION);
+
+    if (m_bClosePending)
+      return;
+
+    if (iAnswer == IDYES)
       {
 		  CWaitCursor	wait;
 
@@ -287,16 +492,20 @@ void CTextDocument::OnFileChanged(void)
       } // end of approving modification or wanting it anyway
     } // end of time changing
 
-	m_bInFileChanged = false;
 }
 
 
 // kill the monitoring thread during the save
 BOOL CTextDocument::DoSave(LPCTSTR lpszPathName, BOOL bReplace)
   {
-  KillThread (m_pThread, m_eventFileChanged);
+  CTextDocumentOperationGuard operationGuard (this);
+  StopMonitoringThread (m_iMonitorToken);
+  m_bFileChangedPending = false;
 
   BOOL bResult = CDocument::DoSave (lpszPathName, bReplace);
+
+  if (m_bClosePending)
+    return bResult;
 
   // monitor this file again
   if (!GetPathName ().IsEmpty ())
@@ -309,7 +518,8 @@ BOOL CTextDocument::DoSave(LPCTSTR lpszPathName, BOOL bReplace)
 void CTextDocument::CreateMonitoringThread(const char * sName)
 {
   // kill any old thread
-  KillThread (m_pThread, m_eventFileChanged);
+  StopMonitoringThread (m_iMonitorToken);
+  m_bFileChangedPending = false;
 
   // find when the file was last modified
 
@@ -318,13 +528,16 @@ void CTextDocument::CreateMonitoringThread(const char * sName)
   m_timeFileMod = status.m_mtime;
 
   // create the thread
-  m_pThread = ::CreateMonitoringThread (sName, (DWORD) this, m_eventFileChanged);
+  m_iMonitorToken = ::CreateMonitoringThread
+    (sName, m_iTextDocumentNumber, WM_USER_FILE_CONTENTS_CHANGED);
 
   UpdateAllViews  (NULL);     // force window title to be redrawn
 }
 
 void CTextDocument::OnFileOpen() 
 {
+	CTextDocumentOperationGuard operationGuard (this);
+
 	CString title;
 	VERIFY(title.LoadString(AFX_IDS_OPENFILE));
 
@@ -464,6 +677,8 @@ CMUSHclientDoc * pDoc = FindWorld ();
 
 BOOL CTextDocument::SaveModified() 
 {
+	CTextDocumentOperationGuard operationGuard (this);
+
 // don't bother asking if they want to save an empty document
 CTextView* pView = (CTextView*) m_viewList.GetHead();
   

--- a/TextDocument.h
+++ b/TextDocument.h
@@ -32,15 +32,19 @@ protected:
 // Attributes
 public:
 
-	HANDLE	m_pThread;			// Notification thread
-	CEvent  m_eventFileChanged;		// file changed thread event
+  __int64 m_iMonitorToken;  // Current monitor generation; zero means stopped.
   bool m_bInFileChanged;
+  bool m_bFileChangedPending;
+  int m_iActiveOperations;
+  bool m_bClosePending;
+  bool m_bCloseQueued;
   CTime m_timeFileMod;
 
   CString m_strTitle;
   CMUSHclientDoc * m_pRelatedWorld; // which world it belongs to, if any
 
    __int64 m_iUniqueDocumentNumber;    // to confirm we have the right doc
+   __int64 m_iTextDocumentNumber;      // identifies this text document instance
    CString m_strFontName;        // window font
    LONG     m_iFontSize;
    LONG     m_iFontWeight;
@@ -92,6 +96,8 @@ public:
   void CreateMonitoringThread(const char * sName);
   void SetTheFont (void);
   void SetReadOnly (BOOL bReadOnly);
+  void BeginOperation (void);
+  void EndOperation (void);
 
 	// Generated message map functions
 protected:
@@ -103,6 +109,26 @@ protected:
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };
+
+class CTextDocumentOperationGuard
+  {
+  public:
+    CTextDocumentOperationGuard (CTextDocument * pDoc) : m_pDoc (pDoc)
+      {
+      ASSERT (m_pDoc);
+      m_pDoc->BeginOperation ();
+      }
+
+    ~CTextDocumentOperationGuard ()
+      {
+      m_pDoc->EndOperation ();
+      }
+
+  private:
+    CTextDocument * m_pDoc;
+    CTextDocumentOperationGuard (const CTextDocumentOperationGuard &);
+    CTextDocumentOperationGuard & operator= (const CTextDocumentOperationGuard &);
+  };
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.

--- a/TextView.cpp
+++ b/TextView.cpp
@@ -144,6 +144,18 @@ void CTextView::Dump(CDumpContext& dc) const
 /////////////////////////////////////////////////////////////////////////////
 // CTextView message handlers
 
+BOOL CTextView::OnCmdMsg(UINT nID, int nCode, void* pExtra,
+                         AFX_CMDHANDLERINFO* pHandlerInfo)
+  {
+  CTextDocument * pDoc = (CTextDocument *) GetDocument ();
+
+  if (!pDoc)
+    return CEditView::OnCmdMsg (nID, nCode, pExtra, pHandlerInfo);
+
+  CTextDocumentOperationGuard operationGuard (pDoc);
+  return CEditView::OnCmdMsg (nID, nCode, pExtra, pHandlerInfo);
+  }
+
 BOOL CTextView::PreCreateWindow(CREATESTRUCT& cs) 
 {
 	cs.style &= ~FWS_ADDTOTITLE;  // do not add document name to window title

--- a/TextView.h
+++ b/TextView.h
@@ -44,6 +44,8 @@ public:
 // Overrides
 
   virtual void SerializeRaw(CArchive& ar);
+  virtual BOOL OnCmdMsg(UINT nID, int nCode, void* pExtra,
+                        AFX_CMDHANDLERINFO* pHandlerInfo);
 
   void OpenLuaDelayed ();
   void OpenLua ();

--- a/chatsock.cpp
+++ b/chatsock.cpp
@@ -28,6 +28,7 @@ CChatSocket::CChatSocket(CMUSHclientDoc* pDoc)
 {
 	m_pDoc = pDoc;
   m_hNameLookup = NULL;
+  m_iNameLookupGeneration = 0;
   m_pGetHostStruct = NULL;
   ZeroMemory (&m_ServerAddr, sizeof m_ServerAddr);
   m_bDeleteMe = false;  
@@ -1567,6 +1568,12 @@ void CChatSocket::Process_Snoop_data				  (const CString strMessage)
   bool bOldNotesInRGB = m_pDoc->m_bNotesInRGB;
   COLORREF iOldNoteColourFore = m_pDoc->m_iNoteColourFore;
   COLORREF iOldNoteColourBack = m_pDoc->m_iNoteColourBack;
+  CValueStateGuard<bool> notesRGBGuard
+    (m_pDoc->m_bNotesInRGB, m_pDoc->m_bNotesInRGB);
+  CValueStateGuard<COLORREF> noteForeGuard
+    (m_pDoc->m_iNoteColourFore, m_pDoc->m_iNoteColourFore);
+  CValueStateGuard<COLORREF> noteBackGuard
+    (m_pDoc->m_iNoteColourBack, m_pDoc->m_iNoteColourBack);
 
   m_pDoc->ColourTell ("springgreen", "black", ">");
 
@@ -1617,7 +1624,7 @@ void CChatSocket::Process_Send_command				  (const CString strMessage)
                   TFormat ("%s commands you to '%s'.",
                                 (LPCTSTR) m_strRemoteUserName,
                                 (LPCTSTR) strMessage));
-    m_pDoc->m_iExecutionDepth = 0;
+    CValueStateGuard<int> executionDepthGuard (m_pDoc->m_iExecutionDepth, 0);
     m_pDoc->Execute (strMessage);
     }   // end of allowed to send commands
   else

--- a/chatsock.cpp
+++ b/chatsock.cpp
@@ -169,6 +169,7 @@ void CChatSocket::StopFileTransfer (const bool bAbort)
 
 void CChatSocket::OnReceive(int nErrorCode)
 {
+  CWorldDocumentOperationGuard operationGuard (m_pDoc);
 
 char buff [1000];
 int count = Receive (buff, sizeof (buff) - 1);

--- a/chatsock.h
+++ b/chatsock.h
@@ -121,6 +121,7 @@ public:
 
   HANDLE      m_hNameLookup;      // for name lookup
   char *      m_pGetHostStruct;   // ditto
+  unsigned long m_iNameLookupGeneration;
 
   int m_iChatStatus;              // status of session, see enum above
   int m_iChatConnectionType;      // type of connection, see enum above

--- a/childfrm.cpp
+++ b/childfrm.cpp
@@ -3,6 +3,7 @@
 
 #include "stdafx.h"
 #include "MUSHclient.h"
+#include "dialogs\ProgDlg.h"
 
 #include "doc.h"
 #include "childfrm.h"
@@ -135,8 +136,15 @@ BOOL CChildFrame::PreCreateWindow(CREATESTRUCT& cs)
 
 void CChildFrame::OnClose() 
 {
-
-  
+  if (m_pDoc && (CProgressDlg::IsPumpingMessages () ||
+                 m_pDoc->m_iActiveProgressOperations != 0))
+    {
+    MSG msg = {};
+    msg.hwnd = GetSafeHwnd ();
+    msg.message = WM_CLOSE;
+    App.DeferMessageUntilIdle (msg, m_pDoc->m_iUniqueDocumentNumber);
+    return;
+    }
 	CMDIChildWnd::OnClose();
 }
 

--- a/dialogs/ChooseNotepadDlg.cpp
+++ b/dialogs/ChooseNotepadDlg.cpp
@@ -25,6 +25,7 @@ CChooseNotepadDlg::CChooseNotepadDlg(CWnd* pParent /*=NULL*/)
 	//}}AFX_DATA_INIT
  m_pWorld = NULL;
  m_pTextDocument = NULL;
+ m_iWorldDocumentNumber = 0;
 
 }
 
@@ -41,16 +42,23 @@ void CChooseNotepadDlg::DoDataExchange(CDataExchange* pDX)
   if (!pDX->m_bSaveAndValidate)
     {   // loading
 
+    CMUSHclientDoc * pWorld = GetLiveWorld ();
+    if (!pWorld)
+      return;
+
+    m_NotepadDocumentNumbers.RemoveAll ();
+
     for (docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
         docPos != NULL; )
       {
       int nItem;
 
-      CTextDocument * pDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+      CTextDocument * pDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
       // ignore unrelated worlds
-      if (pDoc->m_pRelatedWorld != m_pWorld ||
-          pDoc->m_iUniqueDocumentNumber != m_pWorld->m_iUniqueDocumentNumber)
+      if (pDoc->m_bClosePending ||
+          pDoc->m_pRelatedWorld != pWorld ||
+          pDoc->m_iUniqueDocumentNumber != m_iWorldDocumentNumber)
         continue;
 
       CString strTitle = pDoc->GetPathName ();
@@ -62,13 +70,54 @@ void CChooseNotepadDlg::DoDataExchange(CDataExchange* pDX)
       nItem = m_ctlNotepadList.AddString (strTitle);
 
       if (nItem != LB_ERR  && nItem != LB_ERRSPACE )
-         m_ctlNotepadList.SetItemData (nItem, (DWORD) pDoc);
+        {
+        int iDocument = m_NotepadDocumentNumbers.Add (pDoc->m_iTextDocumentNumber);
+        m_ctlNotepadList.SetItemData (nItem, (DWORD) iDocument);
+        }
 
       } // end of doing each document
 
     }   // end of loading
 
 }
+
+CMUSHclientDoc * CChooseNotepadDlg::GetLiveWorld (void) const
+  {
+  if (!m_pWorld)
+    return NULL;
+
+  for (POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition(); pos; )
+    {
+    CMUSHclientDoc * pWorld =
+      (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (pos);
+    if (pWorld == m_pWorld &&
+        pWorld->m_iUniqueDocumentNumber == m_iWorldDocumentNumber)
+      return pWorld;
+    }
+
+  return NULL;
+  }
+
+CTextDocument * CChooseNotepadDlg::GetNotepadForIndex (const int iIndex) const
+  {
+  CMUSHclientDoc * pWorld = GetLiveWorld ();
+  if (!pWorld || iIndex < 0 || iIndex >= m_NotepadDocumentNumbers.GetSize ())
+    return NULL;
+
+  __int64 iDocumentNumber = m_NotepadDocumentNumbers [iIndex];
+  for (POSITION pos = App.m_pNormalDocTemplate->GetFirstDocPosition(); pos; )
+    {
+    CTextDocument * pDoc =
+      (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc (pos);
+    if (!pDoc->m_bClosePending &&
+        pDoc->m_iTextDocumentNumber == iDocumentNumber &&
+        pDoc->m_pRelatedWorld == pWorld &&
+        pDoc->m_iUniqueDocumentNumber == m_iWorldDocumentNumber)
+      return pDoc;
+    }
+
+  return NULL;
+  }
 
 
 BEGIN_MESSAGE_MAP(CChooseNotepadDlg, CDialog)
@@ -90,7 +139,12 @@ int nItem = m_ctlNotepadList.GetCurSel ();
   if (nItem == LB_ERR)
     return;
 
-  m_pTextDocument = (CTextDocument *) m_ctlNotepadList.GetItemData (nItem);
+  m_pTextDocument = GetNotepadForIndex ((int) m_ctlNotepadList.GetItemData (nItem));
+  if (!m_pTextDocument)
+    {
+    m_ctlNotepadList.DeleteString (nItem);
+    return;
+    }
 
   OnOK ();
 	

--- a/dialogs/ChooseNotepadDlg.h
+++ b/dialogs/ChooseNotepadDlg.h
@@ -24,6 +24,8 @@ public:
 
   CMUSHclientDoc * m_pWorld;
   CTextDocument  * m_pTextDocument;
+  __int64 m_iWorldDocumentNumber;
+  CArray<__int64, __int64> m_NotepadDocumentNumbers;
 
 // Overrides
 	// ClassWizard generated virtual function overrides
@@ -34,6 +36,9 @@ public:
 
 // Implementation
 protected:
+
+  CMUSHclientDoc * GetLiveWorld (void) const;
+  CTextDocument * GetNotepadForIndex (const int iIndex) const;
 
 	// Generated message map functions
 	//{{AFX_MSG(CChooseNotepadDlg)

--- a/dialogs/ProgDlg.cpp
+++ b/dialogs/ProgDlg.cpp
@@ -10,6 +10,19 @@
 static char BASED_CODE THIS_FILE[] = __FILE__;
 #endif
 
+// Counts nested progress message loops on the UI thread.
+static int s_iProgressMessageDepth = 0;
+
+class CProgressMessageScope
+  {
+  public:
+    CProgressMessageScope () { ++s_iProgressMessageDepth; }
+    ~CProgressMessageScope () { --s_iProgressMessageDepth; }
+  private:
+    CProgressMessageScope (const CProgressMessageScope &);
+    CProgressMessageScope & operator= (const CProgressMessageScope &);
+  };
+
 /////////////////////////////////////////////////////////////////////////////
 // CProgressDlg dialog
 
@@ -28,12 +41,50 @@ CProgressDlg::CProgressDlg(UINT nCaptionID)
     //}}AFX_DATA_INIT
     m_bParentDisabled = FALSE;
     m_bHideCancel = FALSE;
+    m_iActiveOperations = 0;
+    m_bDeletePending = false;
+    m_hParentWindow = NULL;
+    m_pParentWindowIdentity = NULL;
 }
 
 CProgressDlg::~CProgressDlg()
 {
     if(m_hWnd!=NULL)
       DestroyWindow();
+}
+
+bool CProgressDlg::IsPumpingMessages ()
+{
+    return s_iProgressMessageDepth != 0;
+}
+
+bool CProgressDlg::IsUsable () const
+{
+    return !m_bDeletePending && m_hWnd != NULL && ::IsWindow (m_hWnd) &&
+      CWnd::FromHandlePermanent (m_hWnd) == this;
+}
+
+void CProgressDlg::BeginOperation ()
+{
+    ++m_iActiveOperations;
+}
+
+void CProgressDlg::EndOperation ()
+{
+    ASSERT (m_iActiveOperations > 0);
+    if (--m_iActiveOperations == 0 && m_bDeletePending)
+      delete this;
+}
+
+void CProgressDlg::RequestDelete ()
+{
+    if (m_iActiveOperations != 0)
+    {
+      m_bDeletePending = true;
+      m_bCancel = TRUE;
+      return;
+    }
+    delete this;
 }
 
 BOOL CProgressDlg::DestroyWindow()
@@ -44,15 +95,19 @@ BOOL CProgressDlg::DestroyWindow()
 
 void CProgressDlg::ReEnableParent()
 {
-    if(m_bParentDisabled && (m_pParentWnd!=NULL))
-      m_pParentWnd->EnableWindow(TRUE);
+    const bool bEnable = m_bParentDisabled && ::IsWindow (m_hParentWindow) &&
+      CWnd::FromHandlePermanent (m_hParentWindow) == m_pParentWindowIdentity;
     m_bParentDisabled=FALSE;
+    if (bEnable)
+      ::EnableWindow (m_hParentWindow, TRUE);
 }
 
 BOOL CProgressDlg::Create(CWnd *pParent)
 {
     // Get the true parent of the dialog
     m_pParentWnd = CWnd::GetSafeOwner(pParent);
+    m_hParentWindow = m_pParentWnd ? m_pParentWnd->GetSafeHwnd () : NULL;
+    m_pParentWindowIdentity = CWnd::FromHandlePermanent (m_hParentWindow);
 
     // m_bParentDisabled is used to re-enable the parent window
     // when the dialog is destroyed. So we don't want to set
@@ -88,8 +143,8 @@ END_MESSAGE_MAP()
 
 void CProgressDlg::SetStatus(LPCTSTR lpszMessage)
 {
-    ASSERT(m_hWnd); // Don't call this _before_ the dialog has
-                    // been created. Can be called from OnInitDialog
+    if (!IsUsable ())
+      return;
     CWnd *pWndStatus = GetDlgItem(CG_IDC_PROGDLG_STATUS);
 
     // Verify that the static text control exists
@@ -104,6 +159,8 @@ void CProgressDlg::OnCancel()
 
 void CProgressDlg::SetRange(int nLower,int nUpper)
 {
+    if (!IsUsable ())
+      return;
     m_nLower = nLower;
     m_nUpper = nUpper;
     m_Progress.SetRange32(nLower,nUpper);
@@ -112,6 +169,8 @@ void CProgressDlg::SetRange(int nLower,int nUpper)
 int CProgressDlg::SetPos(int nPos)
 {
     PumpMessages();
+    if (!IsUsable ())
+      return 0;
     int iResult = m_Progress.SetPos(nPos);
     UpdatePercent(nPos);
     return iResult;
@@ -119,6 +178,8 @@ int CProgressDlg::SetPos(int nPos)
 
 int CProgressDlg::SetStep(int nStep)
 {
+    if (!IsUsable ())
+      return 0;
     m_nStep = nStep; // Store for later use in calculating percentage
     return m_Progress.SetStep(nStep);
 }
@@ -126,6 +187,8 @@ int CProgressDlg::SetStep(int nStep)
 int CProgressDlg::OffsetPos(int nPos)
 {
     PumpMessages();
+    if (!IsUsable ())
+      return 0;
     int iResult = m_Progress.OffsetPos(nPos);
     UpdatePercent(iResult+nPos);
     return iResult;
@@ -134,6 +197,8 @@ int CProgressDlg::OffsetPos(int nPos)
 int CProgressDlg::StepIt()
 {
     PumpMessages();
+    if (!IsUsable ())
+      return 0;
     int iResult = m_Progress.StepIt();
     UpdatePercent(iResult+m_nStep);
     return iResult;
@@ -141,19 +206,43 @@ int CProgressDlg::StepIt()
 
 void CProgressDlg::PumpMessages()
 {
-    // Must call Create() before using the dialog
-    ASSERT(m_hWnd!=NULL);
-
-    MSG msg;
-    // Handle dialog messages
-    while(PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+    if (!IsUsable ())
     {
-      if(!IsDialogMessage(&msg))
+      m_bCancel = TRUE;
+      return;
+    }
+    CProgressMessageScope messageScope;
+    MSG msg;
+    // Preserve a request to terminate the application.
+    if(::PeekMessage(&msg, NULL, WM_QUIT, WM_QUIT, PM_REMOVE))
+    {
+      m_bCancel = TRUE;
+      ::PostQuitMessage((int) msg.wParam);
+      return;
+    }
+
+    // Socket notifications must keep running during long operations.
+    // Callers retain their data across callbacks; document and application
+    // closure is deferred until the main loop resumes.
+    while(IsUsable () && !m_bCancel && ::PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+    {
+      if(msg.message == WM_QUIT)
+      {
+        m_bCancel = TRUE;
+        ::PostQuitMessage((int) msg.wParam);
+        return;
+      }
+
+      // PeekMessage can dispatch sent messages that close this dialog.
+      // Still dispatch any retrieved message for another window.
+      if(!IsUsable () || !IsDialogMessage(&msg))
       {
         TranslateMessage(&msg);
-        DispatchMessage(&msg);  
+        DispatchMessage(&msg);
       }
     }
+    if (!IsUsable ())
+      m_bCancel = TRUE;
 }
 
 BOOL CProgressDlg::CheckCancelButton()
@@ -176,6 +265,8 @@ BOOL CProgressDlg::CheckCancelButton()
 
 void CProgressDlg::UpdatePercent(int nNewPos)
 {
+    if (!IsUsable ())
+      return;
     CWnd *pWndPercent = GetDlgItem(CG_IDC_PROGDLG_PERCENT);
     int nPercent;
     
@@ -197,10 +288,15 @@ void CProgressDlg::UpdatePercent(int nNewPos)
     strBuf.Format(_T("%d%c"),nPercent,_T('%'));
 
 	CString strCur; // get current percentage
+    const HWND hPercent = pWndPercent->GetSafeHwnd ();
     pWndPercent->GetWindowText(strCur);
 
-	if (strCur != strBuf)
-		pWndPercent->SetWindowText(strBuf);
+    // Reading text sends a window message and can close or replace a control.
+    if (!IsUsable ())
+      return;
+    pWndPercent = GetDlgItem (CG_IDC_PROGDLG_PERCENT);
+    if (pWndPercent && pWndPercent->GetSafeHwnd () == hPercent && strCur != strBuf)
+      pWndPercent->SetWindowText(strBuf);
 }
     
 /////////////////////////////////////////////////////////////////////////////

--- a/dialogs/ProgDlg.h
+++ b/dialogs/ProgDlg.h
@@ -15,6 +15,11 @@ public:
     ~CProgressDlg();
 
     BOOL Create(CWnd *pParent=NULL);
+    static bool IsPumpingMessages ();
+    bool IsUsable () const;
+    void BeginOperation ();
+    void EndOperation ();
+    void RequestDelete ();
 
     // Checking for Cancel button
     BOOL CheckCancelButton();
@@ -52,6 +57,10 @@ protected:
     
     BOOL m_bCancel;
     BOOL m_bParentDisabled;
+    int m_iActiveOperations;
+    bool m_bDeletePending;
+    HWND m_hParentWindow;
+    CWnd * m_pParentWindowIdentity;
 
     void ReEnableParent();
 
@@ -66,5 +75,18 @@ protected:
     //}}AFX_MSG
     DECLARE_MESSAGE_MAP()
 };
+
+// A Lua callback can close the dialog that is currently pumping messages.
+class CProgressDlgOperationGuard
+  {
+  public:
+    explicit CProgressDlgOperationGuard (CProgressDlg * pDialog) : m_pDialog (pDialog)
+      { m_pDialog->BeginOperation (); }
+    ~CProgressDlgOperationGuard () { m_pDialog->EndOperation (); }
+  private:
+    CProgressDlg * m_pDialog;
+    CProgressDlgOperationGuard (const CProgressDlgOperationGuard &);
+    CProgressDlgOperationGuard & operator= (const CProgressDlgOperationGuard &);
+  };
 
 #endif // __PROGDLG_H__

--- a/dialogs/world_prefs/prefspropertypages.cpp
+++ b/dialogs/world_prefs/prefspropertypages.cpp
@@ -9106,15 +9106,32 @@ CalculateMemoryUsage ();
 
 void CPrefsP15::CalculateMemoryUsage ()
   {
-
-  CProgressDlg * pProgressDlg = NULL;
-
-  if (m_doc->m_LineList.GetCount () > 1000)
+  CWorldDocumentOperationGuard operationGuard (m_doc);
+  struct CLineMemory
     {
-    pProgressDlg = new CProgressDlg; 
-    pProgressDlg->Create ();                           
+    long bytes;
+    int styles;
+    };
+  vector<CLineMemory> lines;
+  for (POSITION pos = m_doc->m_LineList.GetHeadPosition (); pos; )
+    {
+    const CLine * pLine = m_doc->m_LineList.GetNext (pos);
+    CLineMemory line;
+    line.styles = (int) pLine->styleList.GetCount ();
+    line.bytes = sizeof (CLine) + pLine->iMemoryAllocated + sizeof (void *) * 3 +
+      line.styles * (sizeof (CStyle) + sizeof (void *) * 3);
+    lines.push_back (line);
+    }
+  const long nLines = (long) lines.size ();
+  std::unique_ptr<CProgressDlg> pProgressDlg;
+
+  if (nLines > 1000)
+    {
+    pProgressDlg.reset (new CProgressDlg);
+    if (!pProgressDlg->Create ())
+      AfxThrowResourceException ();
     pProgressDlg->SetStatus (Translate ("Calculating memory usage..."));               
-    pProgressDlg->SetRange (0, m_doc->m_LineList.GetCount ());
+    pProgressDlg->SetRange (0, nLines);
     pProgressDlg->SetWindowText (Translate ("Memory used by output buffer"));                              
     }
 
@@ -9126,37 +9143,22 @@ void CPrefsP15::CalculateMemoryUsage ()
 
   Frame.SetStatusMessageNow (Translate ("Calculating size of output buffer..."));
 
-  for (POSITION pos = m_doc->m_LineList.GetHeadPosition (); pos; )
+  for (size_t i = 0; i < lines.size (); ++i)
     {
     iCount++;
-
     if (pProgressDlg)
       {
       if ((iCount & 63) == 0)
-        pProgressDlg->SetPos (iCount); 
-
-      if (pProgressDlg->CheckCancelButton())     // abort if user cancels
-        {
-        delete pProgressDlg;
+        pProgressDlg->SetPos (iCount);
+      if (pProgressDlg->CheckCancelButton ())
         return;
-        }
       }
-
-    CLine * pLine = m_doc->m_LineList.GetNext (pos);
-    nMemory += sizeof CLine;          // add the class itself
-    nMemory += pLine->iMemoryAllocated;  // and the text
-
-    // count styles and work out how much memory they take too
-    for (POSITION pos2 = pLine->styleList.GetHeadPosition(); pos2; iStyles++)
-      {
-      pLine->styleList.GetNext (pos2);
-      nMemory += sizeof CStyle;   // length of style class
-      nMemory += sizeof (void *) * 3;   // and the list item
-      }
-
-    nMemory += sizeof (void *) * 3;   // and the list item
+    nMemory += lines [i].bytes;
+    iStyles += lines [i].styles;
     }
 
+  if (!::IsWindow (m_hWnd) || CWnd::FromHandlePermanent (m_hWnd) != this)
+    return;
   m_strBufferLines += TFormat (" (%i styles)", iStyles);
 	SetDlgItemText(IDC_BUFFER_LINES, m_strBufferLines);
 
@@ -9168,9 +9170,9 @@ void CPrefsP15::CalculateMemoryUsage ()
     strKb.Format ("%5.1f Mb", nMemory / (1024.0 * 1024.0));    // show as Mb
 
   // at new document time we won't have a line yet
-  if (m_doc->m_LineList.GetCount ())
+  if (nLines)
     strMemory.Format ("%s (%i bytes/line)", (LPCTSTR) strKb,
-                      nMemory / m_doc->m_LineList.GetCount ());
+                      nMemory / nLines);
   else
     strMemory.Format ("%s", (LPCTSTR) strKb);
 
@@ -9181,7 +9183,7 @@ void CPrefsP15::CalculateMemoryUsage ()
   GetDlgItem (IDC_CALCULATE_MEMORY)->EnableWindow (FALSE);  // only do it once
 
 
-  delete pProgressDlg;
+
 
   } // end of  CPrefsP15::CalculateMemoryUsage 
 

--- a/doc.cpp
+++ b/doc.cpp
@@ -940,7 +940,8 @@ BOOL CMUSHclientDoc::OpenSession (void)
       }
     } // end of executing open script
 
-  if (App.m_bAutoConnectWorlds)
+  if (App.m_bAutoConnectWorlds &&
+      m_iConnectPhase == eConnectNotConnected)
 	  if (ConnectSocket())
 		  return TRUE;
 
@@ -977,6 +978,10 @@ void CMUSHclientDoc::Dump(CDumpContext& dc) const
 
 BOOL CMUSHclientDoc::ConnectSocket(void)
 {
+
+  // Keep the socket and completion phase of an existing host name lookup.
+  if (m_hNameLookup)
+    return TRUE;    // the connection attempt is still waiting for its address
 
 CString str;
 
@@ -1032,6 +1037,8 @@ CString str;
           break;
 
     } // end of switch
+
+  m_iConnectionAttemptNumber++;
 
 	m_bEnableAutoSay = FALSE;		// auto-say off at start of session
 
@@ -4401,6 +4408,7 @@ bool CMUSHclientDoc::SendToMushHelper (CFile * f,
                                        const BOOL bConfirm,
                                        const BOOL bEcho)
   {
+CWorldDocumentOperationGuard operationGuard (this);
 CString str;
 CString full_line;
 
@@ -4451,10 +4459,13 @@ DWORD nLines = 0,
     if (dlg.DoModal () != IDOK)
       return false;
 
+  if (m_bWorldClosePending)
+    return false;
   CArchive ar (f, CArchive::load);
 
   CProgressDlg ProgressDlg;                   
-  ProgressDlg.Create ();                           
+  if (!ProgressDlg.Create ())
+    AfxThrowResourceException ();
   ProgressDlg.SetStatus (Translate ("Sending to world..."));               
   ProgressDlg.SetRange (0, nLines);
   ProgressDlg.SetWindowText (Translate ("Sending..."));                              
@@ -4466,6 +4477,8 @@ DWORD nLines = 0,
 
     if (!dlg.m_strPreamble.IsEmpty ())
       SendMsg (dlg.m_strPreamble, dlg.m_bEcho, false, LoggingInput ());
+    if (m_bWorldClosePending)
+      return false;
     
     CString strSoftcode;
     bool bHashCommenting = false;
@@ -4478,7 +4491,12 @@ DWORD nLines = 0,
       nCurrentLine++;
       ProgressDlg.SetPos (nCurrentLine); 
 
-      if (ProgressDlg.CheckCancelButton())     // abort if user cancels
+      if (m_bWorldClosePending)
+        return false;
+      const BOOL bCancelled = ProgressDlg.CheckCancelButton ();
+      if (m_bWorldClosePending)
+        return false;
+      if (bCancelled)
         break;
 
       if (dlg.m_bCommentedSoftcode)
@@ -4504,6 +4522,8 @@ DWORD nLines = 0,
           full_line += dlg.m_strLinePostamble;
 
           SendMsg (full_line, dlg.m_bEcho, false, LoggingInput ());   // send the line
+          if (m_bWorldClosePending)
+            return false;
           if (dlg.m_iLineDelay > 0)
             {
             if (++iLineCount >= dlg.m_nLineDelayPerLines)
@@ -4544,6 +4564,8 @@ DWORD nLines = 0,
       full_line += str;
       full_line += dlg.m_strLinePostamble;
       SendMsg (full_line, dlg.m_bEcho, false, LoggingInput ());   // send the line
+      if (m_bWorldClosePending)
+        return false;
       if (dlg.m_iLineDelay > 0)
         {
         if (++iLineCount >= dlg.m_nLineDelayPerLines)
@@ -4560,6 +4582,8 @@ DWORD nLines = 0,
       full_line += strSoftcode;
       full_line += dlg.m_strLinePostamble;
       SendMsg (full_line, dlg.m_bEcho, false, LoggingInput ());   // send the line
+      if (m_bWorldClosePending)
+        return false;
       if (dlg.m_iLineDelay > 0)
         {
         if (++iLineCount >= dlg.m_nLineDelayPerLines)
@@ -4590,7 +4614,7 @@ DWORD nLines = 0,
 void CMUSHclientDoc::OnGamePastefile() 
 {
 
-CStdioFile * f = NULL;
+std::unique_ptr<CStdioFile> f;
 CString str;
 CString filename;
 
@@ -4617,9 +4641,9 @@ CString filename;
 
   try
     {
-    f = new CStdioFile (filedlg.GetPathName (), CFile::modeRead | CFile::shareDenyWrite);
+    f.reset (new CStdioFile (filedlg.GetPathName (), CFile::modeRead | CFile::shareDenyWrite));
 
-    SendToMushHelper (f, 
+    SendToMushHelper (f.get (),
                      m_file_preamble,
                      m_line_preamble,
                      m_line_postamble,
@@ -4638,8 +4662,6 @@ CString filename;
       TMessageBox ("Unable to open or read the requested file", MB_ICONEXCLAMATION);
     e->Delete ();
     } // end of catching a file exception
-
-  delete f;       // delete file
 
 }
 
@@ -5409,8 +5431,36 @@ void CMUSHclientDoc::ShowStatusLine (const bool bNow)
 
 
 
+void CMUSHclientDoc::OnCloseDocument()
+{
+  if (m_iActiveProgressOperations != 0 || CProgressDlg::IsPumpingMessages ())
+    {
+    if (!m_bWorldCloseQueued)
+      {
+      App.DeferWorldDocumentClose (m_iUniqueDocumentNumber);
+      m_bWorldCloseQueued = true;
+      }
+    m_bWorldClosePending = true;
+    return;
+    }
+  CDocument::OnCloseDocument ();
+}
+
+void CMUSHclientDoc::BeginProgressOperation ()
+{
+  ++m_iActiveProgressOperations;
+}
+
+void CMUSHclientDoc::EndProgressOperation ()
+{
+  ASSERT (m_iActiveProgressOperations > 0);
+  --m_iActiveProgressOperations;
+}
+
 BOOL CMUSHclientDoc::SaveModified() 
 {
+  if (m_bWorldClosePending)
+    return TRUE; // This accepted close has already run its save and close script.
 CString str;
 
   if (m_pSocket && 
@@ -5834,6 +5884,7 @@ CString CMUSHclientDoc::RecallText (const CString strSearchString,   // what to 
                                     const int  iLines,
                                     const CString strRecallLinePreamble)
     {
+CWorldDocumentOperationGuard operationGuard (this);
 CString strMessage;
 std::unique_ptr<t_regexp> regexp;   // compiled regular expression
 int iCurrentLine;
@@ -5866,18 +5917,6 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
   long nToGo = m_LineList.GetCount ();
   iCurrentLine = 0;
   
-  std::unique_ptr<CProgressDlg> pProgressDlg; // progress dialog
-
-  if (nToGo > 500)
-    {
-    pProgressDlg.reset (new CProgressDlg);
-    if (!pProgressDlg->Create ())
-      AfxThrowResourceException ();
-    pProgressDlg->SetStatus (strStatus);
-    pProgressDlg->SetRange (0, nToGo);     
-    pProgressDlg->SetWindowText (Translate ("Recalling..."));                              
-    }   // end of having enough lines to warrant a progress bar
-
 // go back requested number of lines
 
   POSITION pos = m_LineList.GetHeadPosition ();
@@ -5909,6 +5948,38 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
   else
     pos = m_LineList.GetHeadPosition ();
 
+  struct CRecallLine
+    {
+    CString text;
+    CTime time;
+    int flags;
+    bool hardReturn;
+    };
+  vector<CRecallLine> lines;
+  for (POSITION snapshotPos = pos; snapshotPos; )
+    {
+    const CLine * pLine = m_LineList.GetNext (snapshotPos);
+    CRecallLine line;
+    line.text = CString (pLine->text, pLine->len);
+    line.time = pLine->m_theTime;
+    line.flags = pLine->flags;
+    line.hardReturn = pLine->hard_return;
+    lines.push_back (line);
+    }
+  size_t nextLine = 0;
+
+  std::unique_ptr<CProgressDlg> pProgressDlg; // progress dialog
+
+  if (nToGo > 500)
+    {
+    pProgressDlg.reset (new CProgressDlg);
+    if (!pProgressDlg->Create ())
+      AfxThrowResourceException ();
+    pProgressDlg->SetStatus (strStatus);
+    pProgressDlg->SetRange (0, nToGo);
+    pProgressDlg->SetWindowText (Translate ("Recalling..."));
+    }   // end of having enough lines to warrant a progress bar
+
 // if case-insensitive search wanted, force "text to find" to lower case
 
   if (!bMatchCase)
@@ -5928,15 +5999,15 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
 
       // get lines until a hard return
 
-      while (pos)
+      while (nextLine < lines.size ())
         {
-        CLine * pLine = m_LineList.GetNext (pos);   // get next line
-        strLine += CString (pLine->text, pLine->len);
-        theTime = pLine->m_theTime;
-        iFlags = pLine->flags;
+        const CRecallLine & line = lines [nextLine++];
+        strLine += line.text;
+        theTime = line.time;
+        iFlags = line.flags;
         iMilestone++;
         iCurrentLine++;
-        if (pLine->hard_return)
+        if (line.hardReturn)
           break;
         }
 
@@ -5994,7 +6065,7 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
           } // end of found it
         } // end of not regular expression
 
-      } while (pos);  // end of looping through each line 
+      } while (nextLine < lines.size ());  // end of looping through each line
 
     } // end of try
 
@@ -6852,7 +6923,7 @@ CTextDocument * pTextDoc = NULL;
   for (POSITION docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
       docPos != NULL; )
     {
-    pTextDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+    pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
     // ignore unrelated worlds
     if (pTextDoc->m_pRelatedWorld == this &&
@@ -7782,21 +7853,58 @@ void CMUSHclientDoc::SendTo (
 
 bool CMUSHclientDoc::LookupHostName (LPCTSTR sName)
   {
-  delete [] m_pGetHostStruct;   // delete buffer just in case
-  m_pGetHostStruct = new char [MAXGETHOSTSTRUCT];
-
-  if (!m_pGetHostStruct)
+  std::unique_ptr<char []> pNewHostStruct;
+  try
     {
+    pNewHostStruct.reset (new char [MAXGETHOSTSTRUCT]);
+    }
+  catch (...)
+    {
+    if (!m_hNameLookup)
+      {
+      m_iConnectPhase = eConnectNotConnected;
+      App.m_bUpdateActivity = TRUE;
+      }
+    throw;
+    }
+
+  if (!pNewHostStruct)
+    {
+    if (!m_hNameLookup)
+      {
+      m_iConnectPhase = eConnectNotConnected;
+      App.m_bUpdateActivity = TRUE;
+      }
     TMessageBox ("Unable to allocate memory for host name lookup");
     return true;
     }
 
+  if (m_hNameLookup && WSACancelAsyncRequest (m_hNameLookup) == SOCKET_ERROR)
+    {
+    const int iError = WSAGetLastError ();
+    // These two errors mean that no operation remains for this handle.
+    if (iError != WSAEINVAL && iError != WSAEALREADY)
+      {
+      UMessageBox (TFormat ("Unable to cancel the previous host name lookup, "
+                           "code = %i (%s). The previous lookup was not replaced.",
+                           iError, GetSocketError (iError)));
+      return true;    // retain its buffer, generation, and completion phase
+      }
+    }
+
+  m_hNameLookup = NULL;
+  delete [] m_pGetHostStruct;
+  m_pGetHostStruct = pNewHostStruct.release ();
+
   if (Frame.GetSafeHwnd ())   // forget it if we don't have a window yet
+    {
+    m_iNameLookupGeneration++;
     m_hNameLookup = WSAAsyncGetHostByName (Frame.GetSafeHwnd (),
                                            WM_USER_HOST_NAME_RESOLVED,
                                            sName,
                                            m_pGetHostStruct,
                                            MAXGETHOSTSTRUCT);
+    }
 
  if (!m_hNameLookup)
    {
@@ -7810,6 +7918,7 @@ bool CMUSHclientDoc::LookupHostName (LPCTSTR sName)
     m_iConnectPhase = eConnectNotConnected;
 
     App.m_bUpdateActivity = TRUE;   // new activity!
+    return true;
 
    }
 
@@ -8488,7 +8597,12 @@ void CMUSHclientDoc::ContinueSSLHandshake (void)
   OnConnectionDisconnect ();
 
   // defer the fallback prompt via PostMessage so we're not inside a socket callback
-  Frame.PostMessage (WM_USER_SSL_FALLBACK_PROMPT, (WPARAM) this, 0);
+  CTLSFallbackNotification * pNotification = new CTLSFallbackNotification;
+  pNotification->m_iDocumentNumber = m_iUniqueDocumentNumber;
+  pNotification->m_iConnectionAttemptNumber = m_iConnectionAttemptNumber;
+  if (!Frame.PostMessage (WM_USER_SSL_FALLBACK_PROMPT,
+                          (WPARAM) pNotification, 0))
+    delete pNotification;
 
   }   // end of CMUSHclientDoc::ContinueSSLHandshake
 

--- a/doc.cpp
+++ b/doc.cpp
@@ -5950,17 +5950,55 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
 
   struct CRecallLine
     {
-    CString text;
     CTime time;
+    const char * text;
+    int length;
     int flags;
     bool hardReturn;
     };
+
+  // Size the selected range before allocating its immutable snapshot.
+  // Neither pass pumps messages while it holds positions in the live list.
+  size_t lineCount = 0;
+  size_t textBytesRemaining = 0;
+  for (POSITION snapshotPos = pos; snapshotPos; )
+    {
+    const CLine * pLine = m_LineList.GetNext (snapshotPos);
+    ++lineCount;
+    textBytesRemaining += pLine->len;
+    }
+
   vector<CRecallLine> lines;
+  lines.reserve (lineCount);
+  // Keep each line contiguous without requiring one large text allocation
+  // in the 32-bit process. Moving a block owner does not move its text.
+  vector<std::unique_ptr<char []> > textBlocks;
+  char * nextText = NULL;
+  size_t blockBytesRemaining = 0;
   for (POSITION snapshotPos = pos; snapshotPos; )
     {
     const CLine * pLine = m_LineList.GetNext (snapshotPos);
     CRecallLine line;
-    line.text = CString (pLine->text, pLine->len);
+    line.text = "";
+    line.length = pLine->len;
+    if (line.length != 0)
+      {
+      const size_t length = line.length;
+      if (blockBytesRemaining < length)
+        {
+        const size_t blockSize = (std::max) (length,
+          (std::min) (textBytesRemaining, size_t (64 * 1024)));
+        std::unique_ptr<char []> block (new char [blockSize]);
+        textBlocks.push_back (std::move (block));
+        nextText = textBlocks.back ().get ();
+        blockBytesRemaining = blockSize;
+        }
+      memcpy (nextText, pLine->text, length);
+      line.text = nextText;
+      nextText += length;
+      blockBytesRemaining -= length;
+      textBytesRemaining -= length;
+      }
     line.time = pLine->m_theTime;
     line.flags = pLine->flags;
     line.hardReturn = pLine->hard_return;
@@ -6002,7 +6040,7 @@ CString strStatus = TFormat ("Recalling: %s", (LPCTSTR) strSearchString);
       while (nextLine < lines.size ())
         {
         const CRecallLine & line = lines [nextLine++];
-        strLine += line.text;
+        strLine.Append (line.text, line.length);
         theTime = line.time;
         iFlags = line.flags;
         iMilestone++;
@@ -6925,8 +6963,9 @@ CTextDocument * pTextDoc = NULL;
     {
     pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
-    // ignore unrelated worlds
-    if (pTextDoc->m_pRelatedWorld == this &&
+    // ignore unrelated worlds and notepads whose close was accepted
+    if (!pTextDoc->m_bClosePending &&
+        pTextDoc->m_pRelatedWorld == this &&
        pTextDoc->m_iUniqueDocumentNumber == m_iUniqueDocumentNumber)
       break;
 

--- a/doc.h
+++ b/doc.h
@@ -1216,6 +1216,11 @@ public:
   int m_lastGoTo;         // last line we went to
 
   bool  m_bWorldClosing;    // true if world is closing
+  bool  m_bWorldCloseQueued;
+  bool  m_bWorldClosePending;
+  int   m_iActiveProgressOperations;
+  void BeginProgressOperation ();
+  void EndProgressOperation ();
 
 // we save the current style here on any style change *from the mud*
 // we don't want to mix up notes/user input with mud-set styles
@@ -1255,7 +1260,9 @@ public:
 
   HANDLE      m_hNameLookup;
   char *      m_pGetHostStruct;
+  unsigned long m_iNameLookupGeneration;
   int         m_iConnectPhase;    // see enum above
+  unsigned long m_iConnectionAttemptNumber;
 
 
 // chatting
@@ -1301,9 +1308,9 @@ public:
 
   CString m_strLastImmediateExpression;
 
-	HANDLE	m_pThread;			// Notification thread
-	CEvent  m_eventScriptFileChanged;		// script file changed thread event
+  __int64 m_iMonitorToken;  // Current monitor generation; zero means stopped.
   bool m_bInScriptFileChanged;
+  bool m_bScriptFileChangedPending;
   CTime m_timeScriptFileMod;
 
   CString m_strStatusMessage;   // "ready" or user-supplied message
@@ -2034,7 +2041,6 @@ public:
   bool CreateScriptEngine();
   void DisableScripting (void);
   void CreateMonitoringThread();
-	static void ThreadFunc(LPVOID pParam);
   void OnScriptFileChanged(const bool bForce = false);
   DISPID GetProcedureDispid (const CString & strName, 
                              const CString & strType,
@@ -2382,6 +2388,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CMUSHclientDoc)
 	public:
+	virtual void OnCloseDocument();
 	virtual BOOL OnNewDocument();
 	virtual BOOL OnOpenDocument(LPCTSTR lpszPathName);
 	protected:
@@ -3178,3 +3185,16 @@ class timer
 
       }
   };    // end of class timer
+
+// Retain a world until a synchronous operation and its callbacks unwind.
+class CWorldDocumentOperationGuard
+  {
+  public:
+    explicit CWorldDocumentOperationGuard (CMUSHclientDoc * pDoc) : m_pDoc (pDoc)
+      { m_pDoc->BeginProgressOperation (); }
+    ~CWorldDocumentOperationGuard () { m_pDoc->EndProgressOperation (); }
+  private:
+    CMUSHclientDoc * m_pDoc;
+    CWorldDocumentOperationGuard (const CWorldDocumentOperationGuard &);
+    CWorldDocumentOperationGuard & operator= (const CWorldDocumentOperationGuard &);
+  };

--- a/doc_construct.cpp
+++ b/doc_construct.cpp
@@ -16,7 +16,6 @@ extern int gdoccount;
 // CMUSHclientDoc construction/destruction
 
 CMUSHclientDoc::CMUSHclientDoc()
-  :	m_eventScriptFileChanged(FALSE, TRUE)
 
 {    // constructor
 
@@ -91,12 +90,17 @@ int i;
   m_bInScreendraw = false;
   m_iLastCommandCount = 0;
   m_iExecutionDepth = 0;
+  m_iConnectionAttemptNumber = 0;
+  m_iNameLookupGeneration = 0;
   m_iNextChatID = 0;
   m_tLastMessageTime = 0;
   m_tLastGroupMessageTime = 0;
   m_bOmitFromCommandHistory = false;
   m_bUTF_8 = false;
   m_bWorldClosing = false;
+  m_bWorldCloseQueued = false;
+  m_bWorldClosePending = false;
+  m_iActiveProgressOperations = 0;
   m_bInSendToScript = true;
 
   m_bInPlaySoundFilePlugin = false;
@@ -404,7 +408,8 @@ int i;
   m_ScriptEngine = NULL;
 
   m_bInScriptFileChanged = false;
-  m_pThread = NULL;
+  m_bScriptFileChangedPending = false;
+  m_iMonitorToken = 0;
   m_bSyntaxErrorOnly = false;
 
   m_dispidWorldOpen = DISPID_UNKNOWN;

--- a/mainfrm.cpp
+++ b/mainfrm.cpp
@@ -11,6 +11,8 @@
 
 #include "ActivityDoc.h"
 #include "ActivityView.h"
+#include "TextDocument.h"
+#include "dialogs\ProgDlg.h"
 #include "childfrm.h"
 
 #include "winplace.h"
@@ -206,6 +208,11 @@ BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWnd)
 	ON_WM_SYSCOMMAND()
 	//}}AFX_MSG_MAP
   ON_MESSAGE(MM_MCINOTIFY, OnMCINotify)
+  ON_MESSAGE(WM_USER_SCRIPT_FILE_CONTENTS_CHANGED, OnScriptFileContentsChanged)
+  ON_MESSAGE(WM_USER_FILE_CONTENTS_CHANGED, OnTextFileContentsChanged)
+  ON_MESSAGE(WM_USER_HOST_NAME_RESOLVED, OnHostNameResolved)
+  ON_MESSAGE(WM_USER_SHOW_TIPS, OnShowTips)
+  ON_MESSAGE(WM_USER_SSL_FALLBACK_PROMPT, OnSSLFallbackPrompt)
   ON_UPDATE_COMMAND_UI(ID_VIEW_TOOLBAR, CMDIFrameWnd::OnUpdateControlBarMenu)
   ON_UPDATE_COMMAND_UI(ID_VIEW_STATUS_BAR, CMDIFrameWnd::OnUpdateControlBarMenu)
   ON_UPDATE_COMMAND_UI(ID_VIEW_GAME_TOOLBAR, CMDIFrameWnd::OnUpdateControlBarMenu)
@@ -517,6 +524,14 @@ void CMainFrame::ReturnToolbarRect(CRect & rect)
 
 void CMainFrame::OnClose() 
 {
+  if (CProgressDlg::IsPumpingMessages () || App.HasActiveDocumentOperations ())
+    {
+    MSG msg = {};
+    msg.hwnd = GetSafeHwnd ();
+    msg.message = WM_CLOSE;
+    App.DeferMessageUntilIdle (msg);
+    return;
+    }
 
   CancelSound ();
   // close any outstanding MCI devices
@@ -939,119 +954,278 @@ void CMainFrame::FixUpTitleBar (void)
 
   } // end of FixUpTitleBar
 
-// should get a WM_USER when a host name lookup completes
-
-BOOL CMainFrame::PreTranslateMessage(MSG* pMsg) 
+LRESULT CMainFrame::OnScriptFileContentsChanged(WPARAM wParam, LPARAM)
 {
+  // A window handler receives this message even from nested modal loops.
+  // OnIdle performs the reload after the current message stack unwinds.
+  CFileChangeNotification * pNotification =
+    (CFileChangeNotification *) wParam;
+  if (!pNotification)
+    return 0;
+
+  __int64 iDocumentNumber = pNotification->m_iDocumentNumber;
+  __int64 iMonitorToken = pNotification->m_iMonitorToken;
+  delete pNotification;
+
+  POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition();
+
+  while (pos)
+    {
+    CMUSHclientDoc* pDoc =
+      (CMUSHclientDoc*) App.m_pWorldDocTemplate->GetNextDoc(pos);
+
+    if (pDoc->m_iUniqueDocumentNumber == iDocumentNumber &&
+        iMonitorToken != 0 && pDoc->m_iMonitorToken == iMonitorToken)
+      {
+      pDoc->m_bScriptFileChangedPending = true;
+      break;
+      }
+    }
+
+  return 0;
+}
+
+LRESULT CMainFrame::OnTextFileContentsChanged(WPARAM wParam, LPARAM)
+{
+  CFileChangeNotification * pNotification =
+    (CFileChangeNotification *) wParam;
+  if (!pNotification)
+    return 0;
+
+  __int64 iDocumentNumber = pNotification->m_iDocumentNumber;
+  __int64 iMonitorToken = pNotification->m_iMonitorToken;
+  delete pNotification;
+
+  POSITION pos = App.m_pNormalDocTemplate->GetFirstDocPosition();
+
+  while (pos)
+    {
+    CTextDocument* pDoc =
+      (CTextDocument*) App.m_pNormalDocTemplate->GetNextDoc(pos);
+
+    if (pDoc->m_iTextDocumentNumber == iDocumentNumber &&
+        iMonitorToken != 0 && pDoc->m_iMonitorToken == iMonitorToken)
+      {
+      pDoc->m_bFileChangedPending = true;
+      break;
+      }
+    }
+
+  return 0;
+}
+
+static void DeferMainFrameMessage(UINT message, WPARAM wParam, LPARAM lParam)
+{
+  MSG msg;
+  ZeroMemory (&msg, sizeof msg);
+  msg.hwnd = Frame.GetSafeHwnd ();
+  msg.message = message;
+  msg.wParam = wParam;
+  msg.lParam = lParam;
+  App.DeferMessageUntilIdle (msg);
+}
+
+LRESULT CMainFrame::OnHostNameResolved(WPARAM wParam, LPARAM lParam)
+{
+  if (wParam == 0)
+    return 0;
+
+  POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition();
+
+  while (pos)
+    {
+    CMUSHclientDoc * pDoc =
+      (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc(pos);
+
+    if (pDoc->m_hNameLookup == (HANDLE) wParam)
+      {
+      MSG msg;
+      ZeroMemory (&msg, sizeof msg);
+      msg.hwnd = Frame.GetSafeHwnd ();
+      msg.message = WM_USER_HOST_NAME_RESOLVED;
+      msg.lParam = lParam;
+      App.DeferMessageUntilIdle
+        (msg, pDoc->m_iUniqueDocumentNumber, (HANDLE) wParam,
+         pDoc->m_iNameLookupGeneration);
+      return 0;
+      }
+
+    for (POSITION chatpos = pDoc->m_ChatList.GetHeadPosition (); chatpos; )
+      {
+      CChatSocket * pSocket = pDoc->m_ChatList.GetNext (chatpos);
+      if (pSocket->m_hNameLookup == (HANDLE) wParam)
+        {
+        MSG msg;
+        ZeroMemory (&msg, sizeof msg);
+        msg.hwnd = Frame.GetSafeHwnd ();
+        msg.message = WM_USER_HOST_NAME_RESOLVED;
+        msg.lParam = lParam;
+        App.DeferMessageUntilIdle
+          (msg, pDoc->m_iUniqueDocumentNumber, (HANDLE) wParam,
+           pSocket->m_iNameLookupGeneration, pSocket->m_iChatID);
+        return 0;
+        }
+      }
+    }
+
+  return 0;
+}
+
+LRESULT CMainFrame::OnShowTips(WPARAM wParam, LPARAM lParam)
+{
+  DeferMainFrameMessage (WM_USER_SHOW_TIPS, wParam, lParam);
+  return 0;
+}
+
+LRESULT CMainFrame::OnSSLFallbackPrompt(WPARAM wParam, LPARAM lParam)
+{
+  CTLSFallbackNotification * pNotification =
+    (CTLSFallbackNotification *) wParam;
+  if (!pNotification)
+    return 0;
+
+  MSG msg;
+  ZeroMemory (&msg, sizeof msg);
+  msg.hwnd = Frame.GetSafeHwnd ();
+  msg.message = WM_USER_SSL_FALLBACK_PROMPT;
+  App.DeferMessageUntilIdle
+    (msg, pNotification->m_iDocumentNumber, NULL,
+     pNotification->m_iConnectionAttemptNumber);
+  delete pNotification;
+  return 0;
+}
+
+void CMainFrame::ProcessDeferredMessage(const CDeferredMessage & deferred)
+{
+  const MSG & msg = deferred.m_msg;
+
+  if (msg.message == WM_CLOSE)
+    {
+    if (msg.hwnd == GetSafeHwnd () && deferred.m_iDocumentNumber == 0)
+      SendMessage (WM_CLOSE);
+    else
+      {
+      // A queued close belongs to this document instance and its frame.
+      CDocTemplate * templates [] = { App.m_pWorldDocTemplate, App.m_pNormalDocTemplate };
+      for (int i = 0; i < 2; ++i)
+        for (POSITION pos = templates [i]->GetFirstDocPosition (); pos; )
+          {
+          CDocument * pDoc = templates [i]->GetNextDoc (pos);
+          const __int64 id = i == 0 ?
+            ((CMUSHclientDoc *) pDoc)->m_iUniqueDocumentNumber :
+            ((CTextDocument *) pDoc)->m_iTextDocumentNumber;
+          if (id != deferred.m_iDocumentNumber)
+            continue;
+          for (POSITION viewPos = pDoc->GetFirstViewPosition (); viewPos; )
+            if (pDoc->GetNextView (viewPos)->GetParentFrame ()->GetSafeHwnd () == msg.hwnd)
+              {
+              ::SendMessage (msg.hwnd, WM_CLOSE, 0, 0);
+              return;
+              }
+          }
+      }
+    return;
+    }
+
+  if (msg.message == WM_COMMAND)
+    {
+    // Keep the normal active-window, frame, and application command route.
+    SendMessage (WM_COMMAND, msg.wParam, msg.lParam);
+    return;
+    }
 
 // ******************* DOMAIN NAME resolution ********************
 
-  if (pMsg->message == WM_USER_HOST_NAME_RESOLVED && pMsg->wParam != 0)
+  if (msg.message == WM_USER_HOST_NAME_RESOLVED)
     {
 
-// find which world this message was for
-
- 	  POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition();
+    POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition();
     CMUSHclientDoc* pDoc = NULL;
 
-	  while (pos)
-	  {
-       pDoc = (CMUSHclientDoc*) App.m_pWorldDocTemplate->GetNextDoc(pos);
+    while (pos)
+      {
+      pDoc = (CMUSHclientDoc*) App.m_pWorldDocTemplate->GetNextDoc(pos);
 
-      if (pDoc->m_hNameLookup == (char *) pMsg->wParam)
-        break;
-
-      for (POSITION chatpos = pDoc->m_ChatList.GetHeadPosition (); chatpos; )
-        {
-        CChatSocket * pSocket = pDoc->m_ChatList.GetNext (chatpos);
-        if (pSocket->m_hNameLookup == (char *) pMsg->wParam)
-          {
-          pSocket->HostNameResolved (pMsg->wParam, pMsg->lParam);
-          return TRUE;    // message handled
-          }   // end of found a chat socket that was resolving a host name
-        }  // end of checking chat sockets
-
-      pDoc = NULL;
-
-     }  // end of checking documents
-
-    if (pDoc)
-      pDoc->HostNameResolved (pMsg->wParam, pMsg->lParam);
-
-    return TRUE;    // message was handled
-    }
-
-// ******************* SCRIPT FILE contents have changed ********************
-
-  if (pMsg->message == WM_USER_SCRIPT_FILE_CONTENTS_CHANGED && pMsg->wParam != 0)
-    {
-
-// find which world this message was for
-
- 	  POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition();
-    CMUSHclientDoc* pDoc = NULL;
-
-	  while (pos)
-	  {
-       pDoc = (CMUSHclientDoc*) App.m_pWorldDocTemplate->GetNextDoc(pos);
-
-      if (pDoc == (CMUSHclientDoc *) pMsg->wParam)
+      if (pDoc->m_iUniqueDocumentNumber == deferred.m_iDocumentNumber)
         break;
       else
         pDoc = NULL;
-
-     }
+      }
 
     if (pDoc)
-      pDoc->OnScriptFileChanged ();
+      {
+      HANDLE hLookup = deferred.m_hLookup;
+      if (deferred.m_iChatID != 0)
+        {
+        for (POSITION chatpos = pDoc->m_ChatList.GetHeadPosition (); chatpos; )
+          {
+          CChatSocket * pSocket = pDoc->m_ChatList.GetNext (chatpos);
+          if (pSocket->m_iChatID == deferred.m_iChatID &&
+              pSocket->m_hNameLookup == hLookup &&
+              pSocket->m_iNameLookupGeneration == deferred.m_iGeneration)
+            {
+            pSocket->HostNameResolved ((WPARAM) hLookup, msg.lParam);
+            break;
+            }
+          }
+        }
+      else if (pDoc->m_hNameLookup == hLookup &&
+               pDoc->m_iNameLookupGeneration == deferred.m_iGeneration)
+        pDoc->HostNameResolved ((WPARAM) hLookup, msg.lParam);
+      }
 
-    return TRUE;    // message was handled
+    return;
     }
 
+// ******************* Tips dialog after unregistered delay ********************
 
- // ******************* Tips dialog after unregistered delay ********************
-
- if (pMsg->message == WM_USER_SHOW_TIPS)
-   {
-   OnHelpTipoftheday ();
-   return TRUE;   // message was handled
-   }
+  if (msg.message == WM_USER_SHOW_TIPS)
+    {
+    OnHelpTipoftheday ();
+    return;
+    }
 
 // ******************* TLS fallback prompt (deferred from socket callback) ********************
 
- if (pMsg->message == WM_USER_SSL_FALLBACK_PROMPT && pMsg->wParam != 0)
-   {
-   // find which world this message was for (verify pointer is still valid)
-   POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition();
-   CMUSHclientDoc* pDoc = NULL;
+  if (msg.message == WM_USER_SSL_FALLBACK_PROMPT)
+    {
+    POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition();
+    CMUSHclientDoc* pDoc = NULL;
 
-   while (pos)
-     {
-     pDoc = (CMUSHclientDoc*) App.m_pWorldDocTemplate->GetNextDoc(pos);
-     if (pDoc == (CMUSHclientDoc *) pMsg->wParam)
-       break;
-     else
-       pDoc = NULL;
-     }
+    while (pos)
+      {
+      pDoc = (CMUSHclientDoc*) App.m_pWorldDocTemplate->GetNextDoc(pos);
+      if (pDoc->m_iUniqueDocumentNumber == deferred.m_iDocumentNumber)
+        break;
+      else
+        pDoc = NULL;
+      }
 
-   if (pDoc)
-     {
-     CString strPrompt;
-     strPrompt.Format ("TLS connection to \"%s\" failed.\n\n%s\n\n"
-                       "Connect without encryption?",
-                       (LPCTSTR) pDoc->m_mush_name,
-                       (LPCTSTR) pDoc->m_strSSLLastError);
+    if (pDoc &&
+        pDoc->m_iConnectionAttemptNumber == deferred.m_iGeneration)
+      {
+      CString strPrompt;
+      strPrompt.Format ("TLS connection to \"%s\" failed.\n\n%s\n\n"
+                        "Connect without encryption?",
+                        (LPCTSTR) pDoc->m_mush_name,
+                        (LPCTSTR) pDoc->m_strSSLLastError);
 
-     if (UMessageBox (strPrompt, MB_YESNO | MB_ICONQUESTION) == IDYES)
-       {
-       pDoc->m_bUseSSL = false;
-       pDoc->ConnectSocket ();
-       }
-     }
+      if (UMessageBox (strPrompt, MB_YESNO | MB_ICONQUESTION) == IDYES)
+        {
+        pDoc->m_bUseSSL = false;
+        pDoc->ConnectSocket ();
+        }
+      }
+    }
+}
 
-   return TRUE;   // message was handled
-   }
-
+BOOL CMainFrame::PreTranslateMessage(MSG* pMsg)
+{
+  if (pMsg->message == WM_USER_SHOW_TIPS)
+    {
+    App.DeferMessageUntilIdle (*pMsg);
+    return TRUE;
+    }
 
  return CMDIFrameWnd::PreTranslateMessage(pMsg);
 

--- a/mainfrm.h
+++ b/mainfrm.h
@@ -9,6 +9,7 @@
 #include "MDITabs.h"
 
 class CMUSHclientDoc;
+struct CDeferredMessage;
 
 #define TRAY_FIRST_MENU 11000
 #define TRAY_MENU_COUNT 50   // number of world menu items we support
@@ -94,6 +95,7 @@ public:
 
    void CheckTimerFallback (void);
    void ProcessTimers (void);
+   void ProcessDeferredMessage (const CDeferredMessage & deferred);
 
 // Overrides
 	// ClassWizard generated virtual function overrides
@@ -203,6 +205,11 @@ protected:
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	//}}AFX_MSG
   afx_msg LRESULT OnMCINotify(WPARAM, LPARAM);
+  afx_msg LRESULT OnScriptFileContentsChanged(WPARAM, LPARAM);
+  afx_msg LRESULT OnTextFileContentsChanged(WPARAM, LPARAM);
+  afx_msg LRESULT OnHostNameResolved(WPARAM, LPARAM);
+  afx_msg LRESULT OnShowTips(WPARAM, LPARAM);
+  afx_msg LRESULT OnSSLFallbackPrompt(WPARAM, LPARAM);
 	afx_msg void OnF1Test();
 	afx_msg void OnUpdateInfoBar(CCmdUI* pCmdUI);
   afx_msg void OnTrayMenu(UINT nID);    

--- a/scripting/lua_progressdlg.cpp
+++ b/scripting/lua_progressdlg.cpp
@@ -34,37 +34,42 @@ static CProgressDlg * Lprogress_getdialog (lua_State *L)
 
 static int Lprogress_setstatus(lua_State *L)
   {
-  CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
 
-  string word (luaL_checkstring (L, 2));
+  const char * text = luaL_checkstring (L, 2);
+  CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
+  string word (text);
+  CProgressDlgOperationGuard operationGuard (pProgressDlg);
   pProgressDlg->SetStatus (word.c_str ());
   return 0;
   } // end of Lprogress_setstatus
 
 static int Lprogress_setrange(lua_State *L)
   {
-  CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
 
   const int iStart = luaL_checkinteger (L, 2);
   const int iEnd = luaL_checkinteger (L, 3);
+  CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
+  CProgressDlgOperationGuard operationGuard (pProgressDlg);
   pProgressDlg->SetRange (iStart, iEnd);
   return 0;
   } // end of Lprogress_setrange
 
 static int Lprogress_setposition(lua_State *L)
   {
-  CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
 
   const int iPos = luaL_checkinteger (L, 2);
+  CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
+  CProgressDlgOperationGuard operationGuard (pProgressDlg);
   pProgressDlg->SetPos (iPos);
   return 0;
   } // end of Lprogress_setposition
 
 static int Lprogress_setstep(lua_State *L)
   {
-  CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
 
   const int iStep = luaL_checkinteger (L, 2);
+  CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
+  CProgressDlgOperationGuard operationGuard (pProgressDlg);
   pProgressDlg->SetStep (iStep);
   return 0;
   } // end of Lprogress_setstep
@@ -72,6 +77,7 @@ static int Lprogress_setstep(lua_State *L)
 static int Lprogress_stepit(lua_State *L)
   {
   CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
+  CProgressDlgOperationGuard operationGuard (pProgressDlg);
 
   pProgressDlg->StepIt ();
   return 0;
@@ -80,6 +86,7 @@ static int Lprogress_stepit(lua_State *L)
 static int Lprogress_checkcancel(lua_State *L)
   {
   CProgressDlg *pProgressDlg = Lprogress_getdialog (L);
+  CProgressDlgOperationGuard operationGuard (pProgressDlg);
   lua_pushboolean (L, pProgressDlg->CheckCancelButton ());
   return 1;
   } // end of Lprogress_checkcancel
@@ -88,9 +95,11 @@ static int Lprogress_checkcancel(lua_State *L)
 static int Lprogress_gc (lua_State *L) {
   CProgressDlg **ud = (CProgressDlg **) luaL_checkudata (L, 1, progress_dlg_handle);
   CProgressDlg *pProgressDlg = *ud;  // note, might be NULL already if they manually closed it
-  delete pProgressDlg;
-  // set userdata to NULL, so we don't try to use it now
+  // Close the handle before a callback can use it again. An active call
+  // retains the dialog until its progress update has returned.
   *ud = NULL;
+  if (pProgressDlg)
+    pProgressDlg->RequestDelete ();
   return 0;
   }  // end of Lprogress_gc
 
@@ -105,14 +114,32 @@ static int Lprogress_tostring (lua_State *L)
 
 static int Lprogress_new(lua_State *L)
 {
-  CProgressDlg *pProgressDlg = new CProgressDlg (); 
-  pProgressDlg->Create ();
-  pProgressDlg->SetWindowText (luaL_optstring (L, 1, "Progress ..."));
+  const char * title = luaL_optstring (L, 1, "Progress ...");
   CProgressDlg **ud = (CProgressDlg **)lua_newuserdata(L, sizeof (CProgressDlg *));
+  *ud = NULL;
   luaL_getmetatable(L, progress_dlg_handle);
   lua_setmetatable(L, -2);
-  *ud = pProgressDlg;    // store pointer to this dialog in the userdata
-  return 1;
+  char errorMessage [1000] = {};
+  try
+    {
+    const string windowTitle (title);
+    std::unique_ptr<CProgressDlg> pProgressDlg (new CProgressDlg);
+    if (!pProgressDlg->Create ())
+      AfxThrowResourceException ();
+    pProgressDlg->SetWindowText (windowTitle.c_str ());
+    *ud = pProgressDlg.release ();
+    return 1;
+    }
+  catch (CException * e)
+    {
+    if (!e->GetErrorMessage (errorMessage, sizeof errorMessage))
+      errorMessage [0] = '\0';
+    e->Delete ();
+    }
+
+  // Lua can longjmp here, after the C++ objects and exception are released.
+  return luaL_error (L, "%s", errorMessage [0] ?
+                    errorMessage : "Unable to create progress dialog");
   }  // end of Lprogress_new
 
 

--- a/scripting/lua_progressdlg.cpp
+++ b/scripting/lua_progressdlg.cpp
@@ -14,6 +14,7 @@
 
 
 #include "stdafx.h"
+#include <new>
 #include "..\MUSHclient.h"
 #include "..\mainfrm.h"
 
@@ -135,6 +136,11 @@ static int Lprogress_new(lua_State *L)
     if (!e->GetErrorMessage (errorMessage, sizeof errorMessage))
       errorMessage [0] = '\0';
     e->Delete ();
+    }
+  catch (const std::bad_alloc &)
+    {
+    // Use the fallback message after allocation failure and C++ cleanup.
+    errorMessage [0] = '\0';
     }
 
   // Lua can longjmp here, after the C++ objects and exception are released.

--- a/scripting/methods/methods_chat.cpp
+++ b/scripting/methods/methods_chat.cpp
@@ -136,11 +136,14 @@ CChatSocket * pSocket = new CChatSocket (this);
       }
 
     if (Frame.GetSafeHwnd ())   // forget it if we don't have a window yet
+      {
+      pSocket->m_iNameLookupGeneration++;
       pSocket->m_hNameLookup = WSAAsyncGetHostByName (Frame.GetSafeHwnd (),
                                                      WM_USER_HOST_NAME_RESOLVED,
                                                      Server,
                                                      pSocket->m_pGetHostStruct,
                                                      MAXGETHOSTSTRUCT);
+      }
 
    if (!pSocket->m_hNameLookup)
      {

--- a/scripting/methods/methods_commands.cpp
+++ b/scripting/methods/methods_commands.cpp
@@ -385,7 +385,12 @@ int nID = StringToCommandID (Command);
   if (nID == 0)
     return eNoSuchCommand;
 
-  Frame.PostMessage(WM_COMMAND, nID, 0);
+  MSG msg;
+  ZeroMemory (&msg, sizeof msg);
+  msg.hwnd = Frame.GetSafeHwnd ();
+  msg.message = WM_COMMAND;
+  msg.wParam = nID;
+  App.DeferMessageUntilIdle (msg);
 
 	return eOK;
 }   // end of  CMUSHclientDoc::DoCommand

--- a/scripting/methods/methods_notepad.cpp
+++ b/scripting/methods/methods_notepad.cpp
@@ -34,15 +34,18 @@
 
 bool CMUSHclientDoc::SwitchToNotepad (void)
   {
+  CMUSHclientDoc * pThisDocument = this;
+  __int64 iThisDocumentNumber = m_iUniqueDocumentNumber;
   int iCount = 0;
 
   for (POSITION docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
       docPos != NULL; )
     {
-    CTextDocument * pTextDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+    CTextDocument * pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
     // ignore unrelated worlds
-    if (pTextDoc->m_pRelatedWorld == this &&
+    if (!pTextDoc->m_bClosePending &&
+        pTextDoc->m_pRelatedWorld == this &&
        pTextDoc->m_iUniqueDocumentNumber == m_iUniqueDocumentNumber)
       iCount++;
     } // end of doing each document
@@ -52,9 +55,26 @@ bool CMUSHclientDoc::SwitchToNotepad (void)
     CChooseNotepadDlg dlg;
 
     dlg.m_pWorld = this;
+    dlg.m_iWorldDocumentNumber = iThisDocumentNumber;
 
     if (dlg.DoModal () != IDOK)
       return true;   // they gave up
+
+    bool bDocumentLive = false;
+    for (POSITION worldPos = App.m_pWorldDocTemplate->GetFirstDocPosition(); worldPos; )
+      {
+      CMUSHclientDoc * pWorld =
+        (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (worldPos);
+      if (pWorld == pThisDocument &&
+          pWorld->m_iUniqueDocumentNumber == iThisDocumentNumber)
+        {
+        bDocumentLive = true;
+        break;
+        }
+      }
+
+    if (!bDocumentLive)
+      return true;
 
     if (dlg.m_pTextDocument)  // they chose an existing one
       {
@@ -213,10 +233,11 @@ CTextDocument * pTextDoc = NULL;
   for (POSITION docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
       docPos != NULL; )
     {
-    pTextDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+    pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
     // ignore unrelated worlds
-    if (pTextDoc->m_pRelatedWorld == this &&
+    if (!pTextDoc->m_bClosePending &&
+        pTextDoc->m_pRelatedWorld == this &&
        pTextDoc->m_iUniqueDocumentNumber == m_iUniqueDocumentNumber &&
        pTextDoc->m_strTitle.CompareNoCase (strTitle) == 0)
       return pTextDoc;      // right title, world, document number
@@ -440,6 +461,9 @@ VARIANT CMUSHclientDoc::GetNotepadList(BOOL All)
     {
     pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(pos);
 
+    if (pTextDoc->m_bClosePending)
+      continue;
+
     if (All || (pTextDoc->m_pRelatedWorld == this &&
        pTextDoc->m_iUniqueDocumentNumber == m_iUniqueDocumentNumber))
       iCount++;
@@ -454,6 +478,9 @@ VARIANT CMUSHclientDoc::GetNotepadList(BOOL All)
     for (iCount = 0, pos = App.m_pNormalDocTemplate->GetFirstDocPosition(); pos != NULL; )
       {
       pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(pos);
+
+      if (pTextDoc->m_bClosePending)
+        continue;
 
       // ignore unrelated worlds
       if (!All)

--- a/scripting/scripting.cpp
+++ b/scripting/scripting.cpp
@@ -301,7 +301,8 @@ HRESULT LoadTypeInfoFromThisModule(REFIID riid, ITypeInfo **ppti) {
 void CMUSHclientDoc::DisableScripting (void)
   {
 
-  KillThread (m_pThread, m_eventScriptFileChanged);
+  StopMonitoringThread (m_iMonitorToken);
+  m_bScriptFileChangedPending = false;
 
 // release engine
 
@@ -310,80 +311,14 @@ void CMUSHclientDoc::DisableScripting (void)
 
   }   // end of CMUSHclientDoc::DisableScripting
 
-// ------------------- script file change monitoring thread -------------------------
-
-void CMUSHclientDoc::ThreadFunc(LPVOID pParam)
-{
-  CThreadData*	pData = (CThreadData*) pParam;
-	char * strDir = pData->m_strFilename;
-  DWORD pDoc = pData->m_pDoc;
-	char * p = strrchr (strDir, '\\');
-	if (!p)
-		p = strrchr (strDir, ':');   // why?
-  if (p)
-    *p = 0;
-	HWND	hWnd = pData->m_hWnd;
-	HANDLE	hEvent = pData->m_hEvent;
-
-	delete pData;
-
-  // Get a handle to a file change notification object.
-  HANDLE	hChange = ::FindFirstChangeNotification(strDir, TRUE, FILE_NOTIFY_CHANGE_LAST_WRITE);
-
-  delete [] strDir;
-
-  // Return now if ::FindFirstChangeNotification failed.
-  if (hChange == INVALID_HANDLE_VALUE)
-    return;
-
-	HANDLE	aHandles[2];
-	aHandles[0] = hChange;
-	aHandles[1] = hEvent;
-	BOOL	bContinue = TRUE;
-
-    // Sleep until a file change notification wakes this thread or
-    // m_eventScriptFileChanged becomes set indicating it's time for the thread to end.
-    while (bContinue)
-	{
-		switch ((::WaitForMultipleObjects(2, aHandles, FALSE, INFINITE)))
-		{
-		case 0:
-			// Respond to a change notification.
-			::PostMessage(hWnd, WM_USER_SCRIPT_FILE_CONTENTS_CHANGED, (WPARAM) pDoc, 0);
-			::FindNextChangeNotification(hChange);
-			break;
-
-		default:
-			// Kill this thread (m_event became signaled).
-            bContinue = FALSE;
-			break;
-		}
-	}
-
-	// Close the file change notification handle and return.
-	::FindCloseChangeNotification(hChange);
-	return;
-}
-
-// Create script source file monitoring thread
-//
+// Both document types use the same independently owned monitor.
 void CMUSHclientDoc::CreateMonitoringThread()
-{
-  KillThread (m_pThread, m_eventScriptFileChanged);
-
-	CThreadData*	pData = new CThreadData;
-	pData->m_strFilename = new char [m_strScriptFilename.GetLength () + 1];
-  strcpy (pData->m_strFilename, m_strScriptFilename);
-	pData->m_hWnd = Frame.GetSafeHwnd ();
-	pData->m_hEvent = m_eventScriptFileChanged;
-  pData->m_pDoc = (DWORD) this;
-	m_eventScriptFileChanged.ResetEvent();
-
-	m_pThread = (HANDLE) _beginthread (ThreadFunc, 0, pData);
-  SetThreadPriority (m_pThread, THREAD_PRIORITY_IDLE);
-
-	// Thread will delete data object
-}
+  {
+  StopMonitoringThread (m_iMonitorToken);
+  m_bScriptFileChangedPending = false;
+  m_iMonitorToken = ::CreateMonitoringThread
+    (m_strScriptFilename, m_iUniqueDocumentNumber, WM_USER_SCRIPT_FILE_CONTENTS_CHANGED);
+  }
 
 
 // ------------------- handle change to script file -------------------------
@@ -406,7 +341,7 @@ void CMUSHclientDoc::OnScriptFileChanged(const bool bForce)
   if (!bForce && m_nReloadOption == eReloadNever)
     return;
 
-  m_bInScriptFileChanged = true;
+  CBoolStateGuard scriptFileChangedGuard (m_bInScriptFileChanged, true);
 
 	// Check if this script file has changed
 	CFileStatus	status;
@@ -425,7 +360,6 @@ void CMUSHclientDoc::OnScriptFileChanged(const bool bForce)
       } // end of approving modification or wanting it anyway
     } // end of time changing
 
-	m_bInScriptFileChanged = false;
 }
 
 

--- a/scripting/scripting.cpp
+++ b/scripting/scripting.cpp
@@ -341,6 +341,7 @@ void CMUSHclientDoc::OnScriptFileChanged(const bool bForce)
   if (!bForce && m_nReloadOption == eReloadNever)
     return;
 
+  CWorldDocumentOperationGuard operationGuard (this);
   CBoolStateGuard scriptFileChangedGuard (m_bInScriptFileChanged, true);
 
 	// Check if this script file has changed

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -1390,28 +1390,66 @@ class COutputSearchSnapshot : public CObject
   struct Line
     {
     __int64 iCreationNumber;
-    CString strText;
+    const char * text;
+    int length;
     bool bHardReturn;
 
     explicit Line (const CLine * pLine) :
       iCreationNumber (pLine->nCreationNumber),
-      strText (pLine->text, pLine->len),
+      text (pLine->text), length (pLine->len),
       bHardReturn (pLine->hard_return) {}
 
     bool IsUnchanged (const CLine * pLine) const
       {
       return iCreationNumber == pLine->nCreationNumber &&
              bHardReturn == pLine->hard_return &&
-             strText.GetLength () == pLine->len &&
-             memcmp ((LPCTSTR) strText, pLine->text, pLine->len) == 0;
+             length == pLine->len &&
+             memcmp (text, pLine->text, pLine->len) == 0;
       }
     };
 
   vector<Line> m_Lines;
+  vector<std::unique_ptr<char []> > m_TextBlocks;
   CFindInfo m_FindInfo;
   const __int64 m_iOutputGeneration;
   long m_nFirstLine, m_nLastLine;
   bool m_bFound, m_bRestart;
+
+  // Copy complete lines into bounded blocks, as RecallText does. All source
+  // pointers stay within this non-yielding copy; readers use only owned text.
+  static void CopyText (vector<Line> & lines,
+                        vector<std::unique_ptr<char []> > & textBlocks)
+    {
+    size_t textBytesRemaining = 0;
+    for (const Line & line : lines)
+      textBytesRemaining += line.length;
+
+    char * nextText = NULL;
+    size_t blockBytesRemaining = 0;
+    for (Line & line : lines)
+      {
+      if (line.length == 0)
+        {
+        line.text = "";
+        continue;
+        }
+      const size_t length = line.length;
+      if (blockBytesRemaining < length)
+        {
+        const size_t blockSize = (std::max) (length,
+          (std::min) (textBytesRemaining, size_t (64 * 1024)));
+        std::unique_ptr<char []> block (new char [blockSize]);
+        textBlocks.push_back (std::move (block));
+        nextText = textBlocks.back ().get ();
+        blockBytesRemaining = blockSize;
+        }
+      memcpy (nextText, line.text, length);
+      line.text = nextText;
+      nextText += length;
+      blockBytesRemaining -= length;
+      textBytesRemaining -= length;
+      }
+    }
 
   COutputSearchSnapshot (CMUSHclientDoc * pDoc, bool bAgain) :
     m_iOutputGeneration (pDoc->m_iOutputGeneration),
@@ -1440,6 +1478,7 @@ class COutputSearchSnapshot : public CObject
     m_Lines.reserve (pDoc->m_LineList.GetCount ());
     for (POSITION pos = pDoc->m_LineList.GetHeadPosition (); pos; )
       m_Lines.push_back (Line (pDoc->m_LineList.GetNext (pos)));
+    CopyText (m_Lines, m_TextBlocks);
     }
 
   // Verify the complete logical line, including its wrap boundaries. No yield
@@ -1564,13 +1603,13 @@ void CSendView::DoFind (bool bAgain)
     {
     // Columns are byte offsets into the complete wrapped line.
     while (nStartLine < snapshot->m_nLastLine &&
-           iStartColumn >= snapshot->m_Lines [nStartLine].strText.GetLength ())
-      iStartColumn -= snapshot->m_Lines [nStartLine++].strText.GetLength ();
+           iStartColumn >= snapshot->m_Lines [nStartLine].length)
+      iStartColumn -= snapshot->m_Lines [nStartLine++].length;
     while (nEndLine < snapshot->m_nLastLine &&
-           iEndColumn > snapshot->m_Lines [nEndLine].strText.GetLength ())
-      iEndColumn -= snapshot->m_Lines [nEndLine++].strText.GetLength ();
-    bSelect = iStartColumn <= snapshot->m_Lines [nStartLine].strText.GetLength () &&
-              iEndColumn <= snapshot->m_Lines [nEndLine].strText.GetLength ();
+           iEndColumn > snapshot->m_Lines [nEndLine].length)
+      iEndColumn -= snapshot->m_Lines [nEndLine++].length;
+    bSelect = iStartColumn <= snapshot->m_Lines [nStartLine].length &&
+              iEndColumn <= snapshot->m_Lines [nEndLine].length;
     if (find.m_iStartColumn == find.m_iEndColumn)
       {
       nEndLine = nStartLine;
@@ -1588,9 +1627,13 @@ void CSendView::DoFind (bool bAgain)
   // Prepare the only allocating publication steps before changing ownership.
   list<pair<int, int> > matches (find.m_MatchesOnLine);
   vector<COutputSearchSnapshot::Line> matchedLines;
+  vector<std::unique_ptr<char []> > matchedTextBlocks;
   if (bSelect)
+    {
     matchedLines.assign (snapshot->m_Lines.begin () + snapshot->m_nFirstLine,
                          snapshot->m_Lines.begin () + snapshot->m_nLastLine + 1);
+    COutputSearchSnapshot::CopyText (matchedLines, matchedTextBlocks);
+    }
   if (!find.m_strFindStringList.IsEmpty () &&
       (saved.m_strFindStringList.IsEmpty () ||
        saved.m_strFindStringList.GetHead () != find.m_strFindStringList.GetHead ()))
@@ -1638,6 +1681,7 @@ void CSendView::DoFind (bool bAgain)
 
   // Only the matched logical line is needed to validate the next Find Again.
   snapshot->m_Lines.swap (matchedLines);
+  snapshot->m_TextBlocks.swap (matchedTextBlocks);
   snapshot->m_nFirstLine = bSelect ? 0 : -1;
   snapshot->m_nLastLine = static_cast<long> (snapshot->m_Lines.size ()) - 1;
   pTopView->Invalidate ();
@@ -1669,7 +1713,8 @@ bool CSendView::GetNextLine (const CObject * pObject,
   strLine.Empty ();
   while (true)
     {
-    strLine += snapshot->m_Lines [nLast].strText;
+    const COutputSearchSnapshot::Line & line = snapshot->m_Lines [nLast];
+    strLine.Append (line.text, line.length);
     if (snapshot->m_Lines [nLast].bHardReturn ||
         nLast + 1 == static_cast<long> (snapshot->m_Lines.size ()))
       break;

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -1382,182 +1382,302 @@ CString strCurrent;
   return false;
   }
 
-void CSendView::DoFind (bool bAgain)
+// Output find callbacks read only this invocation's source and find state.
+// Keep the last snapshot to validate pending Find Again matches before reuse.
+class COutputSearchSnapshot : public CObject
   {
+  public:
+  struct Line
+    {
+    __int64 iCreationNumber;
+    CString strText;
+    bool bHardReturn;
 
-CMUSHclientDoc* pDoc = GetDocument();
-ASSERT_VALID(pDoc);
+    explicit Line (const CLine * pLine) :
+      iCreationNumber (pLine->nCreationNumber),
+      strText (pLine->text, pLine->len),
+      bHardReturn (pLine->hard_return) {}
 
-pDoc->m_DisplayFindInfo.m_bAgain = bAgain;
+    bool IsUnchanged (const CLine * pLine) const
+      {
+      return iCreationNumber == pLine->nCreationNumber &&
+             bHardReturn == pLine->hard_return &&
+             strText.GetLength () == pLine->len &&
+             memcmp ((LPCTSTR) strText, pLine->text, pLine->len) == 0;
+      }
+    };
 
-// we can find multiple instances on the same line
-pDoc->m_DisplayFindInfo.m_bRepeatOnSameLine = true;
+  vector<Line> m_Lines;
+  CFindInfo m_FindInfo;
+  const __int64 m_iOutputGeneration;
+  long m_nFirstLine, m_nLastLine;
+  bool m_bFound, m_bRestart;
 
-bool found = FindRoutine (pDoc,                    // passed back to callback routines
-                          pDoc->m_DisplayFindInfo, // finding structure
-                          InitiateSearch,          // how to re-initiate a find
-                          GetNextLine);            // get the next line
-	
+  COutputSearchSnapshot (CMUSHclientDoc * pDoc, bool bAgain) :
+    m_iOutputGeneration (pDoc->m_iOutputGeneration),
+    m_nFirstLine (-1), m_nLastLine (-1), m_bFound (false), m_bRestart (false)
+    {
+    const CFindInfo & saved = pDoc->m_DisplayFindInfo;
+    m_FindInfo.m_strTitle = saved.m_strTitle;
+    m_FindInfo.m_bCanGoBackwards = saved.m_bCanGoBackwards;
+    m_FindInfo.m_bForwards = saved.m_bForwards;
+    m_FindInfo.m_bMatchCase = saved.m_bMatchCase;
+    m_FindInfo.m_bAgain = bAgain;
+    m_FindInfo.m_bRegexp = saved.m_bRegexp;
+    m_FindInfo.m_bUTF8 = saved.m_bUTF8;
+    m_FindInfo.m_bRepeatOnSameLine = true;
+    m_FindInfo.m_iStartColumn = saved.m_iStartColumn;
+    m_FindInfo.m_iEndColumn = saved.m_iEndColumn;
+    m_FindInfo.m_nCurrentLine = saved.m_nCurrentLine;
+    for (POSITION pos = saved.m_strFindStringList.GetHeadPosition (); pos; )
+      m_FindInfo.m_strFindStringList.AddTail (saved.m_strFindStringList.GetNext (pos));
 
-if (found)
-  {
+    // CFindInfo owns its regexp. Never share it or the progress dialog.
+    if (bAgain && saved.m_bRegexp && !saved.m_strFindStringList.IsEmpty ())
+      m_FindInfo.m_regexp = regcomp (saved.m_strFindStringList.GetHead (),
+        (saved.m_bMatchCase ? 0 : PCRE_CASELESS) | (saved.m_bUTF8 ? PCRE_UTF8 : 0));
 
-// because find now finds batches of lines, we must work out which line it is 
-// really on, so we highlight the correct columns
-
-  POSITION pos = pDoc->GetLinePosition (pDoc->m_DisplayFindInfo.m_nCurrentLine);
-  POSITION prevpos = NULL;
-  CLine * pLine;
-
-// select the found text, so it is highlighted
-
-  m_topview->m_selstart_line = pDoc->m_DisplayFindInfo.m_nCurrentLine;
-  m_topview->m_selend_line = pDoc->m_DisplayFindInfo.m_nCurrentLine;
-  m_topview->m_selstart_col =  pDoc->m_DisplayFindInfo.m_iStartColumn;
-  m_topview->m_selend_col = pDoc->m_DisplayFindInfo.m_iEndColumn;
-
-  pLine = pDoc->m_LineList.GetPrev (pos);
-  while (pos)
-   {
-   prevpos = pos;   // remember line which did have a hard return
-   pLine = pDoc->m_LineList.GetPrev (pos);
-   if (pLine->hard_return)
-     break;
-   m_topview->m_selstart_line--;
-   m_topview->m_selend_line--;
-   }
-
- // if prevpos is non-null it is now the position of the last line with a hard return
- // so, get the next one, that is the one which starts *our* sequence
-
-
-   if (prevpos)
-      pDoc->m_LineList.GetNext (prevpos);
-   else       // must be the only line in the buffer
-      prevpos = pDoc->m_LineList.GetHeadPosition ();
-
-  pos = prevpos;
-  while (pos)
-   {
-   pLine = pDoc->m_LineList.GetNext (pos);
-   if (m_topview->m_selstart_col < pLine->len)
-     break;
-   m_topview->m_selstart_col -= pLine->len;
-   m_topview->m_selend_col -= pLine->len;
-   m_topview->m_selstart_line ++;
-   m_topview->m_selend_line ++;
-   }
-
-  // if selendcol is > line length, selection must extend over multiple lines
-
-  if (m_topview->m_selend_col > pLine->len)
-    {       
-    while (pos)
-     {
-     // first subtract out the line we were on (and subsequent ones)
-     m_topview->m_selend_col -= pLine->len;
-     m_topview->m_selend_line ++;
-
-     // now check out the next ones
-     pLine = pDoc->m_LineList.GetNext (pos);
-     if (m_topview->m_selend_col < pLine->len)
-       break;
-     }
+    m_Lines.reserve (pDoc->m_LineList.GetCount ());
+    for (POSITION pos = pDoc->m_LineList.GetHeadPosition (); pos; )
+      m_Lines.push_back (Line (pDoc->m_LineList.GetNext (pos)));
     }
 
-  // make sure selection visible
+  // Verify the complete logical line, including its wrap boundaries. No yield
+  // occurs while these fresh live positions are in use.
+  bool MapMatch (CMUSHclientDoc * pDoc, long & nLiveFirst) const
+    {
+    if (m_nFirstLine < 0 || m_nLastLine < m_nFirstLine ||
+        m_nLastLine >= static_cast<long> (m_Lines.size ()))
+      return false;
 
-  m_topview->EnsureSelectionVisible ();
+    bool bPreviousHardReturn = true;
+    nLiveFirst = 0;
+    POSITION pos = pDoc->m_LineList.GetHeadPosition ();
+    while (pos)
+      {
+      CLine * pLine = pDoc->m_LineList.GetNext (pos);
+      if (pLine->nCreationNumber == m_Lines [m_nFirstLine].iCreationNumber)
+        {
+        if (!bPreviousHardReturn)
+          return false;
+        for (long i = m_nFirstLine; i <= m_nLastLine; ++i)
+          {
+          if (!m_Lines [i].IsUnchanged (pLine))
+            return false;
+          if (i < m_nLastLine)
+            {
+            if (!pos)
+              return false;
+            pLine = pDoc->m_LineList.GetNext (pos);
+            }
+          }
+        // An unterminated snapshot line must still be the last logical line.
+        return m_Lines [m_nLastLine].bHardReturn || !pos;
+        }
+      bPreviousHardReturn = pLine->hard_return;
+      ++nLiveFirst;
+      }
+    return false;
+    }
 
-  }   // end of being found
+  bool HasSameSearch (const CFindInfo & saved) const
+    {
+    return !m_FindInfo.m_strFindStringList.IsEmpty () &&
+           !saved.m_strFindStringList.IsEmpty () &&
+           m_FindInfo.m_strFindStringList.GetHead () == saved.m_strFindStringList.GetHead () &&
+           m_FindInfo.m_bRegexp == saved.m_bRegexp &&
+           m_FindInfo.m_bMatchCase == saved.m_bMatchCase &&
+           m_FindInfo.m_bUTF8 == saved.m_bUTF8 &&
+           m_FindInfo.m_MatchesOnLine == saved.m_MatchesOnLine;
+    }
+  };
 
-  // Invalidate new selection rectangle
-  m_topview->NotifySelectionChanged ();
-  m_topview->Invalidate ();
+void CSendView::DoFind (bool bAgain)
+  {
+  CMUSHclientDoc * pDoc = GetDocument ();
+  ASSERT_VALID (pDoc);
+  CWorldDocumentOperationGuard operationGuard (pDoc);
+  const __int64 iDocumentNumber = pDoc->m_iUniqueDocumentNumber;
+  const HWND hSendView = GetSafeHwnd ();
+  CMUSHView * pTopView = m_topview;
+  const HWND hTopView = pTopView->GetSafeHwnd ();
 
+  std::shared_ptr<COutputSearchSnapshot> previous = m_pOutputSearchSnapshot;
+  std::shared_ptr<COutputSearchSnapshot> snapshot (new COutputSearchSnapshot (pDoc, bAgain));
+  CFindInfo & find = snapshot->m_FindInfo;
+  CFindInfo & saved = pDoc->m_DisplayFindInfo;
+
+  // Cached columns belong to a particular logical line, not to its old index.
+  if (bAgain && previous && previous->m_bRestart)
+    find.m_nCurrentLine += find.m_bForwards ? -1 : 1;
+  else if (bAgain && previous && previous->m_bFound && previous->HasSameSearch (saved))
+    {
+    long nLiveFirst;
+    if (previous->MapMatch (pDoc, nLiveFirst))
+      {
+      snapshot->m_nFirstLine = nLiveFirst;
+      snapshot->m_nLastLine = nLiveFirst + previous->m_nLastLine - previous->m_nFirstLine;
+      find.m_nCurrentLine = find.m_bForwards ? snapshot->m_nLastLine : snapshot->m_nFirstLine;
+      find.m_MatchesOnLine = saved.m_MatchesOnLine;
+      }
+    else
+      {
+      // Output changed since the last match. Search the current live line again.
+      find.m_nCurrentLine += find.m_bForwards ? -1 : 1;
+      }
+    }
+  else if (bAgain && !saved.m_MatchesOnLine.empty ())
+    find.m_nCurrentLine += find.m_bForwards ? -1 : 1;
+
+  m_pOutputSearchSnapshot = snapshot;
+  bool bCancelled = false;
+  const bool bFound = FindRoutine (snapshot.get (), find,
+                                   InitiateSearch, GetNextLine, &bCancelled);
+
+  // FindRoutine can dispatch messages from its dialogs, progress and status UI.
+  // Do not touch a dead owner, or publish over a newer nested invocation.
+  const auto IsCurrent = [&] () -> bool
+    {
+    return IsWorldDocumentLive (pDoc, iDocumentNumber) &&
+           !pDoc->m_bWorldClosePending &&
+           ::IsWindow (hSendView) && CWnd::FromHandlePermanent (hSendView) == this &&
+           ::IsWindow (hTopView) && CWnd::FromHandlePermanent (hTopView) == pTopView &&
+           m_topview == pTopView && m_pOutputSearchSnapshot == snapshot;
+    };
+  if (!IsCurrent ())
+    return;
+  if (bCancelled)
+    {
+    m_pOutputSearchSnapshot = previous;
+    return;
+    }
+  previous.reset ();
+
+  long nLiveFirst = 0;
+  const bool bMapped = bFound && snapshot->MapMatch (pDoc, nLiveFirst);
+  long nStartLine = snapshot->m_nFirstLine;
+  long nEndLine = nStartLine;
+  int iStartColumn = find.m_iStartColumn;
+  int iEndColumn = find.m_iEndColumn;
+  bool bSelect = bMapped && iStartColumn >= 0 && iEndColumn >= iStartColumn;
+  if (bSelect)
+    {
+    // Columns are byte offsets into the complete wrapped line.
+    while (nStartLine < snapshot->m_nLastLine &&
+           iStartColumn >= snapshot->m_Lines [nStartLine].strText.GetLength ())
+      iStartColumn -= snapshot->m_Lines [nStartLine++].strText.GetLength ();
+    while (nEndLine < snapshot->m_nLastLine &&
+           iEndColumn > snapshot->m_Lines [nEndLine].strText.GetLength ())
+      iEndColumn -= snapshot->m_Lines [nEndLine++].strText.GetLength ();
+    bSelect = iStartColumn <= snapshot->m_Lines [nStartLine].strText.GetLength () &&
+              iEndColumn <= snapshot->m_Lines [nEndLine].strText.GetLength ();
+    if (find.m_iStartColumn == find.m_iEndColumn)
+      {
+      nEndLine = nStartLine;
+      iEndColumn = iStartColumn;
+      }
+    }
+
+  if (bFound && !bSelect)
+    {
+    find.m_MatchesOnLine.clear ();
+    find.m_iStartColumn = -1;
+    find.m_bAgain = false;
+    }
+
+  // Prepare the only allocating publication steps before changing ownership.
+  list<pair<int, int> > matches (find.m_MatchesOnLine);
+  vector<COutputSearchSnapshot::Line> matchedLines;
+  if (bSelect)
+    matchedLines.assign (snapshot->m_Lines.begin () + snapshot->m_nFirstLine,
+                         snapshot->m_Lines.begin () + snapshot->m_nLastLine + 1);
+  if (!find.m_strFindStringList.IsEmpty () &&
+      (saved.m_strFindStringList.IsEmpty () ||
+       saved.m_strFindStringList.GetHead () != find.m_strFindStringList.GetHead ()))
+    saved.m_strFindStringList.AddHead (find.m_strFindStringList.GetHead ());
+  saved.m_bForwards = find.m_bForwards;
+  saved.m_bMatchCase = find.m_bMatchCase;
+  saved.m_bRegexp = find.m_bRegexp;
+  saved.m_bAgain = find.m_bAgain;
+  saved.m_bRepeatOnSameLine = true;
+  saved.m_iStartColumn = find.m_iStartColumn;
+  saved.m_iEndColumn = find.m_iEndColumn;
+  saved.m_nTotalLines = pDoc->m_LineList.GetCount ();
+  saved.m_pFindPosition = NULL;
+  saved.m_MatchesOnLine.swap (matches);
+  delete saved.m_regexp;
+  saved.m_regexp = find.m_regexp;
+  find.m_regexp = NULL;
+  if (bSelect)
+    saved.m_nCurrentLine = nLiveFirst + (find.m_bForwards ?
+      snapshot->m_nLastLine - snapshot->m_nFirstLine : 0);
+  else if (!bFound && pDoc->m_iOutputGeneration == snapshot->m_iOutputGeneration)
+    {
+    saved.m_nCurrentLine = find.m_nCurrentLine;
+    // Find Again advances once before reading. Leave an exhausted cursor on
+    // the last searched line so newly appended output is not skipped.
+    if (find.m_nCurrentLine == static_cast<long> (snapshot->m_Lines.size ()))
+      --saved.m_nCurrentLine;
+    else if (find.m_nCurrentLine < 0)
+      ++saved.m_nCurrentLine;
+    }
+  snapshot->m_bFound = bSelect;
+  snapshot->m_bRestart = (bFound && !bSelect) ||
+    (!bFound && pDoc->m_iOutputGeneration != snapshot->m_iOutputGeneration);
+
+  if (bSelect)
+    {
+    pTopView->m_selstart_line = nLiveFirst + nStartLine - snapshot->m_nFirstLine;
+    pTopView->m_selend_line = nLiveFirst + nEndLine - snapshot->m_nFirstLine;
+    pTopView->m_selstart_col = iStartColumn;
+    pTopView->m_selend_col = iEndColumn;
+    pTopView->EnsureSelectionVisible ();
+    if (!IsCurrent ())
+      return;
+    }
+
+  // Only the matched logical line is needed to validate the next Find Again.
+  snapshot->m_Lines.swap (matchedLines);
+  snapshot->m_nFirstLine = bSelect ? 0 : -1;
+  snapshot->m_nLastLine = static_cast<long> (snapshot->m_Lines.size ()) - 1;
+  pTopView->Invalidate ();
+  // This notification can call plugins. Do not access either view after it.
+  pTopView->NotifySelectionChanged ();
   } // end of CSendView::DoFind
 
-
 void CSendView::InitiateSearch (const CObject * pObject,
-                                CFindInfo & FindInfo)
+                               CFindInfo & FindInfo)
   {
-CMUSHclientDoc* pDoc = (CMUSHclientDoc*) pObject;
-
-  FindInfo.m_nTotalLines = pDoc->m_LineList.GetCount ();
-
-  if (FindInfo.m_bAgain)
-    FindInfo.m_pFindPosition = pDoc->GetLinePosition (FindInfo.m_nCurrentLine);
-  else
-    if (FindInfo.m_bForwards)
-      FindInfo.m_pFindPosition = pDoc->m_LineList.GetHeadPosition ();
-    else
-      FindInfo.m_pFindPosition = pDoc->m_LineList.GetTailPosition ();
-
+  const COutputSearchSnapshot * snapshot = (const COutputSearchSnapshot *) pObject;
+  FindInfo.m_nTotalLines = static_cast<long> (snapshot->m_Lines.size ());
+  FindInfo.m_pFindPosition = NULL;
   } // end of CSendView::InitiateSearch
 
 bool CSendView::GetNextLine (const CObject * pObject,
-                             CFindInfo & FindInfo, 
-                             CString & strLine)
+                            CFindInfo & FindInfo,
+                            CString & strLine)
   {
-CMUSHclientDoc* pDoc = (CMUSHclientDoc*) pObject;
+  COutputSearchSnapshot * snapshot = (COutputSearchSnapshot *) pObject;
+  long nFirst = FindInfo.m_nCurrentLine;
+  if (nFirst < 0 || nFirst >= static_cast<long> (snapshot->m_Lines.size ()))
+    return true;
 
-CLine * pLine;
-POSITION prevpos = NULL;
-
-  if (FindInfo.m_pFindPosition == NULL)
-    return true;          // no more lines
-
-  // if doing backwards, we must go back a whole *line* (ie. the one after a hard return)
-  if (!FindInfo.m_bForwards)
-    {
-    pLine = pDoc->m_LineList.GetPrev (FindInfo.m_pFindPosition);
-    while (FindInfo.m_pFindPosition)
-     {
-     prevpos = FindInfo.m_pFindPosition;   // remember line which did have a hard return
-     pLine = pDoc->m_LineList.GetPrev (FindInfo.m_pFindPosition);
-     if (pLine->hard_return)
-       break;
-     }
-
-   // if prevpos is non-null it is now the position of the last line with a hard return
-   // so, get the next one, that is the one which starts *our* sequence
-
-     if (prevpos)
-        pDoc->m_LineList.GetNext (prevpos);
-     else       // must be the only line in the buffer
-        prevpos = pDoc->m_LineList.GetHeadPosition ();
-
-// sequence is now at the start of the batch of lines
-
-     FindInfo.m_pFindPosition = prevpos;
-    }
-
+  // Search one logical line in either direction, including all wrapped pieces.
+  while (nFirst > 0 && !snapshot->m_Lines [nFirst - 1].bHardReturn)
+    --nFirst;
+  long nLast = nFirst;
   strLine.Empty ();
-
-  // get lines until a hard return
-
-  while (FindInfo.m_pFindPosition)
+  while (true)
     {
-    pLine = pDoc->m_LineList.GetNext (FindInfo.m_pFindPosition);   // get next line
-    strLine += CString (pLine->text, pLine->len);
-    if (FindInfo.m_bForwards)
-      FindInfo.m_nCurrentLine++;
-    else
-      FindInfo.m_nCurrentLine--;
-    if (pLine->hard_return)
+    strLine += snapshot->m_Lines [nLast].strText;
+    if (snapshot->m_Lines [nLast].bHardReturn ||
+        nLast + 1 == static_cast<long> (snapshot->m_Lines.size ()))
       break;
+    ++nLast;
     }
-
-  // adjust current line (main find loop adds/subtracts one anyway)
-  if (FindInfo.m_bForwards)
-    FindInfo.m_nCurrentLine--;
-  else
-    {
-    FindInfo.m_pFindPosition = prevpos;
-    pDoc->m_LineList.GetPrev (FindInfo.m_pFindPosition);  // go back to line prior to this batch
-    FindInfo.m_nCurrentLine++;
-    }
-
+  snapshot->m_nFirstLine = nFirst;
+  snapshot->m_nLastLine = nLast;
+  FindInfo.m_nCurrentLine = FindInfo.m_bForwards ? nLast : nFirst;
   return false;
   } // end of CSendView::GetNextLine
 

--- a/sendvw.h
+++ b/sendvw.h
@@ -18,6 +18,8 @@ enum  {
     eAtBottom,
   };
 
+class COutputSearchSnapshot;
+
 class CSendView : public CEditView
 {
 protected:
@@ -109,6 +111,9 @@ protected:
 #endif
 
 // for finding
+
+  // Also identifies the latest invocation when a progress callback starts a find.
+  std::shared_ptr<COutputSearchSnapshot> m_pOutputSearchSnapshot;
 
   static void InitiateSearch (const CObject * pObject,
                               CFindInfo & FindInfo);

--- a/stdafx.h
+++ b/stdafx.h
@@ -512,19 +512,23 @@ CString RemoveFinalSlash (CString str);
 /////////////////////////////////////////////////////////////////////////////
 //  Stuff for the file-change monitoring code
 
-struct CThreadData
-{
-	char *	m_strFilename;    // which file to monitor
-	HWND	m_hWnd;             // window to post event to
-  DWORD m_pDoc;             // which document it belongs to
-	HANDLE	m_hEvent;         // event which will become signalled
-};
+struct CFileChangeNotification
+  {
+  __int64 m_iDocumentNumber;
+  __int64 m_iMonitorToken;
+  };
 
-void ThreadFunc(LPVOID pParam);
-void KillThread (HANDLE & pThread, CEvent & eventFileChanged);
-HANDLE CreateMonitoringThread(const char * sName, DWORD pDoc, CEvent & eventFileChanged);
+struct CTLSFallbackNotification
+  {
+  __int64 m_iDocumentNumber;
+  unsigned long m_iConnectionAttemptNumber;
+  };
 
-#define WM_USER_FILE_CONTENTS_CHANGED (WM_USER + 1001)
+void StopMonitoringThread (__int64 & token);
+void CollectMonitoringThreads ();
+__int64 CreateMonitoringThread (const char * name, __int64 document, UINT message);
+
+#define WM_USER_FILE_CONTENTS_CHANGED (WM_USER + 1002)
 
 #define REGISTRATION_TIMER_ID 0x1001
 #define SPLASH_SCREEN_TIMER_ID 0x1002

--- a/tests/check_cpp_blocks.py
+++ b/tests/check_cpp_blocks.py
@@ -1,0 +1,64 @@
+"""Check C++ block extraction and explicit failures for malformed input."""
+import unittest
+
+from cpp_blocks import block
+
+
+class BlockTests(unittest.TestCase):
+    def test_ignores_comments_and_literals(self):
+        bodies = [
+            'if (true) { return; }',
+            '// }\nreturn;',
+            '/* } { } */ return;',
+            'const char *s = "}";',
+            "char c = '}';",
+            r'const char *s = "\"}";',
+            r"char c = '\''; // }",
+            r'const char *s = "\\}";',
+            'const char *s = "\\\n}";',
+            'const char *s = "\\\r\n}";',
+            '// continued \\\n} still a comment\nreturn;',
+            '// continued \\\r\n} still a comment\r\nreturn;',
+            'const char *s = R"(} " /* { */)";',
+            'const char *s = u8R"tag(} " )wrong" // {\n)tag";',
+            'const char *s = LR"abcdefghijklmnop(})abcdefghijklmnop";',
+        ]
+        for body in bodies:
+            with self.subTest(body=body):
+                definition = 'void sample() {\n' + body + '\n}'
+                source = '// preceding {\n' + definition + '\nvoid later() {}'
+                self.assertEqual(block(source, 'void sample()'), definition)
+
+    def test_ignores_braces_before_body(self):
+        definition = 'class Sample /* } */ { int value; }'
+        self.assertEqual(block(definition + '; class Later {};', 'class Sample'), definition)
+
+    def test_preserves_crlf(self):
+        definition = 'void sample() {\r\n// }\r\nreturn;\r\n}'
+        self.assertEqual(block(definition + '\r\nvoid later() {}', 'void sample()'), definition)
+
+    def test_reports_malformed_input(self):
+        cases = [
+            ('void different() {}', 'Missing source signature'),
+            ('void sample()', 'Missing opening brace'),
+            ('void sample() {', 'Unclosed source block'),
+            ('void sample() }', 'Closing brace before source block'),
+            ('void sample() { /* }', 'Unclosed block comment'),
+            ('void sample() { "}', 'Unclosed quoted literal'),
+            ("void sample() { '}", 'Unclosed quoted literal'),
+            ('void sample() { "}\n}', 'Unclosed quoted literal'),
+            ('void sample() { "\\', 'Unclosed quoted literal'),
+            ('void sample() { R"tag(})wrong"; }', 'Unclosed raw string'),
+            ('void sample() { R"tag', 'Invalid raw string delimiter'),
+            ('void sample() { R"bad tag(})bad tag"; }', 'Invalid raw string delimiter'),
+            ('void sample() { R"abcdefghijklmnopq(})abcdefghijklmnopq"; }',
+             'Invalid raw string delimiter'),
+        ]
+        for source, message in cases:
+            with self.subTest(source=source):
+                with self.assertRaisesRegex(ValueError, message + ': void sample'):
+                    block(source, 'void sample()')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/check_hostname_lookup.py
+++ b/tests/check_hostname_lookup.py
@@ -1,0 +1,75 @@
+"""Test extracted DNS source with a stateful asynchronous resolver fixture.
+
+Requires Python 3 and clang++. Runs with AddressSanitizer and UndefinedBehaviorSanitizer.
+The fixture substitutes MFC, sockets, and Winsock. It checks pending buffer writes,
+cancellation errors, deferred completion routing, and the world-open script call path.
+The generation test covers an already-deferred completion with a saved generation.
+It does not cover raw queued Win32 messages whose handles are reused before capture,
+or a native Windows/Wine resolver.
+"""
+import argparse
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def block(text, signature):
+    start = text.index(signature)
+    brace = text.index('{', start)
+    depth = 0
+    for end in range(brace, len(text)):
+        depth += (text[end] == '{') - (text[end] == '}')
+        if depth == 0:
+            return text[start:end + 1]
+    raise ValueError(f'Unclosed source block: {signature}')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--revision', help='Read source from a Git revision.')
+    parser.add_argument('--output-dir', type=Path)
+    args = parser.parse_args()
+    out = args.output_dir or Path(tempfile.mkdtemp(prefix='mushclient-hostname-'))
+    out.mkdir(parents=True, exist_ok=True)
+
+    def read(path):
+        if args.revision:
+            return subprocess.check_output(
+                ['git', '-C', str(ROOT), 'show', f'{args.revision}:{path}'], text=True)
+        return (ROOT / path).read_text()
+
+    doc = read('doc.cpp')
+    methods = read('scripting/methods/methods_utilities.cpp')
+    frame = read('mainfrm.cpp')
+    functions = '\n\n'.join(block(doc, sig) for sig in [
+        'BOOL CMUSHclientDoc::OpenSession (',
+        'BOOL CMUSHclientDoc::ConnectSocket(',
+        'bool CMUSHclientDoc::LookupHostName (',
+        'void CMUSHclientDoc::HostNameResolved (',
+        'void CMUSHclientDoc::OnConnectionConnect()',
+    ])
+    functions += '\n\n' + block(methods, 'long CMUSHclientDoc::Connect()')
+    # Use the actual deferred-dispatch gate. The fixture supplies the document
+    # already selected by its identity, as the surrounding frame code does.
+    start = frame.index('else if (pDoc->m_hNameLookup == hLookup &&')
+    end = frame.index(';', start) + 1
+    dispatch = frame[start:end].removeprefix('else ')
+    template = Path(__file__).with_name('hostname_lookup.cpp.in').read_text()
+    assert template.count('@FUNCTIONS@') == template.count('@DISPATCH@') == 1
+    cpp = out / 'hostname_lookup.cpp'
+    cpp.write_text(template.replace('@FUNCTIONS@', functions).replace('@DISPATCH@', dispatch))
+    exe = out / 'hostname_lookup'
+    subprocess.run(['clang++', '-std=c++17', '-O1', '-g',
+                    '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                    str(cpp), '-o', str(exe)], check=True)
+    result = subprocess.run([str(exe)], capture_output=True, text=True)
+    (out / 'result.log').write_text(result.stdout + result.stderr)
+    print(result.stdout + result.stderr, end='')
+    print(f'Artifacts: {out}')
+    result.check_returncode()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_hostname_lookup.py
+++ b/tests/check_hostname_lookup.py
@@ -55,7 +55,8 @@ def main():
     for mode, flags in [('hostname_lookup', []), ('hostname_lookup_ndebug', ['-DNDEBUG'])]:
         exe = out / mode
         subprocess.run(['clang++', '-std=c++17', '-O1', '-g',
-                        '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                        '-fsanitize=address,undefined', '-fno-sanitize-recover=all',
+                        '-fno-omit-frame-pointer',
                         *flags, str(cpp), '-o', str(exe)], check=True)
         result = subprocess.run([str(exe)], capture_output=True, text=True)
         log = 'result.log' if not flags else 'result-ndebug.log'

--- a/tests/check_hostname_lookup.py
+++ b/tests/check_hostname_lookup.py
@@ -12,18 +12,9 @@ from pathlib import Path
 import subprocess
 import tempfile
 
+from cpp_blocks import block
+
 ROOT = Path(__file__).resolve().parents[1]
-
-
-def block(text, signature):
-    start = text.index(signature)
-    brace = text.index('{', start)
-    depth = 0
-    for end in range(brace, len(text)):
-        depth += (text[end] == '{') - (text[end] == '}')
-        if depth == 0:
-            return text[start:end + 1]
-    raise ValueError(f'Unclosed source block: {signature}')
 
 
 def main():
@@ -60,15 +51,17 @@ def main():
     assert template.count('@FUNCTIONS@') == template.count('@DISPATCH@') == 1
     cpp = out / 'hostname_lookup.cpp'
     cpp.write_text(template.replace('@FUNCTIONS@', functions).replace('@DISPATCH@', dispatch))
-    exe = out / 'hostname_lookup'
-    subprocess.run(['clang++', '-std=c++17', '-O1', '-g',
-                    '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
-                    str(cpp), '-o', str(exe)], check=True)
-    result = subprocess.run([str(exe)], capture_output=True, text=True)
-    (out / 'result.log').write_text(result.stdout + result.stderr)
-    print(result.stdout + result.stderr, end='')
-    print(f'Artifacts: {out}')
-    result.check_returncode()
+    print(f'Artifacts: {out}', flush=True)
+    for mode, flags in [('hostname_lookup', []), ('hostname_lookup_ndebug', ['-DNDEBUG'])]:
+        exe = out / mode
+        subprocess.run(['clang++', '-std=c++17', '-O1', '-g',
+                        '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                        *flags, str(cpp), '-o', str(exe)], check=True)
+        result = subprocess.run([str(exe)], capture_output=True, text=True)
+        log = 'result.log' if not flags else 'result-ndebug.log'
+        (out / log).write_text(result.stdout + result.stderr)
+        print(result.stdout + result.stderr, end='')
+        result.check_returncode()
 
 
 if __name__ == '__main__':

--- a/tests/check_lua_progress_errors.py
+++ b/tests/check_lua_progress_errors.py
@@ -2,7 +2,7 @@
 """Check the exact Lprogress_new body with the official Lua 5.1.4 C runtime.
 
 Example: python3 tests/check_lua_progress_errors.py --lua-source /tmp/lua-5.1.4/src
-Add --revision a72eea4 to test the faulty baseline (must return nonzero).
+Add --revision ce793ca to test the allocation-failure baseline (must return nonzero).
 CC and CXX select GCC-compatible C and C++17 compilers. No download is made.
 Lua sources are copied and compiled as C in the output directory. Foreign C++
 exceptions can unwind through these C frames; Lua errors still use longjmp.
@@ -10,7 +10,11 @@ Checks run with NDEBUG, then with ASan/UBSan if the compilers support them.
 
 Limits: MFC dialogs and exceptions are substitutes. The fixture supplies its own
 userdata finalizer. This does not test native MFC, Windows UI, production close
-handling, or Lua allocation failure. C++ allocation counters check string cleanup
+handling, or Lua allocation failure. C++ allocation failures are injected once
+into the real string allocation and the substitute dialog allocation. Later
+bad_alloc failures check partial construction and owned-dialog cleanup. Two
+unrelated exception types must propagate to a fixture wrapper before Lua's C
+frames; only that wrapper converts them to errors. C++ counters check cleanup
 even on platforms without LeakSanitizer. Lua and std::string are not substitutes.
 """
 import argparse
@@ -28,7 +32,10 @@ import tempfile
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE = 'scripting/lua_progressdlg.cpp'
 CASES = ['success', 'create_false', 'create_exception', 'title_exception',
-         'constructor_exception', 'message_failure', 'message_empty']
+         'constructor_exception', 'message_failure', 'message_empty',
+         'string_allocation', 'dialog_allocation', 'constructor_bad_alloc',
+         'create_bad_alloc', 'title_bad_alloc', 'unknown_std_exception',
+         'unknown_exception']
 LUA_UNITS = '''lapi lcode ldebug ldo ldump lfunc lgc llex lmem lobject lopcodes
               lparser lstate lstring ltable ltm lundump lvm lzio lauxlib lbaselib
               ldblib liolib lmathlib loslib ltablib lstrlib loadlib linit'''.split()

--- a/tests/check_lua_progress_errors.py
+++ b/tests/check_lua_progress_errors.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Check the exact Lprogress_new body with the official Lua 5.1.4 C runtime.
+
+Example: python3 tests/check_lua_progress_errors.py --lua-source /tmp/lua-5.1.4/src
+Add --revision a72eea4 to test the faulty baseline (must return nonzero).
+CC and CXX select GCC-compatible C and C++17 compilers. No download is made.
+Lua sources are copied and compiled as C in the output directory. Foreign C++
+exceptions can unwind through these C frames; Lua errors still use longjmp.
+Checks run with NDEBUG, then with ASan/UBSan if the compilers support them.
+
+Limits: MFC dialogs and exceptions are substitutes. The fixture supplies its own
+userdata finalizer. This does not test native MFC, Windows UI, production close
+handling, or Lua allocation failure. C++ allocation counters check string cleanup
+even on platforms without LeakSanitizer. Lua and std::string are not substitutes.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = 'scripting/lua_progressdlg.cpp'
+CASES = ['success', 'create_false', 'create_exception', 'title_exception',
+         'constructor_exception', 'message_failure', 'message_empty']
+LUA_UNITS = '''lapi lcode ldebug ldo ldump lfunc lgc llex lmem lobject lopcodes
+              lparser lstate lstring ltable ltm lundump lvm lzio lauxlib lbaselib
+              ldblib liolib lmathlib loslib ltablib lstrlib loadlib linit'''.split()
+SANITIZERS = ['-fsanitize=address,undefined', '-fno-sanitize-recover=all']
+
+
+def extract(source):
+    signature = 'static int Lprogress_new(lua_State *L)'
+    if source.count(signature) != 1:
+        raise ValueError('Expected exactly one Lprogress_new definition')
+    start = source.index(signature)
+    depth = 0
+    # Ignore braces in comments, ordinary strings, and character literals.
+    tokens = r'//[^\n]*|/\*[\s\S]*?\*/|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|[{}]'
+    for match in re.finditer(tokens, source[start:]):
+        if match.group() == '{':
+            depth += 1
+        elif match.group() == '}':
+            depth -= 1
+            if depth == 0:
+                return source[start:start + match.end()]
+    raise ValueError('Unclosed Lprogress_new definition')
+
+
+def compiler(variable, defaults):
+    command = shlex.split(os.environ[variable]) if variable in os.environ else []
+    if variable in os.environ and not command:
+        raise ValueError(f'{variable} must name a compiler')
+    if not command:
+        command = [next((name for name in defaults if shutil.which(name)), defaults[0])]
+    executable = shutil.which(command[0])
+    if executable is None:
+        raise FileNotFoundError(f'Compiler not found: {command[0]}')
+    return [executable, *command[1:]]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--lua-source', required=True, type=Path,
+                        help='Official Lua 5.1.4 source root or its src directory')
+    parser.add_argument('--revision', help='Read production code from this Git revision')
+    parser.add_argument('--output-dir', type=Path, help='Default: a new local temporary directory')
+    parser.add_argument('--sanitizers', choices=['auto', 'required', 'off'], default='auto')
+    args = parser.parse_args()
+    out = (args.output_dir or Path(tempfile.mkdtemp(prefix='mushclient-lua-progress-'))).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    print(f'Artifacts: {out}', flush=True)
+    report_path = out / 'lua_progress_errors.json'
+    report_path.unlink(missing_ok=True)
+    revision = None
+    if args.revision:
+        revision = subprocess.check_output(
+            ['git', '-C', str(ROOT), 'rev-parse', '--verify', args.revision + '^{commit}'],
+            text=True).strip()
+    source = (subprocess.check_output(['git', '-C', str(ROOT), 'show', f'{revision}:{SOURCE}'])
+              if revision else (ROOT / SOURCE).read_bytes())
+    body = extract(source.decode())
+    template = Path(__file__).with_name('lua_progress_errors.cpp.in').read_text()
+    if template.count('@LPROGRESS_NEW@') != 1:
+        raise ValueError('Expected exactly one fixture marker')
+    cpp = out / 'lua_progress_errors.cpp'
+    cpp.write_bytes(template.replace('@LPROGRESS_NEW@', body).encode())
+    report = {'revision': revision or 'working tree', 'source': str(ROOT / SOURCE),
+              'source_sha256': hashlib.sha256(source).hexdigest(),
+              'function_sha256': hashlib.sha256(body.encode()).hexdigest(),
+              'limits': __doc__, 'commands': [], 'runs': []}
+
+    lua_source = args.lua_source.resolve()
+    if not (lua_source / 'lua.h').is_file():
+        lua_source = lua_source / 'src'
+    if not re.search(rb'#define\s+LUA_RELEASE\s+"Lua 5\.1\.4"',
+                     (lua_source / 'lua.h').read_bytes()):
+        raise ValueError('This fixture requires official Lua 5.1.4 sources')
+    lua_copy = out / 'lua-source'
+    if lua_copy == lua_source or lua_source in lua_copy.parents:
+        raise ValueError('The output directory must be outside the supplied Lua sources')
+    lua_copy.mkdir(exist_ok=True)
+    report['lua_source'] = str(lua_source)
+    report['lua_sha256'] = {}
+    for path in sorted([*lua_source.glob('*.h'), *(lua_source / (u + '.c') for u in LUA_UNITS)]):
+        data = path.read_bytes()
+        (lua_copy / path.name).write_bytes(data)
+        report['lua_sha256'][path.name] = hashlib.sha256(data).hexdigest()
+    cc = compiler('CC', ['clang', 'cc'])
+    cxx = compiler('CXX', ['clang++', 'c++'])
+    environment = dict(os.environ, ASAN_OPTIONS='halt_on_error=1',
+                       UBSAN_OPTIONS='halt_on_error=1:print_stacktrace=1')
+
+    def command(argv, log, check=True):
+        report['commands'].append(argv)
+        result = subprocess.run(argv, cwd=out, env=environment, capture_output=True,
+                                text=True, timeout=120)
+        output = result.stdout + result.stderr
+        (out / log).write_text(output)
+        if output:
+            print(output, end='', flush=True)
+        if check:
+            result.check_returncode()
+        return result
+
+    modes = [('release', [])]
+    report['sanitizers'] = 'disabled by --sanitizers off'
+    if args.sanitizers != 'off':
+        probe_c = out / 'sanitizer_probe.c'
+        probe_cpp = out / 'sanitizer_probe.cpp'
+        probe_c.write_text('int probe(void) { return 0; }\n')
+        probe_cpp.write_text('extern "C" int probe(void);\nint main() { return probe(); }\n')
+        probe_obj = out / 'sanitizer_probe.o'
+        probe_exe = out / 'sanitizer_probe'
+        supported = command([*cc, '-x', 'c', '-std=c99', *SANITIZERS, '-c', str(probe_c),
+                             '-o', str(probe_obj)], 'sanitizer_probe_c.log', False).returncode == 0
+        if supported:
+            supported = command([*cxx, '-std=c++17', *SANITIZERS, str(probe_cpp),
+                                 str(probe_obj), '-o', str(probe_exe)],
+                                'sanitizer_probe_link.log', False).returncode == 0
+        if supported:
+            # Runtime failures are errors, not reasons to skip the sanitizer run.
+            command([str(probe_exe)], 'sanitizer_probe_run.log')
+            modes.append(('sanitized', SANITIZERS))
+            report['sanitizers'] = 'ASan and UBSan enabled'
+        else:
+            report['sanitizers'] = 'unsupported compiler/linker; see sanitizer_probe logs'
+            print('SKIP sanitizers: ' + report['sanitizers'], flush=True)
+            if args.sanitizers == 'required':
+                raise RuntimeError('Required sanitizer compiler/linker probe failed')
+
+    failures = []
+    for mode, sanitizer_flags in modes:
+        build = out / mode
+        build.mkdir(exist_ok=True)
+        common = ['-O1', '-g', '-DNDEBUG', '-fno-omit-frame-pointer',
+                  '-fexceptions', '-funwind-tables', *sanitizer_flags]
+        objects = []
+        print(f'Build {mode}: Lua as C, fixture as C++17, NDEBUG enabled', flush=True)
+        for unit in LUA_UNITS:
+            obj = build / (unit + '.o')
+            # -x c prevents a CXX override or driver default from changing Lua's
+            # longjmp implementation into its optional C++ exception implementation.
+            command([*cc, '-x', 'c', '-std=c99', *common, '-I', str(lua_copy), '-c',
+                     str(lua_copy / (unit + '.c')), '-o', str(obj)], f'{mode}/{unit}.log')
+            objects.append(str(obj))
+        exe = build / 'lua_progress_errors'
+        command([*cxx, '-std=c++17', *common, '-Wall', '-Wextra', '-I', str(lua_copy),
+                 str(cpp), *objects, '-lm', '-o', str(exe)], f'{mode}/link.log')
+        for case in CASES:
+            print(f'Run {mode}/{case}', flush=True)
+            result = command([str(exe), case], f'{mode}/{case}.log', False)
+            passed = result.returncode == 0 and f'PASS: {case}\n' in result.stdout
+            report['runs'].append({'mode': mode, 'case': case, 'passed': passed,
+                                   'returncode': result.returncode,
+                                   'log': str(build / (case + '.log'))})
+            if not passed:
+                failures.append(f'{mode}/{case}')
+    if not revision and (ROOT / SOURCE).read_bytes() != source:
+        failures.append('production source changed during the run; run again')
+    report['result'] = 'fail' if failures else 'pass'
+    report_path.write_text(json.dumps(report, indent=2) + '\n')
+    print(f'Report: {report_path}', flush=True)
+    if failures:
+        raise RuntimeError('Regression failures: ' + ', '.join(failures))
+    print(f'PASS: {len(CASES)} cases in each of {len(modes)} modes', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_monitor_lifetime.py
+++ b/tests/check_monitor_lifetime.py
@@ -1,0 +1,64 @@
+"""Compile and run extracted monitor production code with Win32/MFC stubs.
+
+Uses real C++ threads and ASan/UBSan. Does not validate native Windows or Wine.
+"""
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def block(text, signature):
+    start = text.index(signature)
+    brace = text.index('{', start)
+    depth = 0
+    for end in range(brace, len(text)):
+        depth += (text[end] == '{') - (text[end] == '}')
+        if depth == 0:
+            return text[start:end + 1]
+    raise ValueError(signature)
+
+text = (ROOT / 'TextDocument.cpp').read_text()
+start = text.index('// ------------------- file change monitoring thread')
+end = text.index('// ------------------- handle change to file', start)
+production = text[start:end]
+frame = (ROOT / 'mainfrm.cpp').read_text()
+handlers = '\n'.join(block(frame, name) for name in [
+    'LRESULT CMainFrame::OnScriptFileContentsChanged',
+    'LRESULT CMainFrame::OnTextFileContentsChanged'])
+notification = block((ROOT / 'stdafx.h').read_text(), 'struct CFileChangeNotification') + ';'
+template = Path(__file__).with_name('monitor_lifetime.cpp.in').read_text()
+for name, value in [('PRODUCTION', production), ('HANDLERS', handlers), ('NOTIFICATION', notification)]:
+    assert template.count('@' + name + '@') == 1
+    template = template.replace('@' + name + '@', value)
+# Verify the wiring that the extracted functions do not compile.
+assert 'CollectMonitoringThreads ();' in block((ROOT / 'MUSHclient.cpp').read_text(), 'BOOL CMUSHclientApp::OnIdle')
+assert 'SetTimer(TICK_TIMER_ID, 40, NULL )' in frame
+for path, pending in [('TextDocument.cpp', 'm_bFileChangedPending'), ('scripting/scripting.cpp', 'm_bScriptFileChangedPending')]:
+    source = (ROOT / path).read_text()
+    assert 'm_eventFileChanged' not in source and 'm_eventScriptFileChanged' not in source
+    assert 'StopMonitoringThread (m_iMonitorToken);\n  ' + pending + ' = false;' in source
+out = Path(tempfile.mkdtemp(prefix='mushclient-monitor-'))
+cpp = out / 'monitor_lifetime.cpp'
+cpp.write_text(template)
+for mode, flags in [('release', []), ('debug', ['-D_DEBUG'])]:
+    exe = out / mode
+    subprocess.run(['clang++', '-std=c++17', '-pthread', '-O1', '-g',
+                    '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                    *flags, str(cpp), '-o', str(exe)], check=True)
+    subprocess.run([str(exe)], check=True, timeout=30)
+print(f'Artifacts: {out}')
+
+# One targeted mutation proves that stale-generation rejection is exercised.
+mutated = template.replace('iMonitorToken != 0 && pDoc->m_iMonitorToken == iMonitorToken', 'true')
+assert mutated != template
+mutant = out / 'stale_token_mutation.cpp'
+mutant.write_text(mutated)
+exe = out / 'stale_token_mutation'
+subprocess.run(['clang++', '-std=c++17', '-pthread', '-O1', '-g',
+                '-fsanitize=address,undefined', str(mutant), '-o', str(exe)], check=True)
+result = subprocess.run([str(exe)], capture_output=True, text=True, timeout=30)
+(out / 'mutation.log').write_text(result.stdout + result.stderr)
+assert result.returncode != 0, 'Stale-token mutation escaped detection'
+assert '!text.m_bFileChangedPending' in result.stderr, result.stderr
+print('PASS: removing the stale-token guard fails the expected assertion')

--- a/tests/check_monitor_lifetime.py
+++ b/tests/check_monitor_lifetime.py
@@ -36,10 +36,19 @@ cpp.write_text(template)
 for mode, flags in [('release', []), ('debug', ['-D_DEBUG'])]:
     exe = out / mode
     subprocess.run(['clang++', '-std=c++17', '-pthread', '-O1', '-g',
-                    '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                    '-fsanitize=address,undefined', '-fno-sanitize-recover=all',
+                    '-fno-omit-frame-pointer',
                     *flags, str(cpp), '-o', str(exe)], check=True)
     subprocess.run([str(exe)], check=True, timeout=30)
 print(f'Artifacts: {out}')
+
+# Reject builds that remove the test assertions.
+disabled = subprocess.run(['clang++', '-std=c++17', '-pthread', '-DNDEBUG',
+                           '-fsyntax-only', str(cpp)], capture_output=True, text=True)
+(out / 'ndebug.log').write_text(disabled.stdout + disabled.stderr)
+if disabled.returncode == 0 or 'Monitor lifetime tests require assertions' not in disabled.stderr:
+    raise RuntimeError('The monitor fixture did not reject NDEBUG')
+print('PASS: NDEBUG is rejected')
 
 # One targeted mutation proves that stale-generation rejection is exercised.
 mutated = template.replace('iMonitorToken != 0 && pDoc->m_iMonitorToken == iMonitorToken', 'true')
@@ -48,7 +57,8 @@ mutant = out / 'stale_token_mutation.cpp'
 mutant.write_text(mutated)
 exe = out / 'stale_token_mutation'
 subprocess.run(['clang++', '-std=c++17', '-pthread', '-O1', '-g',
-                '-fsanitize=address,undefined', str(mutant), '-o', str(exe)], check=True)
+                '-fsanitize=address,undefined', '-fno-sanitize-recover=all',
+                str(mutant), '-o', str(exe)], check=True)
 result = subprocess.run([str(exe)], capture_output=True, text=True, timeout=30)
 (out / 'mutation.log').write_text(result.stdout + result.stderr)
 assert result.returncode != 0, 'Stale-token mutation escaped detection'

--- a/tests/check_monitor_lifetime.py
+++ b/tests/check_monitor_lifetime.py
@@ -6,17 +6,9 @@ from pathlib import Path
 import subprocess
 import tempfile
 
-ROOT = Path(__file__).resolve().parents[1]
+from cpp_blocks import block
 
-def block(text, signature):
-    start = text.index(signature)
-    brace = text.index('{', start)
-    depth = 0
-    for end in range(brace, len(text)):
-        depth += (text[end] == '{') - (text[end] == '}')
-        if depth == 0:
-            return text[start:end + 1]
-    raise ValueError(signature)
+ROOT = Path(__file__).resolve().parents[1]
 
 text = (ROOT / 'TextDocument.cpp').read_text()
 start = text.index('// ------------------- file change monitoring thread')

--- a/tests/check_notepad_close.py
+++ b/tests/check_notepad_close.py
@@ -77,6 +77,7 @@ def main():
             'void CTextDocument::EndOperation',
             'BOOL CTextDocument::SaveModified()']),
         'COMMAND': block(source('TextView.cpp'), 'BOOL CTextView::OnCmdMsg'),
+        'FLIP': block(source('doc.cpp'), 'void CMUSHclientDoc::OnEditFliptonotepad()'),
         'NOTEPAD': '\n'.join(block(notepad, signature) for signature in [
             'bool CMUSHclientDoc::SwitchToNotepad',
             'CTextDocument * CMUSHclientDoc::FindNotepad',
@@ -116,7 +117,8 @@ def main():
 
     environment = dict(os.environ, UBSAN_OPTIONS='halt_on_error=1:print_stacktrace=1')
     cases = ['close_append', 'close_replace', 'cancelled_close', 'repeated_close',
-             'stale_chooser', 'enumeration', 'switch', 'immediate_close']
+             'stale_chooser', 'enumeration', 'switch', 'immediate_close',
+             'flip_pending_only', 'flip_pending_before_live', 'flip_live', 'flip_absent']
     for mode, flags in [('release', []), ('debug', ['-D_DEBUG'])]:
         exe = compile_fixture(mode, template, flags)
         for case in cases:
@@ -128,6 +130,8 @@ def main():
 
     if args.check_mutations:
         mutations = [
+            ('flip_selection', 'void CMUSHclientDoc::OnEditFliptonotepad()',
+             '!pTextDoc->m_bClosePending &&', '', 'flip_pending_only'),
             ('title_lookup', 'CTextDocument * CMUSHclientDoc::FindNotepad',
              '!pTextDoc->m_bClosePending &&', '', 'close_append'),
             ('switch_count', 'bool CMUSHclientDoc::SwitchToNotepad',

--- a/tests/check_notepad_close.py
+++ b/tests/check_notepad_close.py
@@ -1,0 +1,160 @@
+"""Check deferred notepad closure with extracted production C++ paths.
+
+Run with Python 3 and clang++ or CXX. Requires ASan/UBSan support.
+--revision reads a Git revision. --check-mutations checks each visibility filter.
+The fixture supplies MFC controls and registries. It does not run native UI.
+"""
+import argparse
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def block(text, signature):
+    start = text.index(signature)
+    depth = 0
+    opened = False
+    tokens = r'//[^\n]*|/\*[\s\S]*?\*/|"(?:\\.|[^"\\])*"|\{|\}'
+    for token in re.finditer(tokens, text[start:]):
+        if token.group() == '{':
+            depth += 1
+            opened = True
+        elif token.group() == '}':
+            depth -= 1
+            if opened and depth == 0:
+                return text[start:start + token.end()]
+    raise ValueError(f'Unclosed production block: {signature}')
+
+
+def compiler_command():
+    override = os.environ.get('CXX', '')
+    if override:
+        command = shlex.split(override)
+        if not command:
+            raise ValueError('CXX must name a C++ compiler')
+        compiler = shutil.which(command[0])
+        if not compiler:
+            raise FileNotFoundError(f'CXX compiler not found: {command[0]}')
+        return [compiler, *command[1:]]
+    compiler = shutil.which('clang++') or shutil.which('c++')
+    if not compiler:
+        raise FileNotFoundError('No C++ compiler found')
+    return [compiler]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--revision')
+    parser.add_argument('--output-dir', type=Path)
+    parser.add_argument('--check-mutations', action='store_true')
+    args = parser.parse_args()
+    out = args.output_dir or Path(tempfile.mkdtemp(prefix='mushclient-notepad-close-'))
+    out.mkdir(parents=True, exist_ok=True)
+    print(f'Artifacts: {out}', flush=True)
+
+    def source(path):
+        if args.revision:
+            return subprocess.check_output(
+                ['git', '-C', str(ROOT), 'show', f'{args.revision}:{path}'], text=True)
+        return (ROOT / path).read_text()
+
+    textdoc = source('TextDocument.cpp')
+    notepad = source('scripting/methods/methods_notepad.cpp')
+    chooser = source('dialogs/ChooseNotepadDlg.cpp')
+    app = source('MUSHclient.cpp')
+    parts = {
+        'GUARD': block(source('TextDocument.h'), 'class CTextDocumentOperationGuard') + ';',
+        'DOCUMENT': '\n'.join(block(textdoc, signature) for signature in [
+            'void CTextDocument::OnCloseDocument()',
+            'void CTextDocument::BeginOperation',
+            'void CTextDocument::EndOperation',
+            'BOOL CTextDocument::SaveModified()']),
+        'COMMAND': block(source('TextView.cpp'), 'BOOL CTextView::OnCmdMsg'),
+        'NOTEPAD': '\n'.join(block(notepad, signature) for signature in [
+            'bool CMUSHclientDoc::SwitchToNotepad',
+            'CTextDocument * CMUSHclientDoc::FindNotepad',
+            'long CMUSHclientDoc::CloseNotepad',
+            'bool CMUSHclientDoc::AppendToTheNotepad',
+            'BOOL CMUSHclientDoc::AppendToNotepad',
+            'BOOL CMUSHclientDoc::ReplaceNotepad',
+            'VARIANT CMUSHclientDoc::GetNotepadList']),
+        'CHOOSER': '\n'.join(block(chooser, signature) for signature in [
+            'void CChooseNotepadDlg::DoDataExchange',
+            'CMUSHclientDoc * CChooseNotepadDlg::GetLiveWorld',
+            'CTextDocument * CChooseNotepadDlg::GetNotepadForIndex',
+            'void CChooseNotepadDlg::OnOpenExisting']),
+        'DEFER': block(app, 'void CMUSHclientApp::DeferTextDocumentClose'),
+        # Compile the exact deferred-close branch of OnIdle. Other idle work
+        # needs the full application and is outside this test's scope.
+        'IDLE_CLOSE': block(block(app, 'BOOL CMUSHclientApp::OnIdle'),
+                            'if (!m_DeferredTextDocumentCloses.empty ())'),
+    }
+    template = Path(__file__).with_name('notepad_close.cpp.in').read_text()
+    for name, value in parts.items():
+        marker = '@' + name + '@'
+        if template.count(marker) != 1:
+            raise ValueError(f'Expected one template marker: {marker}')
+        template = template.replace(marker, value)
+
+    compiler = compiler_command()
+
+    def compile_fixture(name, fixture, flags=()):
+        cpp = out / (name + '.cpp')
+        exe = out / name
+        cpp.write_text(fixture)
+        subprocess.run([*compiler, '-std=c++17', '-O1', '-g',
+                        '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                        *flags, str(cpp), '-o', str(exe)], check=True)
+        return exe.resolve()
+
+    environment = dict(os.environ, UBSAN_OPTIONS='halt_on_error=1:print_stacktrace=1')
+    cases = ['close_append', 'close_replace', 'cancelled_close', 'repeated_close',
+             'stale_chooser', 'enumeration', 'switch', 'immediate_close']
+    for mode, flags in [('release', []), ('debug', ['-D_DEBUG'])]:
+        exe = compile_fixture(mode, template, flags)
+        for case in cases:
+            result = subprocess.run([str(exe), case], capture_output=True, text=True,
+                                    env=environment, timeout=30)
+            (out / f'{mode}-{case}.log').write_text(result.stdout + result.stderr)
+            print(result.stdout + result.stderr, end='', flush=True)
+            result.check_returncode()
+
+    if args.check_mutations:
+        mutations = [
+            ('title_lookup', 'CTextDocument * CMUSHclientDoc::FindNotepad',
+             '!pTextDoc->m_bClosePending &&', '', 'close_append'),
+            ('switch_count', 'bool CMUSHclientDoc::SwitchToNotepad',
+             '!pTextDoc->m_bClosePending &&', '', 'switch'),
+            ('list_count', 'VARIANT CMUSHclientDoc::GetNotepadList',
+             '    if (pTextDoc->m_bClosePending)\n      continue;', '', 'enumeration'),
+            ('list_fill', 'VARIANT CMUSHclientDoc::GetNotepadList',
+             '      if (pTextDoc->m_bClosePending)\n        continue;', '', 'enumeration'),
+            ('chooser_list', 'void CChooseNotepadDlg::DoDataExchange',
+             'pDoc->m_bClosePending ||', '', 'stale_chooser'),
+            ('chooser_resolution', 'CTextDocument * CChooseNotepadDlg::GetNotepadForIndex',
+             '!pDoc->m_bClosePending &&', '', 'stale_chooser'),
+        ]
+        for name, signature, old, new, case in mutations:
+            original = block(template, signature)
+            if original.count(old) != 1:
+                raise ValueError(f'Expected one mutation target: {name}')
+            mutated = template.replace(original, original.replace(old, new), 1)
+            exe = compile_fixture('mutation-' + name, mutated)
+            result = subprocess.run([str(exe), case], capture_output=True, text=True,
+                                    env=environment, timeout=30)
+            (out / f'mutation-{name}.log').write_text(result.stdout + result.stderr)
+            if result.returncode == 0 or 'CHECK failed:' not in result.stderr:
+                raise RuntimeError(f'Mutation did not fail a check: {name}\n'
+                                   + result.stdout + result.stderr)
+            print(f'PASS: {name} mutation rejected by {case}', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_notepad_close.py
+++ b/tests/check_notepad_close.py
@@ -117,7 +117,8 @@ def main():
 
     environment = dict(os.environ, UBSAN_OPTIONS='halt_on_error=1:print_stacktrace=1')
     cases = ['close_append', 'close_replace', 'cancelled_close', 'repeated_close',
-             'stale_chooser', 'enumeration', 'switch', 'immediate_close',
+             'stale_chooser', 'stale_mapping', 'switch_closed_before_selection',
+             'enumeration', 'switch', 'immediate_close',
              'flip_pending_only', 'flip_pending_before_live', 'flip_live', 'flip_absent']
     for mode, flags in [('release', []), ('debug', ['-D_DEBUG'])]:
         exe = compile_fixture(mode, template, flags)

--- a/tests/check_output_search_snapshot.py
+++ b/tests/check_output_search_snapshot.py
@@ -73,7 +73,9 @@ def main():
     if disabled.returncode == 0 or 'Output search checks require assertions' not in disabled.stderr:
         raise RuntimeError('The harness did not reject NDEBUG')
     mutants = {
-        'text_validation': ('memcmp ((LPCTSTR) strText, pLine->text, pLine->len) == 0', 'true'),
+        'text_validation': ('memcmp (text, pLine->text, pLine->len) == 0', 'true'),
+        'borrowed_source': ('    CopyText (m_Lines, m_TextBlocks);', ''),
+        'borrowed_match': ('    COutputSearchSnapshot::CopyText (matchedLines, matchedTextBlocks);', ''),
         'nested_publication': ('m_pOutputSearchSnapshot == snapshot', 'true'),
     }
     for name, (before, after) in mutants.items():
@@ -86,8 +88,11 @@ def main():
         result = subprocess.run([str(exe)], capture_output=True, text=True, timeout=30,
                                 env=environment)
         (out / (name + '.log')).write_text(result.stdout + result.stderr)
-        if result.returncode == 0 or 'Assertion failed' not in result.stderr and 'Assertion ' not in result.stderr:
-            raise RuntimeError(f'Mutation did not fail an assertion: {name}\n{result.stderr}')
+        expected = ('AddressSanitizer: heap-use-after-free' in result.stderr
+                    if name.startswith('borrowed_') else
+                    'Assertion failed' in result.stderr or 'Assertion ' in result.stderr)
+        if result.returncode == 0 or not expected:
+            raise RuntimeError(f'Mutation did not fail the expected check: {name}\n{result.stderr}')
         print(f'PASS: {name} mutation rejected')
     print('PASS: NDEBUG rejected; extracted output search checks passed')
 

--- a/tests/check_output_search_snapshot.py
+++ b/tests/check_output_search_snapshot.py
@@ -1,0 +1,102 @@
+"""Run extracted output-find code with callback, window and regexp substitutes.
+
+This checks snapshot ownership and selection mapping, not native MFC dispatch
+or PCRE matching. Build failures and unexpected runtime failures propagate.
+"""
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def block(text, signature):
+    start = text.index(signature)
+    brace = text.index('{', start)
+    depth = 0
+    for end in range(brace, len(text)):
+        depth += (text[end] == '{') - (text[end] == '}')
+        if depth == 0:
+            return text[start:end + 1]
+    raise ValueError(f'Unclosed production block: {signature}')
+
+
+def compiler_command():
+    if os.environ.get('CXX'):
+        command = shlex.split(os.environ['CXX'])
+        if not command:
+            raise SystemExit('CXX must name a C++ compiler')
+        compiler = shutil.which(command[0])
+        if compiler is None:
+            raise SystemExit(f'CXX compiler not found: {command[0]}')
+        return [compiler, *command[1:]]
+    compiler = shutil.which('clang++') or shutil.which('c++')
+    if compiler is None:
+        raise SystemExit('No C++ compiler found')
+    return [compiler]
+
+
+def main():
+    send = (ROOT / 'sendvw.cpp').read_text()
+    header = (ROOT / 'sendvw.h').read_text()
+    finding = (ROOT / 'Finding.cpp').read_text()
+    stdafx = (ROOT / 'stdafx.h').read_text()
+    doc = (ROOT / 'doc.h').read_text()
+    production = send[send.index('class COutputSearchSnapshot :'):send.index('void CSendView::OnDisplayFind()')]
+    tokens = {
+        'FIND_INFO': block(stdafx, 'class CFindInfo :') + ';',
+        'GUARD': block(doc, 'class CWorldDocumentOperationGuard') + ';',
+        'FIND_ROUTINE': finding[finding.index('static void WrapUpFind'):],
+        'PRODUCTION': production,
+    }
+    if 'std::shared_ptr<COutputSearchSnapshot> m_pOutputSearchSnapshot;' not in header:
+        raise RuntimeError('The production view must own the latest snapshot')
+    template = Path(__file__).with_name('output_search_snapshot.cpp.in').read_text()
+    for name, value in tokens.items():
+        marker = '@' + name + '@'
+        if template.count(marker) != 1:
+            raise RuntimeError(f'Expected one template marker: {marker}')
+        template = template.replace(marker, value)
+
+    out = Path(tempfile.mkdtemp(prefix='mushclient-output-search-'))
+    print(f'Artifacts: {out}', flush=True)
+    compiler = compiler_command()
+    flags = ['-std=c++17', '-O1', '-g', '-fsanitize=address,undefined',
+             '-fno-omit-frame-pointer']
+    cpp = out / 'output_search_snapshot.cpp'
+    cpp.write_text(template)
+    for mode, extra in [('release', []), ('debug', ['-D_DEBUG'])]:
+        exe = out / mode
+        subprocess.run([*compiler, *flags, *extra, str(cpp), '-o', str(exe)], check=True)
+        subprocess.run([str(exe)], check=True, timeout=30)
+
+    # Prove that neither the oracle nor the key callback guards can be removed.
+    disabled = subprocess.run([*compiler, *flags, '-DNDEBUG', str(cpp), '-o', str(out / 'ndebug')],
+                              capture_output=True, text=True)
+    (out / 'ndebug.log').write_text(disabled.stdout + disabled.stderr)
+    if disabled.returncode == 0 or 'Output search checks require assertions' not in disabled.stderr:
+        raise RuntimeError('The harness did not reject NDEBUG')
+    mutants = {
+        'text_validation': ('memcmp ((LPCTSTR) strText, pLine->text, pLine->len) == 0', 'true'),
+        'nested_publication': ('m_pOutputSearchSnapshot == snapshot', 'true'),
+    }
+    for name, (before, after) in mutants.items():
+        if template.count(before) != 1:
+            raise RuntimeError(f'Mutation anchor changed: {name}')
+        mutant = out / (name + '.cpp')
+        mutant.write_text(template.replace(before, after))
+        exe = out / name
+        subprocess.run([*compiler, *flags, str(mutant), '-o', str(exe)], check=True)
+        result = subprocess.run([str(exe)], capture_output=True, text=True, timeout=30)
+        (out / (name + '.log')).write_text(result.stdout + result.stderr)
+        if result.returncode == 0 or 'Assertion failed' not in result.stderr and 'Assertion ' not in result.stderr:
+            raise RuntimeError(f'Mutation did not fail an assertion: {name}\n{result.stderr}')
+        print(f'PASS: {name} mutation rejected')
+    print('PASS: NDEBUG rejected; extracted output search checks passed')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_output_search_snapshot.py
+++ b/tests/check_output_search_snapshot.py
@@ -10,18 +10,9 @@ import shutil
 import subprocess
 import tempfile
 
+from cpp_blocks import block
+
 ROOT = Path(__file__).resolve().parents[1]
-
-
-def block(text, signature):
-    start = text.index(signature)
-    brace = text.index('{', start)
-    depth = 0
-    for end in range(brace, len(text)):
-        depth += (text[end] == '{') - (text[end] == '}')
-        if depth == 0:
-            return text[start:end + 1]
-    raise ValueError(f'Unclosed production block: {signature}')
 
 
 def compiler_command():
@@ -65,13 +56,15 @@ def main():
     print(f'Artifacts: {out}', flush=True)
     compiler = compiler_command()
     flags = ['-std=c++17', '-O1', '-g', '-fsanitize=address,undefined',
-             '-fno-omit-frame-pointer']
+             '-fno-sanitize-recover=all', '-fno-omit-frame-pointer']
+    environment = dict(os.environ, ASAN_OPTIONS='halt_on_error=1',
+                       UBSAN_OPTIONS='halt_on_error=1:print_stacktrace=1')
     cpp = out / 'output_search_snapshot.cpp'
     cpp.write_text(template)
     for mode, extra in [('release', []), ('debug', ['-D_DEBUG'])]:
         exe = out / mode
         subprocess.run([*compiler, *flags, *extra, str(cpp), '-o', str(exe)], check=True)
-        subprocess.run([str(exe)], check=True, timeout=30)
+        subprocess.run([str(exe)], check=True, timeout=30, env=environment)
 
     # Prove that neither the oracle nor the key callback guards can be removed.
     disabled = subprocess.run([*compiler, *flags, '-DNDEBUG', str(cpp), '-o', str(out / 'ndebug')],
@@ -90,7 +83,8 @@ def main():
         mutant.write_text(template.replace(before, after))
         exe = out / name
         subprocess.run([*compiler, *flags, str(mutant), '-o', str(exe)], check=True)
-        result = subprocess.run([str(exe)], capture_output=True, text=True, timeout=30)
+        result = subprocess.run([str(exe)], capture_output=True, text=True, timeout=30,
+                                env=environment)
         (out / (name + '.log')).write_text(result.stdout + result.stderr)
         if result.returncode == 0 or 'Assertion failed' not in result.stderr and 'Assertion ' not in result.stderr:
             raise RuntimeError(f'Mutation did not fail an assertion: {name}\n{result.stderr}')

--- a/tests/check_paste_file_cleanup.py
+++ b/tests/check_paste_file_cleanup.py
@@ -1,0 +1,101 @@
+"""Check file ownership in the extracted production OnGamePastefile function.
+
+Requires clang++ with ASan/UBSan. Both debug and NDEBUG builds run every selected
+case. Checks remain active in both builds and under Python -O. MFC dialogs,
+exceptions, and SendToMushHelper are substitutes; files use real C streams.
+Native MFC behavior and Windows file sharing are not tested.
+
+Use --revision a72eea4 to reproduce the non-file exception leaks.
+Generated source, input files, binaries, and logs stay in --output-dir.
+Extraction, compilation, and test errors cause a nonzero exit status.
+"""
+
+import argparse
+import hashlib
+from pathlib import Path
+import re
+import subprocess
+
+
+CASES = (
+    'normal', 'dialog_cancel', 'send_cancel', 'file_open_exception',
+    'file_read_exception', 'file_eof', 'resource_exception', 'other_exception',
+)
+
+
+def extract_function(source):
+    signature = 'void CMUSHclientDoc::OnGamePastefile()'
+    if source.count(signature) != 1:
+        raise ValueError('Expected exactly one OnGamePastefile definition')
+    start = source.index(signature)
+    depth = 0
+    tokens = r'//[^\n]*|/\*[\s\S]*?\*/|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\{|\}'
+    for token in re.finditer(tokens, source[start:]):
+        if token.group() == '{':
+            depth += 1
+        elif token.group() == '}':
+            depth -= 1
+            if depth == 0:
+                return source[start:start + token.end()]
+    raise ValueError('Unclosed OnGamePastefile definition')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output-dir', type=Path, required=True)
+    parser.add_argument('--revision', help='Extract doc.cpp from this Git revision')
+    parser.add_argument('--case', choices=CASES, action='append', dest='cases')
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    output = args.output_dir.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+
+    raw = (subprocess.check_output(['git', 'show', f'{args.revision}:doc.cpp'], cwd=root)
+           if args.revision else (root / 'doc.cpp').read_bytes())
+    function = extract_function(raw.decode('utf-8').replace('\r\n', '\n'))
+    template_path = Path(__file__).with_name('paste_file_cleanup.cpp.in')
+    template_bytes = template_path.read_bytes()
+    template = template_bytes.decode('utf-8').replace('\r\n', '\n')
+    marker = '@PASTE_FILE@'
+    if template.count(marker) != 1:
+        raise ValueError('Expected exactly one paste-file template marker')
+    cpp = output / 'paste_file_cleanup.cpp'
+    cpp.write_text(template.replace(marker, function))
+    (output / 'inputs.sha256').write_text(
+        f'{hashlib.sha256(raw).hexdigest()}  {args.revision or "working-tree"}:doc.cpp\n'
+        f'{hashlib.sha256(template_bytes).hexdigest()}  {template_path.name}\n'
+        f'{hashlib.sha256(function.encode()).hexdigest()}  extracted OnGamePastefile\n')
+    input_file = output / 'paste-input.txt'
+    input_file.write_bytes(b'first line\nsecond line\n')
+
+    failures = []
+    cases = args.cases or CASES
+    for mode, flags in (('debug', ['-O0', '-D_DEBUG']),
+                        ('ndebug', ['-O2', '-DNDEBUG'])):
+        executable = output / f'paste_file_cleanup_{mode}'
+        command = [
+            'clang++', '-std=c++17', '-Wall', '-Wextra', '-Werror', '-g',
+            '-fsanitize=address,undefined', '-fno-sanitize-recover=all',
+            '-fno-omit-frame-pointer', *flags, str(cpp), '-o', str(executable),
+        ]
+        print('Compile:', command, flush=True)
+        with (output / f'{mode}-compile.log').open('w') as log:
+            result = subprocess.run(command, cwd=output, stdout=log, stderr=subprocess.STDOUT)
+        print((output / f'{mode}-compile.log').read_text(), end='', flush=True)
+        result.check_returncode()
+        for case in cases:
+            result = subprocess.run([str(executable), case, str(input_file)],
+                                    cwd=output, capture_output=True, text=True, timeout=30)
+            log = result.stdout + result.stderr
+            (output / f'{mode}-{case}.log').write_text(log)
+            print(f'{mode}/{case}: exit={result.returncode}\n{log}', end='', flush=True)
+            if result.returncode:
+                failures.append(f'{mode}/{case} (exit {result.returncode})')
+    # Report all failed cases after both builds have run. Failures stay fatal.
+    if failures:
+        raise RuntimeError('Failed paste-file checks: ' + ', '.join(failures))
+    print(f'PASS: {len(cases)} cases in both debug and NDEBUG builds', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_progress_messages.py
+++ b/tests/check_progress_messages.py
@@ -1,0 +1,175 @@
+"""Run progress dispatch and lifetime regression tests from production C++.
+
+Portable: python tests/check_progress_messages.py
+Windows: from an MSVC developer prompt, python tests/check_progress_messages.py --native-windows
+Historical fault: add --pump-revision 3318da8 --case blocked_chat (must fail).
+
+Portable mode requires ASan/UBSan. Native mode uses Win32 queues, sent messages,
+and WSAAsyncSelect with a loopback socket; MFC and Lua are test substitutes.
+No source files are changed. Generated C++, executables and logs stay in the
+output directory. Extraction, compilation and test errors propagate.
+"""
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def block(source, signature):
+    start = source.index(signature)
+    depth = 0
+    # Ignore braces in comments, strings and character literals.
+    tokens = r'//[^\n]*|/\*[\s\S]*?\*/|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\{|\}'
+    for token in re.finditer(tokens, source[start:]):
+        if token.group() == '{':
+            depth += 1
+        elif token.group() == '}':
+            depth -= 1
+            if depth == 0:
+                return source[start:start + token.end()]
+    raise ValueError(f'Unclosed production block: {signature}')
+
+
+def compiler_command(native):
+    override = os.environ.get('CXX', '')
+    if override:
+        # A quoted compiler path works on Windows as well as POSIX. Native
+        # callers can omit CXX and use cl from their developer prompt.
+        command = shlex.split(override, posix=os.name != 'nt')
+        command = [part[1:-1] if part.startswith('"') and part.endswith('"') else part
+                   for part in command]
+        if not command:
+            raise ValueError('CXX must name a C++ compiler')
+        compiler = shutil.which(command[0])
+        if not compiler:
+            raise FileNotFoundError(f'CXX compiler not found: {command[0]}')
+        return [compiler, *command[1:]]
+    names = ['cl'] if native else ['clang++', 'c++']
+    for name in names:
+        compiler = shutil.which(name)
+        if compiler:
+            return [compiler]
+    raise FileNotFoundError(f'No compiler found: {names}')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output-dir', type=Path)
+    parser.add_argument('--revision', help='Read all production inputs from this Git revision')
+    parser.add_argument('--pump-revision', help='Replace only PumpMessages with this historical body')
+    parser.add_argument('--native-windows', action='store_true')
+    parser.add_argument('--emit-only', action='store_true', help='Extract without compiling or running')
+    parser.add_argument('--case', action='append', dest='cases')
+    args = parser.parse_args()
+    out = (args.output_dir or Path(tempfile.mkdtemp(prefix='mushclient-progress-'))).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    print(f'Artifacts: {out}', flush=True)
+    inputs = {}
+
+    def source(path, revision=None):
+        revision = revision or args.revision
+        text = (subprocess.check_output(['git', '-C', str(ROOT), 'show', f'{revision}:{path}'], text=True)
+                if revision else (ROOT / path).read_text())
+        inputs[f'{revision or "working-tree"}:{path}'] = hashlib.sha256(text.encode()).hexdigest()
+        return text
+
+    progress = source('dialogs/ProgDlg.cpp')
+    if args.pump_revision:
+        signature = 'void CProgressDlg::PumpMessages()'
+        progress = progress.replace(block(progress, signature),
+                                    block(source('dialogs/ProgDlg.cpp', args.pump_revision), signature), 1)
+    # Keep the full production class and implementation, removing only project
+    # includes. Test substitutes provide the MFC boundary.
+    progress = re.sub(r'^#include[^\n]*\n', '', progress, flags=re.MULTILINE)
+    lua = source('scripting/lua_progressdlg.cpp')
+    doc = source('doc.cpp')
+    textdoc = source('TextDocument.cpp')
+    app = source('MUSHclient.cpp')
+    parts = {
+        'PROGRESS_HEADER': source('dialogs/ProgDlg.h'),
+        'PROGRESS_BODY': progress,
+        'LUA': '\n'.join(block(lua, signature) for signature in [
+            'static CProgressDlg * Lprogress_getdialog',
+            'static int Lprogress_setstatus', 'static int Lprogress_setrange',
+            'static int Lprogress_setposition', 'static int Lprogress_setstep',
+            'static int Lprogress_stepit', 'static int Lprogress_checkcancel',
+            'static int Lprogress_gc', 'static int Lprogress_new']),
+        'SEND': block(source('chatsock.cpp'), 'void CChatSocket::OnSend('),
+        'WORLD_GUARD': block(source('doc.h'), 'class CWorldDocumentOperationGuard') + ';',
+        'TEXT_GUARD': block(source('TextDocument.h'), 'class CTextDocumentOperationGuard') + ';',
+        'DOCUMENTS': '\n'.join([
+            *(block(doc, s) for s in ['void CMUSHclientDoc::OnCloseDocument()',
+                                     'void CMUSHclientDoc::BeginProgressOperation',
+                                     'void CMUSHclientDoc::EndProgressOperation']),
+            *(block(textdoc, s) for s in ['void CTextDocument::OnCloseDocument()',
+                                         'void CTextDocument::BeginOperation',
+                                         'void CTextDocument::EndOperation'])]),
+        'DEFERRED_TYPE': block(source('MUSHclient.h'), 'struct CDeferredMessage') + ';',
+        'APP': '\n'.join(block(app, s) for s in [
+            'void CMUSHclientApp::DeferMessageUntilIdle',
+            'void CMUSHclientApp::DeferWorldDocumentClose',
+            'void CMUSHclientApp::DeferTextDocumentClose',
+            'bool CMUSHclientApp::HasActiveDocumentOperations',
+            'BOOL CMUSHclientApp::OnIdle(']),
+        'NATIVE': Path(__file__).with_name('progress_messages_native.cpp.in').read_text()
+                  if args.native_windows else '',
+    }
+    fixture = Path(__file__).with_name('progress_messages.cpp.in').read_text()
+    for name, value in parts.items():
+        marker = '@' + name + '@'
+        if fixture.count(marker) != 1:
+            raise ValueError(f'Expected exactly one template marker: {marker}')
+        fixture = fixture.replace(marker, value)
+    if re.search(r'@[A-Z_]+@', fixture):
+        raise ValueError('Unexpanded template marker')
+    cpp = out / 'progress_messages.cpp'
+    cpp.write_text(fixture)
+    (out / 'inputs.sha256').write_text(''.join(f'{value}  {key}\n' for key, value in inputs.items()))
+    if args.emit_only:
+        return
+    if args.native_windows and os.name != 'nt':
+        raise RuntimeError('Native execution requires Windows; use --emit-only for cross compilation')
+    compiler = compiler_command(args.native_windows)
+    exe = out / ('progress_messages.exe' if os.name == 'nt' else 'progress_messages')
+    if args.native_windows:
+        command = [*compiler, '/nologo', '/std:c++17', '/EHsc', '/W4', '/Od', '/Zi',
+                   '/DPROGRESS_NATIVE_WINDOWS', str(cpp), '/Fe:' + str(exe),
+                   '/Fo:' + str(out / 'progress_messages.obj'),
+                   '/Fd:' + str(out / 'progress_messages.pdb'),
+                   '/link', 'user32.lib', 'ws2_32.lib']
+    else:
+        command = [*compiler, '-std=c++17', '-O1', '-g', '-Wall', '-Wextra',
+                   '-fsanitize=address,undefined', '-fno-sanitize-recover=all',
+                   '-fno-omit-frame-pointer', str(cpp), '-o', str(exe)]
+    print('Compile:', command, flush=True)
+    subprocess.run(command, check=True, cwd=out)
+    cases = args.cases or [
+        'blocked_chat', 'cancel_quit', 'cancel_stops', 'late_quit', 'nested_depth', 'exception_depth',
+        'lua_nested_close', 'lua_immediate_close', 'lua_control_close', 'lua_exception',
+        'destroy_dispatch', 'destroy_sent', 'sent_foreign', 'destroy_control', 'source_control_order',
+        'window_identity', 'parent_lifetime', 'lua_create', 'lua_create_failure',
+        'lua_argument_failure', 'lua_argument_conversion_close',
+        'world_close', 'text_close', 'close_during_pump', 'queued_then_active',
+        'stale_identity', 'document_exception', 'deferred_messages']
+    if args.native_windows and not args.cases:
+        cases += ['native_socket']
+    environment = dict(os.environ, UBSAN_OPTIONS='halt_on_error=1:print_stacktrace=1')
+    for case in cases:
+        result = subprocess.run([str(exe), case], capture_output=True, text=True,
+                                env=environment, timeout=45, cwd=out)
+        log = result.stdout + result.stderr
+        (out / (case + '.log')).write_text(log)
+        print(log, end='', flush=True)
+        result.check_returncode()
+    print(f'PASS: {len(cases)} cases', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_progress_messages.py
+++ b/tests/check_progress_messages.py
@@ -19,22 +19,9 @@ import shutil
 import subprocess
 import tempfile
 
+from cpp_blocks import block
+
 ROOT = Path(__file__).resolve().parents[1]
-
-
-def block(source, signature):
-    start = source.index(signature)
-    depth = 0
-    # Ignore braces in comments, strings and character literals.
-    tokens = r'//[^\n]*|/\*[\s\S]*?\*/|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\{|\}'
-    for token in re.finditer(tokens, source[start:]):
-        if token.group() == '{':
-            depth += 1
-        elif token.group() == '}':
-            depth -= 1
-            if depth == 0:
-                return source[start:start + token.end()]
-    raise ValueError(f'Unclosed production block: {signature}')
 
 
 def compiler_command(native):

--- a/tests/check_progress_snapshots.py
+++ b/tests/check_progress_snapshots.py
@@ -9,7 +9,9 @@ Limits: portable, synchronous adapters replace MFC strings, heap-backed lists,
 dialogs, document retention, and time formatting. Regex cases use ASCII std::regex,
 not PCRE. Historical source parenthesizes MSVC-only sizeof type expressions.
 Memory totals use adapter sizes, not the Windows ABI. These checks do not
-run Windows/Wine UI, message dispatch, native close handling, locale, or UTF-8.
+run Windows/Wine UI, message dispatch, native close handling, or locale.
+The storage cases preserve raw UTF-8 bytes but do not test PCRE UTF-8 semantics.
+Allocation probes count text allocations and bytes, not native heap overhead.
 """
 import argparse
 import hashlib
@@ -29,6 +31,8 @@ FUNCTIONS = {
     'MEMORY': ('dialogs/world_prefs/prefspropertypages.cpp',
                'void CPrefsP15::CalculateMemoryUsage ()'),
 }
+STORAGE_CASES = ['recall_storage_content', 'recall_storage_cancel',
+                 'recall_storage_short', 'recall_storage_failure']
 CONTROLS = ['recall_control', 'recall_empty', 'recall_cancel',
             'memory_control', 'memory_empty', 'memory_cancel']
 REGRESSIONS = [
@@ -167,7 +171,7 @@ def main():
     # NDEBUG also checks that all fixture checks remain active in release builds.
     for mode, flags in [('debug', ['-D_DEBUG']), ('release', ['-DNDEBUG'])]:
         exe = compile_fixture(mode, program, flags)
-        for case in CONTROLS + REGRESSIONS:
+        for case in CONTROLS + REGRESSIONS + STORAGE_CASES:
             run_case(exe, case)
 
     if args.baseline:
@@ -189,7 +193,7 @@ def main():
         raise RuntimeError('Production functions changed during the run. Run the check again.')
     report['result'] = 'pass'
     report_path.write_text(json.dumps(report, indent=2) + '\n')
-    print(f'PASS: {len(CONTROLS) + len(REGRESSIONS)} cases in each candidate mode', flush=True)
+    print(f'PASS: {len(CONTROLS) + len(REGRESSIONS) + len(STORAGE_CASES)} cases in each candidate mode', flush=True)
     print(f'Report: {report_path}', flush=True)
 
 

--- a/tests/check_progress_snapshots.py
+++ b/tests/check_progress_snapshots.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Check output snapshots with the exact RecallText and CalculateMemoryUsage bodies.
+
+Requires Python 3 and a C++17 compiler with ASan/UBSan. CXX overrides the compiler.
+Run --baseline REV to check the same cases against an earlier Git revision.
+Use --revision REV to test that revision as the candidate, without expected failures.
+
+Limits: portable, synchronous adapters replace MFC strings, heap-backed lists,
+dialogs, document retention, and time formatting. Regex cases use ASCII std::regex,
+not PCRE. Historical source parenthesizes MSVC-only sizeof type expressions.
+Memory totals use adapter sizes, not the Windows ABI. These checks do not
+run Windows/Wine UI, message dispatch, native close handling, locale, or UTF-8.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FUNCTIONS = {
+    'RECALL': ('doc.cpp', 'CString CMUSHclientDoc::RecallText ('),
+    'MEMORY': ('dialogs/world_prefs/prefspropertypages.cpp',
+               'void CPrefsP15::CalculateMemoryUsage ()'),
+}
+CONTROLS = ['recall_control', 'recall_empty', 'recall_cancel',
+            'memory_control', 'memory_empty', 'memory_cancel']
+REGRESSIONS = [
+    f'{operation}_{action}_{event}'
+    for operation in ('recall', 'memory')
+    for action in ('clear', 'prune', 'replace', 'rewrite')
+    for event in ('create', 'setpos', 'poll')
+] + ['recall_clear_cancel', 'memory_clear_cancel', 'memory_clear_publish']
+REGRESSIONS += [f'memory_{action}_{event}'
+                for action in ('destroy', 'reuse')
+                for event in ('create', 'setpos', 'poll')]
+
+
+def block(source, signature):
+    if source.count(signature) != 1:
+        raise ValueError(f'Expected one production function: {signature}')
+    start = source.index(signature)
+    depth = 0
+    opened = False
+    # Ignore braces in comments, ordinary strings, and character literals.
+    tokens = r'//[^\n]*|/\*[\s\S]*?\*/|"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|[{}]'
+    for match in re.finditer(tokens, source[start:]):
+        token = match.group()
+        if token == '{':
+            opened = True
+            depth += 1
+        elif token == '}':
+            depth -= 1
+            if opened and depth == 0:
+                return source[start:start + match.end()]
+    raise ValueError(f'Unclosed production function: {signature}')
+
+
+def compiler_command():
+    override = os.environ.get('CXX', '')
+    if override:
+        command = shlex.split(override)
+        if not command:
+            raise ValueError('CXX must name a C++ compiler')
+        executable = shutil.which(command[0])
+        if executable is None:
+            raise FileNotFoundError(f'CXX compiler not found: {command[0]}')
+        return [executable, *command[1:]]
+    executable = shutil.which('clang++') or shutil.which('c++')
+    if executable is None:
+        raise FileNotFoundError('No C++ compiler found. Set CXX or install clang++ or c++.')
+    return [executable]
+
+
+def extract(source, revision, template):
+    parts = {}
+    for name, (path, signature) in FUNCTIONS.items():
+        if revision:
+            text = subprocess.check_output(
+                ['git', '-C', str(source), 'show', f'{revision}:{path}'], text=True)
+        else:
+            text = (source / path).read_text()
+        parts[name] = block(text, signature)
+        # Older MSVC source permits sizeof Type without parentheses.
+        # Parenthesize only those type expressions for portable compilation.
+        if revision:
+            for typename in ('CLine', 'CStyle'):
+                parts[name] = re.sub(r'\bsizeof ' + typename + r'\b',
+                                     'sizeof (' + typename + ')', parts[name])
+        marker = '@' + name + '@'
+        if template.count(marker) != 1:
+            raise ValueError(f'Expected one template marker: {marker}')
+        # The extracted bodies are inserted without rewriting production code.
+        template = template.replace(marker, parts[name])
+    hashes = {name: hashlib.sha256(body.encode()).hexdigest()
+              for name, body in parts.items()}
+    return template, hashes
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source', type=Path, default=ROOT)
+    parser.add_argument('--revision')
+    parser.add_argument('--baseline', help='Require baseline controls to pass and regressions to fail')
+    parser.add_argument('--output-dir', type=Path)
+    args = parser.parse_args()
+    source = args.source.resolve()
+    out = (args.output_dir or Path(tempfile.mkdtemp(prefix='mushclient-progress-snapshots-'))).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    report_path = out / 'progress_snapshots.json'
+    report_path.unlink(missing_ok=True)
+    print(f'Artifacts: {out}', flush=True)
+    compiler = compiler_command()
+    template = Path(__file__).with_name('progress_snapshots.cpp.in').read_text()
+    program, hashes = extract(source, args.revision, template)
+    report = {'source': str(source), 'revision': args.revision or 'working tree',
+              'function_sha256': hashes, 'limits': __doc__, 'runs': []}
+    environment = dict(os.environ, ASAN_OPTIONS='halt_on_error=1',
+                       UBSAN_OPTIONS='halt_on_error=1:print_stacktrace=1')
+
+    def compile_fixture(name, body, flags):
+        cpp = out / f'{name}.cpp'
+        exe = out / name
+        cpp.write_text(body)
+        command = [*compiler, '-std=c++17', '-O1', '-g', '-Wall', '-Wextra',
+                   '-fsanitize=address,undefined', '-fno-sanitize-recover=all',
+                   '-fno-omit-frame-pointer', *flags, str(cpp), '-o', str(exe)]
+        subprocess.run(command, check=True, timeout=120)
+        report.setdefault('compile_commands', []).append(command)
+        return exe
+
+    def run_case(exe, case, expected_failure=False):
+        result = subprocess.run([str(exe), case], capture_output=True, text=True,
+                                env=environment, timeout=30)
+        log = out / f'{exe.name}-{case}.log'
+        output = result.stdout + result.stderr
+        log.write_text(output)
+        reason = None
+        if expected_failure:
+            if 'ERROR: AddressSanitizer: heap-use-after-free' in result.stderr:
+                reason = 'ASan heap-use-after-free'
+            elif 'CHECK failed: snapshot result' in result.stderr:
+                reason = 'wrong snapshot result'
+            elif 'CHECK failed: cancellation result' in result.stderr:
+                reason = 'wrong cancellation result'
+            elif 'CHECK failed: page window result' in result.stderr:
+                reason = 'access to a destroyed or replaced page window'
+            if result.returncode == 0 or reason is None:
+                raise RuntimeError(f'Baseline did not fail as expected: {case}\n{output}')
+            print(f'EXPECTED BASELINE FAILURE: {case}: {reason} ({log.name})', flush=True)
+        else:
+            print(output, end='', flush=True)
+            result.check_returncode()
+            if f'PASS: {case}\n' not in result.stdout:
+                raise RuntimeError(f'Missing case completion: {case}')
+        report['runs'].append({'binary': exe.name, 'case': case,
+                               'returncode': result.returncode,
+                               'expected_failure': expected_failure,
+                               'reason': reason, 'log': str(log)})
+
+    # NDEBUG also checks that all fixture checks remain active in release builds.
+    for mode, flags in [('debug', ['-D_DEBUG']), ('release', ['-DNDEBUG'])]:
+        exe = compile_fixture(mode, program, flags)
+        for case in CONTROLS + REGRESSIONS:
+            run_case(exe, case)
+
+    if args.baseline:
+        baseline_revision = subprocess.check_output(
+            ['git', '-C', str(source), 'rev-parse', '--verify', args.baseline + '^{commit}'],
+            text=True).strip()
+        baseline, baseline_hashes = extract(source, baseline_revision, template)
+        report['baseline'] = {'revision': baseline_revision,
+                              'function_sha256': baseline_hashes}
+        exe = compile_fixture('baseline', baseline, ['-DNDEBUG'])
+        for case in CONTROLS:
+            run_case(exe, case)
+        for case in REGRESSIONS:
+            run_case(exe, case, expected_failure=True)
+
+    # Do not report a pass for stale functions if another worker changed them.
+    _, final_hashes = extract(source, args.revision, template)
+    if final_hashes != hashes:
+        raise RuntimeError('Production functions changed during the run. Run the check again.')
+    report['result'] = 'pass'
+    report_path.write_text(json.dumps(report, indent=2) + '\n')
+    print(f'PASS: {len(CONTROLS) + len(REGRESSIONS)} cases in each candidate mode', flush=True)
+    print(f'Report: {report_path}', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_world_callback_lifetime.py
+++ b/tests/check_world_callback_lifetime.py
@@ -2,7 +2,9 @@
 
 Requires Python 3 and clang++. Uses ASan/UBSan and MFC/socket stubs.
 The fixture delivers close requests during callbacks and drains deferred closes
-at explicit safe points. It does not prove native modal-message dispatch.
+at explicit safe points. The timer fixture extracts only marked-chat cleanup;
+a continuation counter represents the remaining timer work. It does not prove
+native modal-message dispatch or full timer scheduling.
 """
 import argparse
 import json
@@ -44,8 +46,11 @@ def main():
             'void CMUSHclientDoc::OnCloseDocument()',
             'void CMUSHclientDoc::BeginProgressOperation ()',
             'void CMUSHclientDoc::EndProgressOperation ()']),
+        block(doc, 'CChatSocket * CMUSHclientDoc::GetChatSocket ('),
         block(read('childfrm.cpp'), 'void CChildFrame::OnClose()'),
         block(chat, 'void CChatSocket::OnReceive('),
+        block(chat, 'void CChatSocket::OnClose('),
+        block(read('scripting/methods/methods_chat.cpp'), 'long CMUSHclientDoc::ChatDisconnect('),
         block(chat, 'void CChatSocket::ProcessChatMessage ('),
         block(chat, 'void CChatSocket::Process_Send_command'),
         block(chat, 'void CChatSocket::Process_Message'),
@@ -57,8 +62,11 @@ def main():
         block(stdafx, 'class CBoolStateGuard') + ';',
         block(read('doc.h'), 'class CWorldDocumentOperationGuard') + ';',
     ])
+    cleanup = block(block(read('timers.cpp'), 'void CMUSHclientDoc::CheckTimerList ('),
+                    'for (POSITION chatpos = m_ChatList.GetHeadPosition (); chatpos; )')
     template = Path(__file__).with_name('world_callback_lifetime.cpp.in').read_text()
     source = replace_once(replace_once(template, '@GUARDS@', guards), '@FUNCTIONS@', functions)
+    source = replace_once(source, '@CHAT_CLEANUP@', cleanup)
 
     def compile_source(name, content, flags=()):
         cpp = out / f'{name}.cpp'
@@ -91,6 +99,12 @@ def main():
                 chat_guard + '\n' + inner_guard), 'chat', 'world retained after command'),
             ('remove_script_guard', replace_once(source, script_guard, ''),
                 'script', 'world retained during script reload'),
+            ('remove_chat_cleanup_condition', replace_once(source,
+                'pSocket->m_bDeleteMe && m_iActiveProgressOperations == 0',
+                'pSocket->m_bDeleteMe'), 'timer', 'marked chat survives modal timer cleanup'),
+            ('return_before_timer_cleanup', replace_once(source, cleanup,
+                'if (m_iActiveProgressOperations != 0) return;\n' + cleanup),
+                'timer', 'timer work continues during an active operation'),
         ]
         for name, mutant, case, expected in mutants:
             exe = compile_source(name, mutant, ('-DNDEBUG',))

--- a/tests/check_world_callback_lifetime.py
+++ b/tests/check_world_callback_lifetime.py
@@ -1,0 +1,110 @@
+"""Test world retention in extracted chat and script-reload callbacks.
+
+Requires Python 3 and clang++. Uses ASan/UBSan and MFC/socket stubs.
+The fixture delivers close requests during callbacks and drains deferred closes
+at explicit safe points. It does not prove native modal-message dispatch.
+"""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+from cpp_blocks import block
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def replace_once(source, old, new):
+    if source.count(old) != 1:
+        raise ValueError(f'Expected one mutation target: {old!r}')
+    return source.replace(old, new)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--revision', help='Read production source from a Git revision.')
+    parser.add_argument('--output-dir', type=Path)
+    parser.add_argument('--skip-mutations', action='store_true')
+    args = parser.parse_args()
+    out = args.output_dir or Path(tempfile.mkdtemp(prefix='mushclient-world-callback-'))
+    out.mkdir(parents=True, exist_ok=True)
+
+    def read(path):
+        if args.revision:
+            return subprocess.check_output(
+                ['git', '-C', str(ROOT), 'show', f'{args.revision}:{path}'], text=True)
+        return (ROOT / path).read_text()
+
+    chat = read('chatsock.cpp')
+    doc = read('doc.cpp')
+    stdafx = read('stdafx.h')
+    functions = '\n\n'.join([
+        *(block(doc, signature) for signature in [
+            'void CMUSHclientDoc::OnCloseDocument()',
+            'void CMUSHclientDoc::BeginProgressOperation ()',
+            'void CMUSHclientDoc::EndProgressOperation ()']),
+        block(read('childfrm.cpp'), 'void CChildFrame::OnClose()'),
+        block(chat, 'void CChatSocket::OnReceive('),
+        block(chat, 'void CChatSocket::ProcessChatMessage ('),
+        block(chat, 'void CChatSocket::Process_Send_command'),
+        block(chat, 'void CChatSocket::Process_Message'),
+        block(read('scripting/methods/methods_commands.cpp'), 'long CMUSHclientDoc::Execute('),
+        block(read('scripting/scripting.cpp'), 'void CMUSHclientDoc::OnScriptFileChanged('),
+    ])
+    guards = '\n\n'.join([
+        block(stdafx, 'template <class T>\nclass CValueStateGuard') + ';',
+        block(stdafx, 'class CBoolStateGuard') + ';',
+        block(read('doc.h'), 'class CWorldDocumentOperationGuard') + ';',
+    ])
+    template = Path(__file__).with_name('world_callback_lifetime.cpp.in').read_text()
+    source = replace_once(replace_once(template, '@GUARDS@', guards), '@FUNCTIONS@', functions)
+
+    def compile_source(name, content, flags=()):
+        cpp = out / f'{name}.cpp'
+        cpp.write_text(content)
+        exe = out / name
+        subprocess.run(['clang++', '-std=c++17', '-O1', '-g',
+                        '-fsanitize=address,undefined', '-fno-sanitize-recover=all',
+                        '-fno-omit-frame-pointer',
+                        *flags, str(cpp), '-o', str(exe)], check=True)
+        return exe
+
+    evidence = {'production': [], 'mutations': []}
+    for name, flags in [('world_callback_lifetime', ()),
+                        ('world_callback_lifetime_ndebug', ('-DNDEBUG',))]:
+        exe = compile_source(name, source, flags)
+        result = subprocess.run([str(exe)], capture_output=True, text=True, timeout=30)
+        (out / f'{name}.log').write_text(result.stdout + result.stderr)
+        print(result.stdout + result.stderr, end='')
+        result.check_returncode()
+        evidence['production'].append({'name': name, 'exit_code': result.returncode})
+
+    if not args.skip_mutations:
+        chat_guard = '  CWorldDocumentOperationGuard operationGuard (m_pDoc);'
+        script_guard = '  CWorldDocumentOperationGuard operationGuard (this);'
+        inner_guard = '    CValueStateGuard<int> executionDepthGuard (m_pDoc->m_iExecutionDepth, 0);'
+        no_chat_guard = replace_once(source, chat_guard, '')
+        mutants = [
+            ('remove_chat_guard', no_chat_guard, 'chat', 'world retained during command'),
+            ('move_chat_guard_to_command', replace_once(no_chat_guard, inner_guard,
+                chat_guard + '\n' + inner_guard), 'chat', 'world retained after command'),
+            ('remove_script_guard', replace_once(source, script_guard, ''),
+                'script', 'world retained during script reload'),
+        ]
+        for name, mutant, case, expected in mutants:
+            exe = compile_source(name, mutant, ('-DNDEBUG',))
+            result = subprocess.run([str(exe), case], capture_output=True, text=True, timeout=30)
+            log = result.stdout + result.stderr
+            (out / f'{name}.log').write_text(log)
+            if result.returncode == 0 or expected not in log:
+                raise AssertionError(f'{name} did not fail at the expected check:\n{log}')
+            evidence['mutations'].append({'name': name, 'exit_code': result.returncode,
+                                          'expected_failure': expected})
+            print(f'PASS: {name} fails at {expected}')
+    (out / 'results.json').write_text(json.dumps(evidence, indent=2) + '\n')
+    print(f'Artifacts: {out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/cpp_blocks.py
+++ b/tests/cpp_blocks.py
@@ -1,0 +1,65 @@
+"""Extract C++ source blocks while skipping comments and literals."""
+import re
+
+
+_TOKEN = re.compile(r'//|/\*|R"|[\"\'{}]')
+
+
+def block(source, signature):
+    """Return a definition through its closing brace; raise ValueError on failure."""
+    start = source.find(signature)
+    if not signature or start < 0:
+        raise ValueError(f'Missing source signature: {signature}')
+    position = start
+    depth = 0
+    opened = False
+    while match := _TOKEN.search(source, position):
+        token = match.group()
+        position = match.end()
+        if token == '//':
+            end = source.find('\n', position)
+            while end >= 0 and source[position:end].rstrip('\r').endswith('\\'):
+                end = source.find('\n', end + 1)
+            position = len(source) if end < 0 else end + 1
+        elif token == '/*':
+            end = source.find('*/', position)
+            if end < 0:
+                raise ValueError(f'Unclosed block comment: {signature}')
+            position = end + 2
+        elif token == 'R"':
+            opening = source.find('(', position)
+            delimiter = source[position:opening]
+            if (opening < 0 or len(delimiter) > 16 or
+                    any(char.isspace() or char in '()\\' for char in delimiter)):
+                raise ValueError(f'Invalid raw string delimiter: {signature}')
+            closing = ')' + delimiter + '"'
+            end = source.find(closing, opening + 1)
+            if end < 0:
+                raise ValueError(f'Unclosed raw string: {signature}')
+            position = end + len(closing)
+        elif token in ('"', "'"):
+            while position < len(source):
+                char = source[position]
+                if char == token:
+                    position += 1
+                    break
+                if char in '\r\n':
+                    raise ValueError(f'Unclosed quoted literal: {signature}')
+                if char == '\\':
+                    position += 3 if source.startswith('\\\r\n', position) else 2
+                else:
+                    position += 1
+            else:
+                raise ValueError(f'Unclosed quoted literal: {signature}')
+        elif token == '{':
+            depth += 1
+            opened = True
+        else:
+            if not opened:
+                raise ValueError(f'Closing brace before source block: {signature}')
+            depth -= 1
+            if depth == 0:
+                return source[start:position]
+    if not opened:
+        raise ValueError(f'Missing opening brace: {signature}')
+    raise ValueError(f'Unclosed source block: {signature}')

--- a/tests/hostname_lookup.cpp.in
+++ b/tests/hostname_lookup.cpp.in
@@ -1,6 +1,5 @@
 // Platform substitutes for the extracted hostname code. Resolver requests retain
 // their buffer until cancellation or completion; a late write checks its lifetime.
-#include <cassert>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdint>
@@ -14,6 +13,13 @@
 #include <set>
 #include <string>
 #include <vector>
+[[noreturn]] static void fail(const char *condition, int line) {
+    std::fprintf(stderr, "CHECK failed at line %d: %s\n", line, condition);
+    std::exit(EXIT_FAILURE);
+}
+// These checks remain active when the runner compiles with NDEBUG.
+#define CHECK(condition) do { if (!(condition)) fail(#condition, __LINE__); } while (0)
+
 using BOOL = int;
 using LPCTSTR = const char *;
 using HANDLE = void *;
@@ -88,27 +94,28 @@ void *operator new[](size_t size) {
 void operator delete[](void *p) noexcept {
     if (!p) return;
     for (const auto &item: requests)
-        assert(!(item.second.pending && item.second.buffer==p) && "freed a pending resolver buffer");
-    assert(buffers.erase(p)==1); std::free(p);
+        CHECK(!(item.second.pending && item.second.buffer==p) && "freed a pending resolver buffer");
+    const size_t removed = buffers.erase(p);
+    CHECK(removed==1); std::free(p);
 }
 HANDLE WSAAsyncGetHostByName(int hwnd, int message, const char *, char *buffer, int size) {
-    assert(hwnd && message==WM_USER_HOST_NAME_RESOLVED && size==MAXGETHOSTSTRUCT);
-    assert(buffers.count(buffer)); ++starts;
+    CHECK(hwnd && message==WM_USER_HOST_NAME_RESOLVED && size==MAXGETHOSTSTRUCT);
+    CHECK(buffers.count(buffer)); ++starts;
     if (failStart) { lastError=WSAENETDOWN; return 0; }
     const HANDLE handle=reinterpret_cast<HANDLE>(nextHandle++);
-    assert(!requests.count(handle) || !requests.at(handle).pending);
+    CHECK(!requests.count(handle) || !requests.at(handle).pending);
     requests[handle]={buffer,true}; return handle;
 }
 int WSACancelAsyncRequest(HANDLE handle) {
     ++cancels;
     Request &r=requests.at(handle);
     if (!cancelError) { r.pending=false; return 0; }
-    if (cancelError==WSAEINVAL || cancelError==WSAEALREADY) assert(!r.pending);
+    if (cancelError==WSAEINVAL || cancelError==WSAEALREADY) CHECK(!r.pending);
     lastError=cancelError; return SOCKET_ERROR;
 }
 void complete(HANDLE handle, unsigned long address) {
     Request &r=requests.at(handle);
-    assert(r.pending && buffers.count(r.buffer));
+    CHECK(r.pending && buffers.count(r.buffer));
     // Actual asynchronous result write, after the replacement attempt returned.
     auto *value=reinterpret_cast<in_addr *>(r.buffer+sizeof(hostent));
     value->s_addr=address;
@@ -146,7 +153,7 @@ struct CMUSHclientDoc {
     void UpdateAllViews(void *) {}
     void Note(const CString &s) { UMessageBox(s); }
     void InitiateConnection() {
-        assert(m_pSocket);
+        CHECK(m_pSocket);
         ++connections;
         m_iConnectPhase=(m_iSocksProcessing==eProxyServerNone ? eConnectConnectingToMud : eConnectConnectingToProxy);
     }
@@ -154,7 +161,7 @@ struct CMUSHclientDoc {
     void HostNameResolved(WPARAM,LPARAM); void OnConnectionConnect(); long Connect();
     ~CMUSHclientDoc() {
         // Test cleanup must not conceal an active request or leaked buffer.
-        assert(!m_hNameLookup && !m_pGetHostStruct);
+        CHECK(!m_hNameLookup && !m_pGetHostStruct);
         delete m_pSocket;
     }
 };
@@ -170,8 +177,8 @@ void finish(CMUSHclientDoc &doc, unsigned long address=42) {
     auto event=capture(doc); complete(event.handle,address); dispatch(&doc,event);
 }
 void reset() {
-    assert(buffers.empty());
-    for (auto &item: requests) assert(!item.second.pending);
+    CHECK(buffers.empty());
+    for (auto &item: requests) CHECK(!item.second.pending);
     requests.clear(); reports.clear();
     failAllocation=failStart=false; starts=cancels=cancelError=socketCreates=socketDeletes=0;
     nextHandle=1; Frame.hwnd=1; App.m_bAutoConnectWorlds=true; App.m_bUpdateActivity=false;
@@ -179,107 +186,107 @@ void reset() {
 void worldOpen(bool proxy) {
     reset(); CMUSHclientDoc doc;
     if (proxy) { doc.m_server="192.0.2.1"; doc.m_iSocksProcessing=eProxyServerSocks5; }
-    doc.onOpen=[&] { assert(doc.Connect()==eOK); };
+    doc.onOpen=[&] { CHECK(doc.Connect()==eOK); };
     doc.OpenSession();
-    assert(starts==1 && cancels==0 && socketCreates==1 && socketDeletes==0);
-    assert(doc.m_iConnectionAttemptNumber==1 && doc.m_iNameLookupGeneration==1);
-    assert(doc.m_iConnectPhase==(proxy ? eConnectProxyNameLookup : eConnectMudNameLookup));
-    finish(doc); assert(doc.connections==1);
+    CHECK(starts==1 && cancels==0 && socketCreates==1 && socketDeletes==0);
+    CHECK(doc.m_iConnectionAttemptNumber==1 && doc.m_iNameLookupGeneration==1);
+    CHECK(doc.m_iConnectPhase==(proxy ? eConnectProxyNameLookup : eConnectMudNameLookup));
+    finish(doc); CHECK(doc.connections==1);
 }
 void repeatConnect(bool proxy) {
     reset(); CMUSHclientDoc doc;
     if (proxy) { doc.m_server="192.0.2.1"; doc.m_iSocksProcessing=eProxyServerSocks5; }
-    assert(doc.ConnectSocket());
+    CHECK(doc.ConnectSocket());
     auto event=capture(doc); auto *buffer=doc.m_pGetHostStruct; auto *socket=doc.m_pSocket;
     int phase=doc.m_iConnectPhase;
-    assert(doc.ConnectSocket());
-    assert(doc.m_hNameLookup==event.handle && doc.m_iNameLookupGeneration==event.m_iGeneration);
-    assert(doc.m_pGetHostStruct==buffer && doc.m_pSocket==socket && doc.m_iConnectPhase==phase);
-    assert(starts==1 && socketCreates==1 && socketDeletes==0 && doc.m_iConnectionAttemptNumber==1);
-    finish(doc); assert(doc.connections==1);
+    CHECK(doc.ConnectSocket());
+    CHECK(doc.m_hNameLookup==event.handle && doc.m_iNameLookupGeneration==event.m_iGeneration);
+    CHECK(doc.m_pGetHostStruct==buffer && doc.m_pSocket==socket && doc.m_iConnectPhase==phase);
+    CHECK(starts==1 && socketCreates==1 && socketDeletes==0 && doc.m_iConnectionAttemptNumber==1);
+    finish(doc); CHECK(doc.connections==1);
 }
 void cancellationFailure(int error, bool proxy) {
     reset(); CMUSHclientDoc doc;
     if (proxy) { doc.m_server="192.0.2.1"; doc.m_iSocksProcessing=eProxyServerSocks5; }
-    assert(doc.ConnectSocket());
+    CHECK(doc.ConnectSocket());
     const auto event=capture(doc); auto *buffer=doc.m_pGetHostStruct; const int phase=doc.m_iConnectPhase;
     cancelError=error;
-    assert(doc.LookupHostName("replacement.example"));
-    assert(cancels==1 && starts==1 && buffers.size()==1);
-    assert(doc.m_hNameLookup==event.handle && doc.m_pGetHostStruct==buffer);
-    assert(doc.m_iNameLookupGeneration==event.m_iGeneration && doc.m_iConnectPhase==phase);
-    assert(reports.size()==1 && reports[0].find(std::to_string(error))!=std::string::npos);
+    CHECK(doc.LookupHostName("replacement.example"));
+    CHECK(cancels==1 && starts==1 && buffers.size()==1);
+    CHECK(doc.m_hNameLookup==event.handle && doc.m_pGetHostStruct==buffer);
+    CHECK(doc.m_iNameLookupGeneration==event.m_iGeneration && doc.m_iConnectPhase==phase);
+    CHECK(reports.size()==1 && reports[0].find(std::to_string(error))!=std::string::npos);
     complete(event.handle,99); dispatch(&doc,event);
-    assert((proxy ? doc.m_ProxyAddr : doc.m_sockAddr).sin_addr.s_addr==99);
-    assert(doc.connections==1 && buffers.empty());
+    CHECK((proxy ? doc.m_ProxyAddr : doc.m_sockAddr).sin_addr.s_addr==99);
+    CHECK(doc.connections==1 && buffers.empty());
 }
 void replacement(int error, bool reuseHandle) {
-    reset(); CMUSHclientDoc doc; assert(doc.ConnectSocket());
+    reset(); CMUSHclientDoc doc; CHECK(doc.ConnectSocket());
     const auto old=capture(doc); auto *buffer=doc.m_pGetHostStruct;
     if (error) complete(old.handle,11); // complete the request before cancellation
     cancelError=error;
     if (reuseHandle) nextHandle=reinterpret_cast<uintptr_t>(old.handle);
-    assert(!doc.LookupHostName("replacement.example"));
-    assert(cancels==1 && starts==2 && doc.m_iNameLookupGeneration==old.m_iGeneration+1);
-    assert(doc.m_pGetHostStruct!=buffer && buffers.size()==1 && reports.empty());
+    CHECK(!doc.LookupHostName("replacement.example"));
+    CHECK(cancels==1 && starts==2 && doc.m_iNameLookupGeneration==old.m_iGeneration+1);
+    CHECK(doc.m_pGetHostStruct!=buffer && buffers.size()==1 && reports.empty());
     // This event already carries a saved generation for deferred dispatch.
     // A raw Win32 message received after handle reuse is outside this fixture.
     dispatch(&doc,old);
-    assert(doc.connections==0 && doc.m_hNameLookup && doc.m_pGetHostStruct);
-    finish(doc,22); assert(doc.connections==1 && doc.m_sockAddr.sin_addr.s_addr==22);
+    CHECK(doc.connections==0 && doc.m_hNameLookup && doc.m_pGetHostStruct);
+    finish(doc,22); CHECK(doc.connections==1 && doc.m_sockAddr.sin_addr.s_addr==22);
 }
 void allocationFailure(bool pending) {
     reset(); CMUSHclientDoc doc;
-    if (pending) assert(doc.ConnectSocket());
+    if (pending) CHECK(doc.ConnectSocket());
     const auto old=capture(doc); auto *buffer=doc.m_pGetHostStruct;
     failAllocation=true; bool threw=false;
     try {
         if (pending) doc.LookupHostName("replacement.example");
         else doc.ConnectSocket();
     } catch (const std::bad_alloc &) { threw=true; }
-    assert(threw && !failAllocation && cancels==0);
-    assert(doc.m_hNameLookup==old.handle && doc.m_pGetHostStruct==buffer);
-    assert(doc.m_iNameLookupGeneration==old.m_iGeneration);
-    if (pending) { assert(doc.m_iConnectPhase==eConnectMudNameLookup); finish(doc); }
+    CHECK(threw && !failAllocation && cancels==0);
+    CHECK(doc.m_hNameLookup==old.handle && doc.m_pGetHostStruct==buffer);
+    CHECK(doc.m_iNameLookupGeneration==old.m_iGeneration);
+    if (pending) { CHECK(doc.m_iConnectPhase==eConnectMudNameLookup); finish(doc); }
     else {
-        assert(starts==0 && doc.m_iConnectPhase==eConnectNotConnected && App.m_bUpdateActivity);
-        assert(doc.ConnectSocket()); finish(doc); // retry remains available
+        CHECK(starts==0 && doc.m_iConnectPhase==eConnectNotConnected && App.m_bUpdateActivity);
+        CHECK(doc.ConnectSocket()); finish(doc); // retry remains available
     }
 }
 void startupFailure(bool window) {
     reset(); CMUSHclientDoc doc;
     Frame.hwnd=window ? 1 : 0; failStart=window;
-    assert(!doc.ConnectSocket());
-    assert(!doc.m_hNameLookup && !doc.m_pGetHostStruct && buffers.empty());
-    assert(doc.m_iConnectPhase==eConnectNotConnected && reports.size()==1);
+    CHECK(!doc.ConnectSocket());
+    CHECK(!doc.m_hNameLookup && !doc.m_pGetHostStruct && buffers.empty());
+    CHECK(doc.m_iConnectPhase==eConnectNotConnected && reports.size()==1);
 }
 void completedWithoutWindow() {
-    reset(); CMUSHclientDoc doc; assert(doc.ConnectSocket());
+    reset(); CMUSHclientDoc doc; CHECK(doc.ConnectSocket());
     const auto old=capture(doc); complete(old.handle,11);
     cancelError=WSAEALREADY; Frame.hwnd=0;
-    assert(doc.LookupHostName("replacement.example"));
-    assert(!doc.m_hNameLookup && !doc.m_pGetHostStruct && buffers.empty());
-    dispatch(&doc,old); assert(doc.connections==0 && reports.size()==1);
+    CHECK(doc.LookupHostName("replacement.example"));
+    CHECK(!doc.m_hNameLookup && !doc.m_pGetHostStruct && buffers.empty());
+    dispatch(&doc,old); CHECK(doc.connections==0 && reports.size()==1);
 }
 void mudThenProxy() {
     reset(); CMUSHclientDoc doc; doc.m_iSocksProcessing=eProxyServerSocks5;
-    assert(doc.ConnectSocket()); finish(doc,11);
-    assert(starts==2 && cancels==0 && doc.m_iNameLookupGeneration==2);
-    assert(doc.m_iConnectPhase==eConnectProxyNameLookup && doc.connections==0);
+    CHECK(doc.ConnectSocket()); finish(doc,11);
+    CHECK(starts==2 && cancels==0 && doc.m_iNameLookupGeneration==2);
+    CHECK(doc.m_iConnectPhase==eConnectProxyNameLookup && doc.connections==0);
     finish(doc,22);
-    assert(doc.connections==1 && doc.m_sockAddr.sin_addr.s_addr==11 && doc.m_ProxyAddr.sin_addr.s_addr==22);
+    CHECK(doc.connections==1 && doc.m_sockAddr.sin_addr.s_addr==11 && doc.m_ProxyAddr.sin_addr.s_addr==22);
 }
 void openPhaseAndOptions() {
     reset();
     for (int phase: {eConnectConnectingToMud,eConnectConnectingToProxy,eConnectConnectedToMud}) {
         CMUSHclientDoc doc; doc.onOpen=[&] { doc.m_iConnectPhase=phase; };
-        doc.OpenSession(); assert(starts==0 && socketCreates==0);
+        doc.OpenSession(); CHECK(starts==0 && socketCreates==0);
     }
-    { CMUSHclientDoc doc; assert(doc.OpenSession()); finish(doc); }
+    { CMUSHclientDoc doc; CHECK(doc.OpenSession()); finish(doc); }
     App.m_bAutoConnectWorlds=false;
-    { CMUSHclientDoc doc; assert(!doc.OpenSession()); assert(starts==1); }
-    { CMUSHclientDoc doc; doc.onOpen=[&] { assert(doc.Connect()==eOK); };
-      doc.OpenSession(); assert(starts==2); finish(doc); }
+    { CMUSHclientDoc doc; CHECK(!doc.OpenSession()); CHECK(starts==1); }
+    { CMUSHclientDoc doc; doc.onOpen=[&] { CHECK(doc.Connect()==eOK); };
+      doc.OpenSession(); CHECK(starts==2); finish(doc); }
 }
 int main() {
     worldOpen(false); worldOpen(true);

--- a/tests/hostname_lookup.cpp.in
+++ b/tests/hostname_lookup.cpp.in
@@ -1,0 +1,301 @@
+// Platform substitutes for the extracted hostname code. Resolver requests retain
+// their buffer until cancellation or completion; a late write checks its lifetime.
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <new>
+#include <set>
+#include <string>
+#include <vector>
+using BOOL = int;
+using LPCTSTR = const char *;
+using HANDLE = void *;
+using WPARAM = uintptr_t;
+using LPARAM = long;
+using DWORD = unsigned long;
+using u_short = unsigned short;
+constexpr int TRUE=1, FALSE=0, AF_INET=2, SOCK_STREAM=1;
+constexpr int FD_READ=1, FD_WRITE=2, FD_CONNECT=4, FD_CLOSE=8;
+constexpr int SOCKET_ERROR=-1, WSAEINVAL=10022, WSAEALREADY=10037;
+constexpr int WSAEINPROGRESS=10036, WSAENETDOWN=10050, WSANOTINITIALISED=10093;
+constexpr int MAXGETHOSTSTRUCT=1024, WM_USER_HOST_NAME_RESOLVED=1234;
+constexpr int SIO_KEEPALIVE_VALS=1, eWorldAction=0, eOK=0, eWorldOpen=1;
+constexpr unsigned long INADDR_NONE=0xffffffffUL;
+enum {eConnectNotConnected, eConnectMudNameLookup, eConnectProxyNameLookup,
+      eConnectConnectingToMud, eConnectConnectingToProxy, eConnectConnectedToMud};
+enum {eProxyServerNone, eProxyServerSocks4, eProxyServerSocks5};
+struct CString : std::string {
+    using std::string::string;
+    CString(const std::string &s) : std::string(s) {}
+    bool IsEmpty() const { return empty(); }
+    operator const char *() const { return c_str(); }
+};
+CString TFormat(const char *format, ...) {
+    char text[2048]; va_list args; va_start(args, format);
+    vsnprintf(text, sizeof text, format, args); va_end(args); return text;
+}
+std::vector<std::string> reports;
+void UMessageBox(const CString &s) { reports.push_back(s); }
+void TMessageBox(const char *s) { UMessageBox(s); }
+const char *GetSocketError(int) { return "injected socket error"; }
+#define TRACE(...) ((void)0)
+struct DISPPARAMS { void *a; void *b; int c; int d; };
+struct in_addr { unsigned long s_addr; };
+using LPIN_ADDR = in_addr *;
+struct sockaddr_in { int sin_family=0; unsigned short sin_port=0; in_addr sin_addr{INADDR_NONE}; };
+struct hostent { char *h_addr; };
+struct tcp_keepalive { int a,b,c; };
+#undef htons
+unsigned short htons(unsigned short n) { return n; }
+unsigned long inet_addr(const char *s) {
+    if (std::strcmp(s, "192.0.2.1") == 0) return 0xc0000201;
+    return INADDR_NONE;
+}
+void WSAIoctl(int, int, void *, size_t, void *, int, DWORD *, void *, void *) {}
+int lastError=0;
+int GetLastError() { return lastError; }
+int WSAGetLastError() { return lastError; }
+int WSAGETASYNCERROR(LPARAM value) { return static_cast<int>(value); }
+struct {
+    bool m_bAutoConnectWorlds=true, m_bUpdateActivity=false;
+    bool m_bNotifyIfCannotConnect=true, m_bErrorNotificationToOutputWindow=true;
+} App;
+struct {
+    int hwnd=1;
+    int GetSafeHwnd() { return hwnd; }
+    void SetStatusMessageNow(const CString &) {}
+} Frame;
+
+struct Request { char *buffer; bool pending; };
+std::map<HANDLE, Request> requests;
+std::set<void *> buffers;
+bool failAllocation=false, failStart=false;
+int starts=0, cancels=0, cancelError=0, socketCreates=0, socketDeletes=0;
+uintptr_t nextHandle=1;
+void *operator new[](size_t size) {
+    if (failAllocation) { failAllocation=false; throw std::bad_alloc(); }
+    void *p=std::malloc(size);
+    if (!p) throw std::bad_alloc();
+    buffers.insert(p); return p;
+}
+void operator delete[](void *p) noexcept {
+    if (!p) return;
+    for (const auto &item: requests)
+        assert(!(item.second.pending && item.second.buffer==p) && "freed a pending resolver buffer");
+    assert(buffers.erase(p)==1); std::free(p);
+}
+HANDLE WSAAsyncGetHostByName(int hwnd, int message, const char *, char *buffer, int size) {
+    assert(hwnd && message==WM_USER_HOST_NAME_RESOLVED && size==MAXGETHOSTSTRUCT);
+    assert(buffers.count(buffer)); ++starts;
+    if (failStart) { lastError=WSAENETDOWN; return 0; }
+    const HANDLE handle=reinterpret_cast<HANDLE>(nextHandle++);
+    assert(!requests.count(handle) || !requests.at(handle).pending);
+    requests[handle]={buffer,true}; return handle;
+}
+int WSACancelAsyncRequest(HANDLE handle) {
+    ++cancels;
+    Request &r=requests.at(handle);
+    if (!cancelError) { r.pending=false; return 0; }
+    if (cancelError==WSAEINVAL || cancelError==WSAEALREADY) assert(!r.pending);
+    lastError=cancelError; return SOCKET_ERROR;
+}
+void complete(HANDLE handle, unsigned long address) {
+    Request &r=requests.at(handle);
+    assert(r.pending && buffers.count(r.buffer));
+    // Actual asynchronous result write, after the replacement attempt returned.
+    auto *value=reinterpret_cast<in_addr *>(r.buffer+sizeof(hostent));
+    value->s_addr=address;
+    reinterpret_cast<hostent *>(r.buffer)->h_addr=reinterpret_cast<char *>(value);
+    r.pending=false;
+}
+struct CWorldSocket {
+    int m_hSocket=1;
+    template<class T> explicit CWorldSocket(T *) { ++socketCreates; }
+    ~CWorldSocket() { ++socketDeletes; }
+    BOOL Create(int,int,int,void *) { return TRUE; }
+    BOOL AsyncSelect() { return TRUE; }
+};
+struct CMUSHclientDoc {
+    HANDLE m_hNameLookup=0;
+    char *m_pGetHostStruct=nullptr;
+    unsigned long m_iNameLookupGeneration=0, m_iConnectionAttemptNumber=0;
+    int m_iConnectPhase=eConnectNotConnected, m_iSocksProcessing=eProxyServerNone;
+    CString m_server="mud.example", m_strProxyServerName="proxy.example", m_mush_name="Test world";
+    int m_port=4000, m_iProxyServerPort=1080;
+    bool m_bEnableScripts=true; void *m_ScriptEngine=nullptr;
+    CString m_strWorldOpen="OnWorldOpen"; int m_dispidWorldOpen=1;
+    std::function<void()> onOpen;
+    bool m_bEnableAutoSay=true, m_bDisconnectOK=false, m_bCompress=false;
+    bool m_bSupports_MCCP_2=false, m_bNoEcho=false, m_bSendKeepAlives=false;
+    int m_iMCCP_type=0, m_iInputPacketCount=0, m_iOutputPacketCount=0, m_iUTF8ErrorCount=0;
+    sockaddr_in m_sockAddr, m_ProxyAddr;
+    CWorldSocket *m_pSocket=nullptr;
+    int connections=0;
+    void CreateScriptEngine() { m_ScriptEngine=this; }
+    bool SeeIfHandlerCanExecute(const CString &) { return true; }
+    void ExecuteScript(int,const CString &,int,const char *,const char *,DISPPARAMS &,long &) {
+        if (onOpen) onOpen();
+    }
+    void UpdateAllViews(void *) {}
+    void Note(const CString &s) { UMessageBox(s); }
+    void InitiateConnection() {
+        assert(m_pSocket);
+        ++connections;
+        m_iConnectPhase=(m_iSocksProcessing==eProxyServerNone ? eConnectConnectingToMud : eConnectConnectingToProxy);
+    }
+    BOOL OpenSession(); BOOL ConnectSocket(); bool LookupHostName(LPCTSTR);
+    void HostNameResolved(WPARAM,LPARAM); void OnConnectionConnect(); long Connect();
+    ~CMUSHclientDoc() {
+        // Test cleanup must not conceal an active request or leaked buffer.
+        assert(!m_hNameLookup && !m_pGetHostStruct);
+        delete m_pSocket;
+    }
+};
+@FUNCTIONS@
+struct Completion { HANDLE handle; unsigned long m_iGeneration; };
+Completion capture(const CMUSHclientDoc &doc) { return {doc.m_hNameLookup,doc.m_iNameLookupGeneration}; }
+void dispatch(CMUSHclientDoc *pDoc, Completion deferred, LPARAM error=0) {
+    HANDLE hLookup=deferred.handle;
+    struct { LPARAM lParam; } msg{error};
+    @DISPATCH@
+}
+void finish(CMUSHclientDoc &doc, unsigned long address=42) {
+    auto event=capture(doc); complete(event.handle,address); dispatch(&doc,event);
+}
+void reset() {
+    assert(buffers.empty());
+    for (auto &item: requests) assert(!item.second.pending);
+    requests.clear(); reports.clear();
+    failAllocation=failStart=false; starts=cancels=cancelError=socketCreates=socketDeletes=0;
+    nextHandle=1; Frame.hwnd=1; App.m_bAutoConnectWorlds=true; App.m_bUpdateActivity=false;
+}
+void worldOpen(bool proxy) {
+    reset(); CMUSHclientDoc doc;
+    if (proxy) { doc.m_server="192.0.2.1"; doc.m_iSocksProcessing=eProxyServerSocks5; }
+    doc.onOpen=[&] { assert(doc.Connect()==eOK); };
+    doc.OpenSession();
+    assert(starts==1 && cancels==0 && socketCreates==1 && socketDeletes==0);
+    assert(doc.m_iConnectionAttemptNumber==1 && doc.m_iNameLookupGeneration==1);
+    assert(doc.m_iConnectPhase==(proxy ? eConnectProxyNameLookup : eConnectMudNameLookup));
+    finish(doc); assert(doc.connections==1);
+}
+void repeatConnect(bool proxy) {
+    reset(); CMUSHclientDoc doc;
+    if (proxy) { doc.m_server="192.0.2.1"; doc.m_iSocksProcessing=eProxyServerSocks5; }
+    assert(doc.ConnectSocket());
+    auto event=capture(doc); auto *buffer=doc.m_pGetHostStruct; auto *socket=doc.m_pSocket;
+    int phase=doc.m_iConnectPhase;
+    assert(doc.ConnectSocket());
+    assert(doc.m_hNameLookup==event.handle && doc.m_iNameLookupGeneration==event.m_iGeneration);
+    assert(doc.m_pGetHostStruct==buffer && doc.m_pSocket==socket && doc.m_iConnectPhase==phase);
+    assert(starts==1 && socketCreates==1 && socketDeletes==0 && doc.m_iConnectionAttemptNumber==1);
+    finish(doc); assert(doc.connections==1);
+}
+void cancellationFailure(int error, bool proxy) {
+    reset(); CMUSHclientDoc doc;
+    if (proxy) { doc.m_server="192.0.2.1"; doc.m_iSocksProcessing=eProxyServerSocks5; }
+    assert(doc.ConnectSocket());
+    const auto event=capture(doc); auto *buffer=doc.m_pGetHostStruct; const int phase=doc.m_iConnectPhase;
+    cancelError=error;
+    assert(doc.LookupHostName("replacement.example"));
+    assert(cancels==1 && starts==1 && buffers.size()==1);
+    assert(doc.m_hNameLookup==event.handle && doc.m_pGetHostStruct==buffer);
+    assert(doc.m_iNameLookupGeneration==event.m_iGeneration && doc.m_iConnectPhase==phase);
+    assert(reports.size()==1 && reports[0].find(std::to_string(error))!=std::string::npos);
+    complete(event.handle,99); dispatch(&doc,event);
+    assert((proxy ? doc.m_ProxyAddr : doc.m_sockAddr).sin_addr.s_addr==99);
+    assert(doc.connections==1 && buffers.empty());
+}
+void replacement(int error, bool reuseHandle) {
+    reset(); CMUSHclientDoc doc; assert(doc.ConnectSocket());
+    const auto old=capture(doc); auto *buffer=doc.m_pGetHostStruct;
+    if (error) complete(old.handle,11); // complete the request before cancellation
+    cancelError=error;
+    if (reuseHandle) nextHandle=reinterpret_cast<uintptr_t>(old.handle);
+    assert(!doc.LookupHostName("replacement.example"));
+    assert(cancels==1 && starts==2 && doc.m_iNameLookupGeneration==old.m_iGeneration+1);
+    assert(doc.m_pGetHostStruct!=buffer && buffers.size()==1 && reports.empty());
+    // This event already carries a saved generation for deferred dispatch.
+    // A raw Win32 message received after handle reuse is outside this fixture.
+    dispatch(&doc,old);
+    assert(doc.connections==0 && doc.m_hNameLookup && doc.m_pGetHostStruct);
+    finish(doc,22); assert(doc.connections==1 && doc.m_sockAddr.sin_addr.s_addr==22);
+}
+void allocationFailure(bool pending) {
+    reset(); CMUSHclientDoc doc;
+    if (pending) assert(doc.ConnectSocket());
+    const auto old=capture(doc); auto *buffer=doc.m_pGetHostStruct;
+    failAllocation=true; bool threw=false;
+    try {
+        if (pending) doc.LookupHostName("replacement.example");
+        else doc.ConnectSocket();
+    } catch (const std::bad_alloc &) { threw=true; }
+    assert(threw && !failAllocation && cancels==0);
+    assert(doc.m_hNameLookup==old.handle && doc.m_pGetHostStruct==buffer);
+    assert(doc.m_iNameLookupGeneration==old.m_iGeneration);
+    if (pending) { assert(doc.m_iConnectPhase==eConnectMudNameLookup); finish(doc); }
+    else {
+        assert(starts==0 && doc.m_iConnectPhase==eConnectNotConnected && App.m_bUpdateActivity);
+        assert(doc.ConnectSocket()); finish(doc); // retry remains available
+    }
+}
+void startupFailure(bool window) {
+    reset(); CMUSHclientDoc doc;
+    Frame.hwnd=window ? 1 : 0; failStart=window;
+    assert(!doc.ConnectSocket());
+    assert(!doc.m_hNameLookup && !doc.m_pGetHostStruct && buffers.empty());
+    assert(doc.m_iConnectPhase==eConnectNotConnected && reports.size()==1);
+}
+void completedWithoutWindow() {
+    reset(); CMUSHclientDoc doc; assert(doc.ConnectSocket());
+    const auto old=capture(doc); complete(old.handle,11);
+    cancelError=WSAEALREADY; Frame.hwnd=0;
+    assert(doc.LookupHostName("replacement.example"));
+    assert(!doc.m_hNameLookup && !doc.m_pGetHostStruct && buffers.empty());
+    dispatch(&doc,old); assert(doc.connections==0 && reports.size()==1);
+}
+void mudThenProxy() {
+    reset(); CMUSHclientDoc doc; doc.m_iSocksProcessing=eProxyServerSocks5;
+    assert(doc.ConnectSocket()); finish(doc,11);
+    assert(starts==2 && cancels==0 && doc.m_iNameLookupGeneration==2);
+    assert(doc.m_iConnectPhase==eConnectProxyNameLookup && doc.connections==0);
+    finish(doc,22);
+    assert(doc.connections==1 && doc.m_sockAddr.sin_addr.s_addr==11 && doc.m_ProxyAddr.sin_addr.s_addr==22);
+}
+void openPhaseAndOptions() {
+    reset();
+    for (int phase: {eConnectConnectingToMud,eConnectConnectingToProxy,eConnectConnectedToMud}) {
+        CMUSHclientDoc doc; doc.onOpen=[&] { doc.m_iConnectPhase=phase; };
+        doc.OpenSession(); assert(starts==0 && socketCreates==0);
+    }
+    { CMUSHclientDoc doc; assert(doc.OpenSession()); finish(doc); }
+    App.m_bAutoConnectWorlds=false;
+    { CMUSHclientDoc doc; assert(!doc.OpenSession()); assert(starts==1); }
+    { CMUSHclientDoc doc; doc.onOpen=[&] { assert(doc.Connect()==eOK); };
+      doc.OpenSession(); assert(starts==2); finish(doc); }
+}
+int main() {
+    worldOpen(false); worldOpen(true);
+    std::cout << "PASS: world-open Connect and auto-connect, MUD and proxy\n";
+    repeatConnect(false); repeatConnect(true);
+    std::cout << "PASS: pending ConnectSocket preserves socket, phase, request, and generation\n";
+    for (int error: {WSAEINPROGRESS,WSAENETDOWN,WSANOTINITIALISED,12345})
+        for (bool proxy: {false,true}) cancellationFailure(error,proxy);
+    std::cout << "PASS: cancellation failures retain writable buffers and deliver MUD/proxy completion\n";
+    for (int error: {0,WSAEINVAL,WSAEALREADY})
+        for (bool reuse: {false,true}) replacement(error,reuse);
+    std::cout << "PASS: cancellation and completed requests retire safely; stale deferred generations are rejected\n";
+    allocationFailure(false); allocationFailure(true);
+    std::cout << "PASS: allocation exceptions propagate; initial retry and pending completion work\n";
+    startupFailure(false); startupFailure(true); completedWithoutWindow();
+    std::cout << "PASS: startup failures return failure and release buffers without stale handles\n";
+    mudThenProxy(); openPhaseAndOptions(); reset();
+    std::cout << "PASS: MUD-to-proxy handoff and world-open phase/auto-connect options\n";
+}

--- a/tests/lua_progress_errors.cpp.in
+++ b/tests/lua_progress_errors.cpp.in
@@ -1,0 +1,277 @@
+// Real Lua C protected calls; only MFC dialog/exception behavior is substituted.
+// This finalizer is a fixture helper, not the production close implementation.
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <new>
+#include <string>
+extern "C" {
+#include "lua.h"
+#include "lauxlib.h"
+#include "lualib.h"
+}
+using std::string;
+using BOOL = int;
+using UINT = unsigned int;
+const BOOL TRUE = 1;
+const BOOL FALSE = 0;
+
+[[noreturn]] static void fail(const char *condition, int line) {
+  std::fprintf(stderr, "CHECK failed at line %d: %s\n", line, condition);
+  std::exit(EXIT_FAILURE);
+}
+// These checks remain active when the runner compiles with NDEBUG.
+#define CHECK(condition) do { if (!(condition)) fail(#condition, __LINE__); } while (0)
+
+static char longTitle[65537];
+static std::size_t cppLive;
+static bool watchTitleAllocation;
+static bool sawTitleAllocation;
+
+// Observe real std::string allocations. Lua uses its real C allocator, so its
+// retained strings do not affect this count. No STL objects are substituted.
+void *operator new(std::size_t size) {
+  void *p = std::malloc(size ? size : 1);
+  if (!p) throw std::bad_alloc();
+  ++cppLive;
+  if (watchTitleAllocation && size >= sizeof longTitle) sawTitleAllocation = true;
+  return p;
+}
+void operator delete(void *p) noexcept {
+  if (p) {
+    CHECK(cppLive > 0);
+    --cppLive;
+    std::free(p);
+  }
+}
+void *operator new[](std::size_t size) { return ::operator new(size); }
+void operator delete[](void *p) noexcept { ::operator delete(p); }
+#if defined(__cpp_sized_deallocation)
+void operator delete(void *p, std::size_t) noexcept { ::operator delete(p); }
+void operator delete[](void *p, std::size_t) noexcept { ::operator delete(p); }
+#endif
+
+enum class Fault { success, create_false, create_exception, title_exception,
+                   constructor_exception, message_failure, message_empty };
+static Fault fault;
+static const char *caseName;
+static const char *exceptionMessage;
+static lua_State *activeLua;
+struct CProgressDlg;
+static CProgressDlg **lastUserdata;
+static std::size_t heapBefore;
+static struct {
+  int constructorCalls, constructed, destroyed, liveDialogs;
+  int memberConstructed, memberDestroyed;
+  int createCalls, titleCalls;
+  int exceptionConstructed, exceptionDeleted, exceptionDestroyed, messageCalls;
+  int gcCalls, nullGcCalls;
+} counts;
+
+struct CException {
+  char message[160];
+  CException() {
+    ++counts.exceptionConstructed;
+    std::snprintf(message, sizeof message, "%s", exceptionMessage);
+  }
+  virtual ~CException() {
+    CHECK(counts.exceptionDeleted == counts.exceptionDestroyed + 1);
+    ++counts.exceptionDestroyed;
+    std::memset(message, '#', sizeof message);
+  }
+  virtual BOOL GetErrorMessage(char *buffer, UINT size, UINT * = nullptr) const {
+    ++counts.messageCalls;
+    CHECK(size > 0);
+    if (fault == Fault::message_failure) {
+      std::snprintf(buffer, size, "%s", "discard this partial error message");
+      return FALSE;
+    }
+    std::snprintf(buffer, size, "%s", fault == Fault::message_empty ? "" : message);
+    return TRUE;
+  }
+  void Delete() {
+    ++counts.exceptionDeleted;
+    CHECK(counts.exceptionDeleted == counts.exceptionConstructed);
+    delete this;
+  }
+};
+struct CResourceException : CException {};
+[[noreturn]] static void AfxThrowResourceException() { throw new CResourceException; }
+
+struct DialogMember {
+  DialogMember() { ++counts.memberConstructed; }
+  ~DialogMember() { ++counts.memberDestroyed; }
+};
+struct CProgressDlg {
+  DialogMember member;  // Also checks unwinding when the dialog constructor fails.
+  CProgressDlg() {
+    ++counts.constructorCalls;
+    CHECK(lua_type(activeLua, -1) == LUA_TUSERDATA);
+    CHECK(lua_objlen(activeLua, -1) == sizeof(CProgressDlg *));
+    lastUserdata = static_cast<CProgressDlg **>(lua_touserdata(activeLua, -1));
+    CHECK(lastUserdata && *lastUserdata == nullptr);
+    if (fault == Fault::constructor_exception) throw new CException;
+    ++counts.constructed;
+    ++counts.liveDialogs;
+  }
+  ~CProgressDlg() {
+    ++counts.destroyed;
+    --counts.liveDialogs;
+  }
+  BOOL Create() {
+    ++counts.createCalls;
+    CHECK(*lastUserdata == nullptr);
+    if (fault == Fault::create_exception || fault == Fault::message_failure ||
+        fault == Fault::message_empty) throw new CException;
+    return fault == Fault::create_false ? FALSE : TRUE;
+  }
+  void SetWindowText(const char *title) {
+    ++counts.titleCalls;
+    CHECK(*lastUserdata == nullptr);
+    CHECK(std::strcmp(title, longTitle) == 0);
+    if (fault == Fault::title_exception) throw new CException;
+  }
+};
+const char progress_dlg_handle[] = "mushclient.progress_dialog_handle";
+
+@LPROGRESS_NEW@
+
+static int collectDialog(lua_State *L) {
+  auto ud = static_cast<CProgressDlg **>(luaL_checkudata(L, 1, progress_dlg_handle));
+  ++counts.gcCalls;
+  if (!*ud) ++counts.nullGcCalls;
+  delete *ud;
+  *ud = nullptr;
+  return 0;
+}
+
+static void attempt(lua_State *L, Fault requested) {
+  counts = {};
+  fault = requested;
+  lastUserdata = nullptr;
+  heapBefore = cppLive;
+  sawTitleAllocation = false;
+  CHECK(lua_gettop(L) == 0);
+  CHECK(luaL_loadstring(L, "return pcall(progress.new, test_title)") == 0);
+  watchTitleAllocation = true;
+  int status = lua_pcall(L, 0, 2, 0);
+  watchTitleAllocation = false;
+  // A longjmp from inside a C++ catch skips __cxa_end_catch (or its ABI
+  // equivalent). This standard C++ query detects the still-active exception.
+  CHECK(!std::current_exception());
+  CHECK(status == 0);
+  CHECK(lua_gettop(L) == 2 && lua_isboolean(L, 1));
+  const bool success = fault == Fault::success;
+  CHECK((lua_toboolean(L, 1) != 0) == success);
+  CHECK(sawTitleAllocation);
+  CHECK(counts.constructorCalls == 1 && counts.memberConstructed == 1);
+  CHECK(counts.gcCalls == 0);  // Cleanup must occur before garbage collection.
+  CHECK(counts.createCalls == (fault == Fault::constructor_exception ? 0 : 1));
+  CHECK(counts.titleCalls == (success || fault == Fault::title_exception ? 1 : 0));
+  if (success) {
+    CHECK(lua_type(L, 2) == LUA_TUSERDATA);
+    CHECK(lua_touserdata(L, 2) == lastUserdata && *lastUserdata != nullptr);
+    CHECK(counts.constructed == 1 && counts.liveDialogs == 1);
+    CHECK(counts.destroyed == 0 && counts.memberDestroyed == 0);
+    CHECK(counts.exceptionConstructed == 0 && counts.exceptionDeleted == 0);
+    CHECK(counts.exceptionDestroyed == 0 && counts.messageCalls == 0);
+    CHECK(cppLive == heapBefore + 1);  // Only the published dialog remains.
+  } else {
+    CHECK(lastUserdata && *lastUserdata == nullptr);
+    CHECK(lua_type(L, 2) == LUA_TSTRING);
+    const char *expected = (fault == Fault::message_failure || fault == Fault::message_empty)
+                           ? "Unable to create progress dialog" : exceptionMessage;
+    const char *actual = lua_tostring(L, 2);
+    std::printf("Lua error (%s): %s\n", caseName, actual);
+    CHECK(std::strcmp(actual, expected) == 0);
+    CHECK(counts.constructed == (fault == Fault::constructor_exception ? 0 : 1));
+    CHECK(counts.destroyed == counts.constructed && counts.liveDialogs == 0);
+    CHECK(counts.memberDestroyed == 1);
+    CHECK(counts.exceptionConstructed == 1 && counts.messageCalls == 1);
+    CHECK(counts.exceptionDeleted == 1 && counts.exceptionDestroyed == 1);
+    // Lua longjmp does not unwind C++ objects. Zero retained allocations and
+    // closed catch state here require cleanup before Lua's error transfer.
+    CHECK(cppLive == heapBefore);
+  }
+}
+
+static void run(Fault requested) {
+  lua_State *L = luaL_newstate();
+  CHECK(L);
+  activeLua = L;
+  luaL_openlibs(L);
+  luaL_newmetatable(L, progress_dlg_handle);
+  lua_pushcfunction(L, collectDialog);
+  lua_setfield(L, -2, "__gc");
+  lua_pop(L, 1);
+  lua_newtable(L);
+  lua_pushcfunction(L, Lprogress_new);
+  lua_setfield(L, -2, "new");
+  lua_setglobal(L, "progress");
+  std::memset(longTitle, 't', sizeof longTitle - 1);
+  longTitle[sizeof longTitle - 1] = '\0';
+  lua_pushstring(L, longTitle);
+  lua_setglobal(L, "test_title");
+  // Keep failed userdata alive until its NULL value has been checked.
+  lua_gc(L, LUA_GCSTOP, 0);
+  attempt(L, requested);
+  lua_settop(L, 0);
+  lua_gc(L, LUA_GCCOLLECT, 0);
+  CHECK(counts.gcCalls == 1);
+  CHECK(counts.nullGcCalls == (requested == Fault::success ? 0 : 1));
+  CHECK(counts.liveDialogs == 0 && counts.destroyed == counts.constructed);
+  CHECK(counts.memberDestroyed == 1 && cppLive == heapBefore);
+
+  // A second protected progress.new and ordinary Lua execution must work in
+  // the same state. Leave the new handle rooted so lua_close finalizes it.
+  attempt(L, Fault::success);
+  CHECK(luaL_loadstring(L, "return 6 * 7") == 0);
+  CHECK(lua_pcall(L, 0, 1, 0) == 0);
+  CHECK(lua_gettop(L) == 3 && lua_tointeger(L, -1) == 42);
+  lua_close(L);
+  CHECK(counts.gcCalls == 1 && counts.nullGcCalls == 0);
+  CHECK(counts.destroyed == 1 && counts.liveDialogs == 0);
+  CHECK(counts.memberDestroyed == 1 && cppLive == heapBefore);
+}
+
+int main(int argc, char **argv) {
+  CHECK(argc == 2);
+  caseName = argv[1];
+  const struct { const char *name; Fault value; const char *message; } cases[] = {
+    {"success", Fault::success, "unused"},
+    {"create_false", Fault::create_false, "fixture: Create returned FALSE (%s)"},
+    {"create_exception", Fault::create_exception, "fixture: Create exception (%s)"},
+    {"title_exception", Fault::title_exception, "fixture: title exception (%s)"},
+    {"constructor_exception", Fault::constructor_exception, "fixture: constructor exception (%s)"},
+    {"message_failure", Fault::message_failure, "unused"},
+    {"message_empty", Fault::message_empty, "unused"},
+  };
+  for (const auto &entry : cases) {
+    if (std::strcmp(caseName, entry.name) != 0) continue;
+    exceptionMessage = entry.message;
+    try {
+      run(entry.value);
+    } catch (CException *) {
+      std::fprintf(stderr, "FAIL: %s: CException* escaped real Lua pcall; "
+                   "dialogs=%d, Delete=%d, destroyed_exceptions=%d\n", caseName,
+                   counts.liveDialogs, counts.exceptionDeleted, counts.exceptionDestroyed);
+      // The foreign exception bypassed Lua frame restoration. Do not reuse or
+      // close that corrupt state, or run leak checks on this deliberate failure.
+      std::fflush(nullptr);
+      std::_Exit(EXIT_FAILURE);
+    } catch (const std::exception &error) {
+      std::fprintf(stderr, "FAIL: %s: C++ exception escaped Lua: %s\n", caseName, error.what());
+      std::fflush(nullptr);
+      std::_Exit(EXIT_FAILURE);
+    } catch (...) {
+      std::fprintf(stderr, "FAIL: %s: unknown C++ exception escaped Lua\n", caseName);
+      std::fflush(nullptr);
+      std::_Exit(EXIT_FAILURE);
+    }
+    std::printf("PASS: %s\n", caseName);
+    return 0;
+  }
+  fail("unknown case", __LINE__);
+}

--- a/tests/lua_progress_errors.cpp.in
+++ b/tests/lua_progress_errors.cpp.in
@@ -7,6 +7,7 @@
 #include <memory>
 #include <new>
 #include <string>
+#include <stdexcept>
 extern "C" {
 #include "lua.h"
 #include "lauxlib.h"
@@ -29,14 +30,23 @@ static char longTitle[65537];
 static std::size_t cppLive;
 static bool watchTitleAllocation;
 static bool sawTitleAllocation;
+static int allocationsBeforeFailure = -1;
+static std::size_t failedAllocationSize;
+[[noreturn]] static void throwBadAlloc();
 
 // Observe real std::string allocations. Lua uses its real C allocator, so its
 // retained strings do not affect this count. No STL objects are substituted.
 void *operator new(std::size_t size) {
+  if (watchTitleAllocation && size >= sizeof longTitle) sawTitleAllocation = true;
+  if (allocationsBeforeFailure == 0) {
+    allocationsBeforeFailure = -1;  // Fail once; error reporting must still work.
+    failedAllocationSize = size;
+    throwBadAlloc();
+  }
+  if (allocationsBeforeFailure > 0) --allocationsBeforeFailure;
   void *p = std::malloc(size ? size : 1);
   if (!p) throw std::bad_alloc();
   ++cppLive;
-  if (watchTitleAllocation && size >= sizeof longTitle) sawTitleAllocation = true;
   return p;
 }
 void operator delete(void *p) noexcept {
@@ -54,7 +64,10 @@ void operator delete[](void *p, std::size_t) noexcept { ::operator delete(p); }
 #endif
 
 enum class Fault { success, create_false, create_exception, title_exception,
-                   constructor_exception, message_failure, message_empty };
+                   constructor_exception, message_failure, message_empty,
+                   string_allocation, dialog_allocation, constructor_bad_alloc,
+                   create_bad_alloc, title_bad_alloc, unknown_std_exception,
+                   unknown_exception };
 static Fault fault;
 static const char *caseName;
 static const char *exceptionMessage;
@@ -68,7 +81,20 @@ static struct {
   int createCalls, titleCalls;
   int exceptionConstructed, exceptionDeleted, exceptionDestroyed, messageCalls;
   int gcCalls, nullGcCalls;
+  int badAllocThrown, unknownPropagated;
 } counts;
+
+[[noreturn]] static void throwBadAlloc() {
+  ++counts.badAllocThrown;
+  // Allocation can fail before the dialog constructor records the userdata.
+  CHECK(lua_type(activeLua, -1) == LUA_TUSERDATA);
+  CHECK(lua_objlen(activeLua, -1) == sizeof(CProgressDlg *));
+  lastUserdata = static_cast<CProgressDlg **>(lua_touserdata(activeLua, -1));
+  CHECK(lastUserdata && *lastUserdata == nullptr);
+  throw std::bad_alloc();
+}
+
+struct UnexpectedException { int marker; };
 
 struct CException {
   char message[160];
@@ -113,6 +139,7 @@ struct CProgressDlg {
     lastUserdata = static_cast<CProgressDlg **>(lua_touserdata(activeLua, -1));
     CHECK(lastUserdata && *lastUserdata == nullptr);
     if (fault == Fault::constructor_exception) throw new CException;
+    if (fault == Fault::constructor_bad_alloc) throwBadAlloc();
     ++counts.constructed;
     ++counts.liveDialogs;
   }
@@ -123,6 +150,7 @@ struct CProgressDlg {
   BOOL Create() {
     ++counts.createCalls;
     CHECK(*lastUserdata == nullptr);
+    if (fault == Fault::create_bad_alloc) throwBadAlloc();
     if (fault == Fault::create_exception || fault == Fault::message_failure ||
         fault == Fault::message_empty) throw new CException;
     return fault == Fault::create_false ? FALSE : TRUE;
@@ -132,11 +160,33 @@ struct CProgressDlg {
     CHECK(*lastUserdata == nullptr);
     CHECK(std::strcmp(title, longTitle) == 0);
     if (fault == Fault::title_exception) throw new CException;
+    if (fault == Fault::title_bad_alloc) throwBadAlloc();
+    if (fault == Fault::unknown_std_exception) throw std::logic_error(exceptionMessage);
+    if (fault == Fault::unknown_exception) throw UnexpectedException{397};
   }
 };
 const char progress_dlg_handle[] = "mushclient.progress_dialog_handle";
 
 @LPROGRESS_NEW@
+
+// Catch the two expected unknown exceptions before they cross Lua's C frames.
+// This wrapper is used only for propagation cases. A production catch-all would
+// bypass it with luaL_error, leave unknownPropagated at zero, and fail the test.
+static int checkUnknownPropagation(lua_State *L) {
+  try {
+    return Lprogress_new(L);
+  } catch (const std::logic_error &error) {
+    CHECK(fault == Fault::unknown_std_exception);
+    CHECK(std::strcmp(error.what(), exceptionMessage) == 0);
+    ++counts.unknownPropagated;
+  } catch (const UnexpectedException &error) {
+    CHECK(fault == Fault::unknown_exception && error.marker == 397);
+    ++counts.unknownPropagated;
+  }
+  CHECK(!std::current_exception());
+  CHECK(cppLive == heapBefore);
+  return luaL_error(L, "%s", exceptionMessage);
+}
 
 static int collectDialog(lua_State *L) {
   auto ud = static_cast<CProgressDlg **>(luaL_checkudata(L, 1, progress_dlg_handle));
@@ -153,9 +203,15 @@ static void attempt(lua_State *L, Fault requested) {
   lastUserdata = nullptr;
   heapBefore = cppLive;
   sawTitleAllocation = false;
+  failedAllocationSize = 0;
+  CHECK(allocationsBeforeFailure == -1);
   CHECK(lua_gettop(L) == 0);
   CHECK(luaL_loadstring(L, "return pcall(progress.new, test_title)") == 0);
   watchTitleAllocation = true;
+  // Lua uses malloc. The first two C++ allocations are the real title string
+  // buffer and the substitute dialog object. Check their sizes below.
+  if (fault == Fault::string_allocation) allocationsBeforeFailure = 0;
+  if (fault == Fault::dialog_allocation) allocationsBeforeFailure = 1;
   int status = lua_pcall(L, 0, 2, 0);
   watchTitleAllocation = false;
   // A longjmp from inside a C++ catch skips __cxa_end_catch (or its ABI
@@ -166,10 +222,26 @@ static void attempt(lua_State *L, Fault requested) {
   const bool success = fault == Fault::success;
   CHECK((lua_toboolean(L, 1) != 0) == success);
   CHECK(sawTitleAllocation);
-  CHECK(counts.constructorCalls == 1 && counts.memberConstructed == 1);
+  const bool earlyAllocation = fault == Fault::string_allocation || fault == Fault::dialog_allocation;
+  const bool constructorFailure = fault == Fault::constructor_exception || fault == Fault::constructor_bad_alloc;
+  const bool badAlloc = earlyAllocation || fault == Fault::constructor_bad_alloc ||
+                        fault == Fault::create_bad_alloc || fault == Fault::title_bad_alloc;
+  const bool unknown = fault == Fault::unknown_std_exception || fault == Fault::unknown_exception;
+  const int expectedConstructors = earlyAllocation ? 0 : 1;
+  const int expectedDialogs = earlyAllocation || constructorFailure ? 0 : 1;
+  const int expectedTitles = success || fault == Fault::title_exception ||
+                             fault == Fault::title_bad_alloc || unknown ? 1 : 0;
+  CHECK(allocationsBeforeFailure == -1);
+  CHECK(counts.badAllocThrown == (badAlloc ? 1 : 0));
+  CHECK(counts.unknownPropagated == (unknown ? 1 : 0));
+  if (fault == Fault::string_allocation) CHECK(failedAllocationSize >= sizeof longTitle);
+  else if (fault == Fault::dialog_allocation) CHECK(failedAllocationSize == sizeof(CProgressDlg));
+  else CHECK(failedAllocationSize == 0);
+  CHECK(counts.constructorCalls == expectedConstructors);
+  CHECK(counts.memberConstructed == expectedConstructors);
   CHECK(counts.gcCalls == 0);  // Cleanup must occur before garbage collection.
-  CHECK(counts.createCalls == (fault == Fault::constructor_exception ? 0 : 1));
-  CHECK(counts.titleCalls == (success || fault == Fault::title_exception ? 1 : 0));
+  CHECK(counts.createCalls == expectedDialogs);
+  CHECK(counts.titleCalls == expectedTitles);
   if (success) {
     CHECK(lua_type(L, 2) == LUA_TUSERDATA);
     CHECK(lua_touserdata(L, 2) == lastUserdata && *lastUserdata != nullptr);
@@ -181,16 +253,19 @@ static void attempt(lua_State *L, Fault requested) {
   } else {
     CHECK(lastUserdata && *lastUserdata == nullptr);
     CHECK(lua_type(L, 2) == LUA_TSTRING);
-    const char *expected = (fault == Fault::message_failure || fault == Fault::message_empty)
+    const char *expected = (badAlloc || fault == Fault::message_failure || fault == Fault::message_empty)
                            ? "Unable to create progress dialog" : exceptionMessage;
     const char *actual = lua_tostring(L, 2);
     std::printf("Lua error (%s): %s\n", caseName, actual);
     CHECK(std::strcmp(actual, expected) == 0);
-    CHECK(counts.constructed == (fault == Fault::constructor_exception ? 0 : 1));
+    CHECK(counts.constructed == expectedDialogs);
     CHECK(counts.destroyed == counts.constructed && counts.liveDialogs == 0);
-    CHECK(counts.memberDestroyed == 1);
-    CHECK(counts.exceptionConstructed == 1 && counts.messageCalls == 1);
-    CHECK(counts.exceptionDeleted == 1 && counts.exceptionDestroyed == 1);
+    CHECK(counts.memberDestroyed == expectedConstructors);
+    const int expectedMfcExceptions = badAlloc || unknown ? 0 : 1;
+    CHECK(counts.exceptionConstructed == expectedMfcExceptions);
+    CHECK(counts.messageCalls == expectedMfcExceptions);
+    CHECK(counts.exceptionDeleted == expectedMfcExceptions);
+    CHECK(counts.exceptionDestroyed == expectedMfcExceptions);
     // Lua longjmp does not unwind C++ objects. Zero retained allocations and
     // closed catch state here require cleanup before Lua's error transfer.
     CHECK(cppLive == heapBefore);
@@ -207,7 +282,8 @@ static void run(Fault requested) {
   lua_setfield(L, -2, "__gc");
   lua_pop(L, 1);
   lua_newtable(L);
-  lua_pushcfunction(L, Lprogress_new);
+  lua_pushcfunction(L, requested == Fault::unknown_std_exception || requested == Fault::unknown_exception
+                      ? checkUnknownPropagation : Lprogress_new);
   lua_setfield(L, -2, "new");
   lua_setglobal(L, "progress");
   std::memset(longTitle, 't', sizeof longTitle - 1);
@@ -222,7 +298,7 @@ static void run(Fault requested) {
   CHECK(counts.gcCalls == 1);
   CHECK(counts.nullGcCalls == (requested == Fault::success ? 0 : 1));
   CHECK(counts.liveDialogs == 0 && counts.destroyed == counts.constructed);
-  CHECK(counts.memberDestroyed == 1 && cppLive == heapBefore);
+  CHECK(counts.memberDestroyed == counts.memberConstructed && cppLive == heapBefore);
 
   // A second protected progress.new and ordinary Lua execution must work in
   // the same state. Leave the new handle rooted so lua_close finalizes it.
@@ -247,6 +323,13 @@ int main(int argc, char **argv) {
     {"constructor_exception", Fault::constructor_exception, "fixture: constructor exception (%s)"},
     {"message_failure", Fault::message_failure, "unused"},
     {"message_empty", Fault::message_empty, "unused"},
+    {"string_allocation", Fault::string_allocation, "unused"},
+    {"dialog_allocation", Fault::dialog_allocation, "unused"},
+    {"constructor_bad_alloc", Fault::constructor_bad_alloc, "unused"},
+    {"create_bad_alloc", Fault::create_bad_alloc, "unused"},
+    {"title_bad_alloc", Fault::title_bad_alloc, "unused"},
+    {"unknown_std_exception", Fault::unknown_std_exception, "fixture: unknown standard exception (%s)"},
+    {"unknown_exception", Fault::unknown_exception, "fixture: unknown exception (%s)"},
   };
   for (const auto &entry : cases) {
     if (std::strcmp(caseName, entry.name) != 0) continue;

--- a/tests/monitor_lifetime.cpp.in
+++ b/tests/monitor_lifetime.cpp.in
@@ -1,3 +1,6 @@
+#ifdef NDEBUG
+#error Monitor lifetime tests require assertions; do not define NDEBUG.
+#endif
 #include <atomic>
 #include <cassert>
 #include <chrono>

--- a/tests/monitor_lifetime.cpp.in
+++ b/tests/monitor_lifetime.cpp.in
@@ -1,0 +1,285 @@
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cerrno>
+#include <functional>
+#include <mutex>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+using namespace std::chrono_literals;
+#define __int64 long long
+#define __stdcall
+using DWORD = unsigned long;
+using LONG = int;
+using UINT = unsigned;
+using BOOL = int;
+using WPARAM = uintptr_t;
+using LPARAM = intptr_t;
+using LRESULT = intptr_t;
+using HWND = void*;
+constexpr BOOL TRUE=1, FALSE=0;
+constexpr unsigned MB_OK=0, MB_ICONERROR=16, MB_TASKMODAL=8192;
+constexpr DWORD WAIT_OBJECT_0=0, WAIT_TIMEOUT=258, WAIT_FAILED=0xffffffff;
+constexpr unsigned FILE_NOTIFY_CHANGE_LAST_WRITE=16, ERROR_NOT_ENOUGH_MEMORY=8;
+constexpr int THREAD_PRIORITY_IDLE=-15;
+constexpr UINT WM_USER_FILE_CONTENTS_CHANGED=1002, WM_USER_SCRIPT_FILE_CONTENTS_CHANGED=1001;
+struct Handle {
+    enum Kind { event, thread, change } kind;
+    std::atomic<bool> signaled{false}, done{false};
+    bool closed=false;
+    std::thread worker;
+    explicit Handle(Kind k):kind(k){}
+};
+using HANDLE=Handle*;
+#define INVALID_HANDLE_VALUE ((HANDLE)(intptr_t)-1)
+std::vector<HANDLE> handles;
+std::mutex handleMutex, setupMutex, queueMutex;
+std::condition_variable setupCV;
+bool blockSetup=false, releaseSetup=false;
+std::atomic<int> setupCalls{0}, waitCalls{0}, postCalls{0};
+std::atomic<bool> failSet{false}, failWait{false}, failFirst{false}, failNext{false}, failPost{false};
+bool failEvent=false, failStart=false, failClose=false, failChangeClose=false;
+std::atomic<bool> holdWorkerStart{false};
+std::vector<std::string> errors;
+std::vector<std::pair<UINT,WPARAM>> queue;
+HANDLE makeHandle(Handle::Kind kind) {
+    auto h = new Handle(kind);
+    std::lock_guard<std::mutex> lock(handleMutex);
+    handles.push_back(h);
+    return h;
+}
+DWORD GetLastError(){return 123;}
+const auto uiThread = std::this_thread::get_id();
+std::function<void()> dialogHook;
+int MessageBoxA(HWND,const char* s,const char*,unsigned){
+    assert(std::this_thread::get_id()==uiThread);
+    errors.emplace_back(s);
+    if(dialogHook){auto hook=dialogHook;dialogHook=nullptr;hook();}
+    return 1;
+}
+LONG InterlockedCompareExchange(volatile LONG* p,LONG desired,LONG expected){
+    __atomic_compare_exchange_n(p,&expected,desired,false,__ATOMIC_SEQ_CST,__ATOMIC_SEQ_CST);return expected;
+}
+LONG InterlockedExchange(volatile LONG* p,LONG v){return __atomic_exchange_n(p,v,__ATOMIC_SEQ_CST);}
+HANDLE CreateEvent(void*,BOOL manual,BOOL initial,void*){
+    assert(manual && !initial); if(failEvent)return nullptr;return makeHandle(Handle::event);
+}
+BOOL SetEvent(HANDLE h){assert(h && !h->closed);if(failSet)return FALSE;h->signaled=true;return TRUE;}
+uintptr_t _beginthreadex(void*,unsigned,unsigned(*fn)(void*),void* p,unsigned flags,void*){
+    assert(flags==0);if(failStart){errno=EAGAIN;return 0;}
+    HANDLE h=makeHandle(Handle::thread);
+    h->worker=std::thread([=]{while(holdWorkerStart)std::this_thread::sleep_for(1ms);fn(p);h->done=true;});return (uintptr_t)h;
+}
+BOOL SetThreadPriority(HANDLE,int){return TRUE;}
+HANDLE FindFirstChangeNotification(char* path,BOOL recursive,unsigned filter){
+    assert(std::string(path)=="C:\\files");assert(recursive && filter==FILE_NOTIFY_CHANGE_LAST_WRITE);
+    std::unique_lock<std::mutex> lock(setupMutex);
+    ++setupCalls;
+    if(blockSetup)setupCV.wait(lock,[]{return releaseSetup;});
+    if(failFirst)return INVALID_HANDLE_VALUE;
+    return makeHandle(Handle::change);
+}
+DWORD WaitForMultipleObjects(unsigned n,HANDLE* h,BOOL all,DWORD timeout){
+    assert(n==2 && !all && timeout>0 && timeout<=250);
+    assert(h[0]->kind==Handle::event && h[1]->kind==Handle::change);
+    assert(!h[0]->closed && !h[1]->closed);++waitCalls;
+    if(h[0]->signaled)return WAIT_OBJECT_0;
+    if(h[1]->signaled.exchange(false))return WAIT_OBJECT_0+1;
+    std::this_thread::sleep_for(1ms);return WAIT_TIMEOUT;
+}
+DWORD WaitForSingleObject(HANDLE h,DWORD timeout){
+    assert(timeout==0 && h->kind==Handle::thread && !h->closed);
+    if(failWait)return WAIT_FAILED;
+    return h->done?WAIT_OBJECT_0:WAIT_TIMEOUT;
+}
+BOOL CloseHandle(HANDLE h){
+    assert(h && !h->closed);
+    if(h->kind==Handle::thread)assert(h->done);
+    if(failClose)return FALSE;
+    if(h->worker.joinable())h->worker.join();h->closed=true;return TRUE;
+}
+BOOL FindCloseChangeNotification(HANDLE h){
+    assert(h && !h->closed && h->kind==Handle::change);
+    if(failChangeClose)return FALSE;h->closed=true;return TRUE;
+}
+BOOL FindNextChangeNotification(HANDLE h){assert(!h->closed);return !failNext;}
+BOOL PostMessage(HWND,UINT msg,WPARAM payload,LPARAM){
+    ++postCalls;if(failPost)return FALSE;
+    std::lock_guard<std::mutex> lock(queueMutex);queue.emplace_back(msg,payload);return TRUE;
+}
+struct CException {virtual ~CException()=default;virtual void Delete(){delete this;}};
+std::atomic<int> exceptionsDeleted{0};
+struct CMemoryException:CException {void Delete()override{++exceptionsDeleted;delete this;}};
+[[noreturn]] void AfxThrowResourceException(){throw std::runtime_error("resource");}
+std::atomic<int> allocationFailure{0};
+void* notificationAlloc(std::size_t n){
+    int mode=allocationFailure.exchange(0);
+    if(mode==1)throw new CMemoryException;
+    if(mode==2)throw std::bad_alloc();
+    return ::operator new(n);
+}
+// Exercise the actual plain-new call with DEBUG_NEW's extra arguments.
+void* operator new(std::size_t n,const char*,int){return notificationAlloc(n);}
+void operator delete(void* p,const char*,int)noexcept{::operator delete(p);}
+@NOTIFICATION@
+using POSITION=std::size_t;
+struct CMUSHclientDoc {__int64 m_iUniqueDocumentNumber=11,m_iMonitorToken=0;bool m_bScriptFileChangedPending=false;};
+struct CTextDocument {__int64 m_iTextDocumentNumber=22,m_iMonitorToken=0;bool m_bFileChangedPending=false;};
+struct DocTemplate {
+    std::vector<void*> docs;
+    POSITION GetFirstDocPosition(){return docs.empty()?0:1;}
+    void* GetNextDoc(POSITION& pos){auto p=docs[pos-1];pos=pos==docs.size()?0:pos+1;return p;}
+} worlds,texts;
+struct AppStub {
+    __int64 next=1;
+    DocTemplate *m_pWorldDocTemplate=&worlds,*m_pNormalDocTemplate=&texts;
+    __int64 GetUniqueNumber(){return next++;}
+} App;
+struct CMainFrame {
+    HWND GetSafeHwnd(){return this;}
+    LRESULT OnScriptFileContentsChanged(WPARAM,LPARAM);
+    LRESULT OnTextFileContentsChanged(WPARAM,LPARAM);
+} Frame;
+#ifdef _DEBUG
+#define DEBUG_NEW new(__FILE__,__LINE__)
+#define new DEBUG_NEW
+#endif
+@PRODUCTION@
+#ifdef _DEBUG
+#undef new
+#endif
+@HANDLERS@
+
+template<class F> void until(F predicate){
+    auto deadline=std::chrono::steady_clock::now()+3s;
+    while(!predicate()){
+        if(std::chrono::steady_clock::now()>deadline)throw std::runtime_error("test timed out");
+        std::this_thread::sleep_for(1ms);
+    }
+}
+void unblock(){
+    {std::lock_guard<std::mutex> lock(setupMutex);releaseSetup=true;blockSetup=false;}
+    setupCV.notify_all();
+}
+void collectAll(){until([]{CollectMonitoringThreads();return monitors==nullptr;});}
+__int64 start(UINT message=WM_USER_FILE_CONTENTS_CHANGED,__int64 doc=22){
+    return CreateMonitoringThread("C:\\files\\test.lua",doc,message);
+}
+void dispatch(){
+    std::vector<std::pair<UINT,WPARAM>> pending;
+    {std::lock_guard<std::mutex> lock(queueMutex);pending.swap(queue);}
+    for(auto item:pending)
+        if(item.first==WM_USER_FILE_CONTENTS_CHANGED)Frame.OnTextFileContentsChanged(item.second,0);
+        else Frame.OnScriptFileContentsChanged(item.second,0);
+}
+int main(){
+    CTextDocument text;CMUSHclientDoc world;texts.docs={&text};worlds.docs={&world};
+    // Stop before worker entry avoids setup entirely.
+    holdWorkerStart=true;auto early=start();int earlyCalls=setupCalls;
+    StopMonitoringThread(early);holdWorkerStart=false;collectAll();assert(setupCalls==earlyCalls);
+    // Setup remains blocked while Stop returns and collection refuses to free it.
+    blockSetup=true;int initialSetup=setupCalls;
+    text.m_iMonitorToken=start();auto old=monitors;auto oldToken=text.m_iMonitorToken;
+    until([&]{return setupCalls>initialSetup;});
+    StopMonitoringThread(text.m_iMonitorToken);
+    assert(text.m_iMonitorToken==0);
+    // Setup can resume only after unblock(). The runner times out if Stop waits.
+    {std::lock_guard<std::mutex> lock(setupMutex);assert(!releaseSetup);}
+    assert(!old->thread->done);
+    CollectMonitoringThreads();assert(monitors==old && !old->stopEvent->closed);
+    // A replacement gets a fresh event and token while the old worker is blocked.
+    {std::lock_guard<std::mutex> lock(setupMutex);blockSetup=false;}
+    text.m_iMonitorToken=start();auto current=monitors;
+    assert(current!=old && current->token!=oldToken && current->stopEvent!=old->stopEvent);
+    assert(!current->stopEvent->signaled && old->stopEvent->signaled);
+    int beforeWait=waitCalls;until([&]{return waitCalls>beforeWait;});
+    Frame.OnTextFileContentsChanged((WPARAM)new CFileChangeNotification{22,oldToken},0);
+    assert(!text.m_bFileChangedPending);
+    Frame.OnTextFileContentsChanged((WPARAM)new CFileChangeNotification{999,current->token},0);
+    assert(!text.m_bFileChangedPending);
+    Frame.OnTextFileContentsChanged((WPARAM)new CFileChangeNotification{22,0},0);
+    assert(!text.m_bFileChangedPending);
+    // Actual worker notification carries both identities.
+    int beforePost=postCalls;current->change->signaled=true;
+    until([&]{return postCalls>beforePost;});
+    until([]{std::lock_guard<std::mutex> lock(queueMutex);return !queue.empty();});
+    dispatch();assert(text.m_bFileChangedPending);
+    // WAIT_FAILED retains all ownership and reports only once across passes.
+    failWait=true;std::size_t beforeErrors=errors.size();
+    CollectMonitoringThreads();CollectMonitoringThreads();
+    assert(errors.size()==beforeErrors+2 && !old->stopEvent->closed && !current->stopEvent->closed);
+    failWait=false;unblock();until([&]{return old->thread->done.load();});
+    beforePost=postCalls;CollectMonitoringThreads();assert(monitors==current && current->next==nullptr);
+    assert(postCalls==beforePost); // Stopped during setup: no notification.
+    // Failed SetEvent is bounded by the finite worker wait and atomic stop flag.
+    failSet=true;StopMonitoringThread(text.m_iMonitorToken);failSet=false;
+    until([&]{return current->thread->done.load();});
+    auto retainedEvent=current->stopEvent;auto retainedThread=current->thread;auto retainedChange=current->change;
+    failClose=true;failChangeClose=true;beforeErrors=errors.size();
+    CollectMonitoringThreads();CollectMonitoringThreads();CollectMonitoringThreads();CollectMonitoringThreads();
+    assert(monitors==current && errors.size()==beforeErrors+4);
+    assert(!retainedEvent->closed && !retainedThread->closed && !retainedChange->closed);
+    failClose=false;CollectMonitoringThreads();assert(monitors==current);
+    assert(retainedEvent->closed && retainedThread->closed && !retainedChange->closed);
+    failChangeClose=false;collectAll();assert(retainedChange->closed);
+    // Startup failure keeps a failed-close event registered until a later retry.
+    failStart=true;failClose=true;
+    try{start();assert(false);}catch(const std::runtime_error&){}
+    assert(monitors && monitors->stopEvent && !monitors->thread);
+    failStart=false;failClose=false;collectAll();
+    failEvent=true;try{start();assert(false);}catch(const std::runtime_error&){}
+    failEvent=false;collectAll();assert(!monitors);
+    // Setup failure, rearm failure, and post failure remain observable.
+    failFirst=true;auto token=start();until([]{return monitors->thread->done.load();});
+    collectAll();failFirst=false;StopMonitoringThread(token);
+    token=start(WM_USER_SCRIPT_FILE_CONTENTS_CHANGED,11);world.m_iMonitorToken=token;
+    current=monitors;beforeWait=waitCalls;until([&]{return waitCalls>beforeWait;});
+    failNext=true;current->change->signaled=true;until([&]{return current->thread->done.load();});
+    dispatch();assert(world.m_bScriptFileChangedPending);failNext=false;
+    StopMonitoringThread(world.m_iMonitorToken);collectAll();world.m_bScriptFileChangedPending=false;
+    Frame.OnScriptFileContentsChanged((WPARAM)new CFileChangeNotification{11,token},0);
+    assert(!world.m_bScriptFileChangedPending);
+    token=start();current=monitors;beforeWait=waitCalls;until([&]{return waitCalls>beforeWait;});
+    failPost=true;beforePost=postCalls;current->change->signaled=true;
+    until([&]{return postCalls>beforePost;});
+    beforeErrors=errors.size();
+    until([&]{CollectMonitoringThreads();return errors.size()>beforeErrors;});
+    assert(!current->thread->done && errors.back().find("PostMessage")!=std::string::npos);
+    failPost=false;beforePost=postCalls;current->change->signaled=true;
+    until([&]{return postCalls>beforePost;});
+    until([]{std::lock_guard<std::mutex> lock(queueMutex);return !queue.empty();});
+    // A successful retry must not hide a later terminal rearm failure.
+    beforeWait=waitCalls;until([&]{return waitCalls>beforeWait;});
+    assert(!current->thread->done);
+    beforeErrors=errors.size();
+    failNext=true;current->change->signaled=true;
+    until([&]{return current->thread->done.load();});
+    collectAll();failNext=false;
+    assert(errors.size()==beforeErrors+1);
+    assert(errors.back().find("FindNextChangeNotification")!=std::string::npos);
+    StopMonitoringThread(token);
+#ifdef _DEBUG
+    // Both MFC pointer exceptions and standard allocation errors are contained.
+    for(int mode: {1,2}){
+        token=start();current=monitors;beforeWait=waitCalls;until([&]{return waitCalls>beforeWait;});
+        allocationFailure=mode;current->change->signaled=true;
+        until([&]{return current->thread->done.load();});StopMonitoringThread(token);collectAll();
+    }
+    assert(exceptionsDeleted==1);
+#endif
+    dispatch();
+    // Modal error handling may recursively collect and create/stop monitors.
+    failFirst=true;token=start();until([]{return monitors->thread->done.load();});
+    failFirst=false;
+    dialogHook=[]{auto nested=start();StopMonitoringThread(nested);collectAll();};
+    CollectMonitoringThreads();assert(!dialogHook);collectAll();
+    for(auto h:handles){assert(h->closed && !h->worker.joinable());delete h;}
+    puts("PASS: blocked setup, independent generations, stale notifications, wait failure, stop fallback, cleanup retries, startup and worker failures");
+}

--- a/tests/notepad_close.cpp.in
+++ b/tests/notepad_close.cpp.in
@@ -31,7 +31,7 @@ enum {
     eNotepadSaveDefault, eNotepadSaveAlways, eNotepadSaveNever
 };
 enum {
-    eNotepadScript, eNotepadMXPdebug, eNotepadPacketDebug, eNotepadLineInfo,
+    eNotepadNormal, eNotepadScript, eNotepadMXPdebug, eNotepadPacketDebug, eNotepadLineInfo,
     eNotepadWorldLoadError, eNotepadXMLcomments, eNotepadPluginInfo, eNotepadRecall
 };
 
@@ -47,6 +47,12 @@ struct CString : std::string {
         return lower(*this).compare(lower(other));
     }
 };
+CString TFormat(const char *format, const char *name) {
+    CHECK(std::string(format) == "Notepad: %s");
+    CString title("Notepad: ");
+    title += name;
+    return title;
+}
 struct VARIANT { std::vector<std::string> titles; };
 struct COleVariant {
     CString title;
@@ -160,6 +166,7 @@ struct CTextView : CEditView {
     BOOL OnCmdMsg(UINT, int, void *, AFX_CMDHANDLERINFO *) override;
 };
 struct CMUSHclientDoc : CDocument {
+    CString m_mush_name = "Review World";
     __int64 m_iUniqueDocumentNumber = App.nextID++;
     int m_input_font_name = 0, m_input_font_height = 0, m_input_font_weight = 0;
     int m_input_font_charset = 0, m_input_text_colour = 0, m_input_background_colour = 0;
@@ -173,6 +180,7 @@ struct CMUSHclientDoc : CDocument {
     long CloseNotepad(LPCTSTR, BOOL);
     VARIANT GetNotepadList(BOOL);
     bool SwitchToNotepad();
+    void OnEditFliptonotepad();
     void Activate() { ++activations; }
 };
 struct CTextDocument : CDocument {
@@ -208,8 +216,10 @@ void CDocument::OnCloseDocument() {
     delete doc;
 }
 void StopMonitoringThread(__int64 &token) { token = 0; }
+int createdWindows = 0;
 template <typename... Rest>
 BOOL CreateTextWindow(LPCTSTR text, LPCTSTR title, CMUSHclientDoc *world, __int64 worldID, Rest...) {
+    ++createdWindows;
     auto *doc = new CTextDocument;
     doc->m_pRelatedWorld = world;
     doc->m_iUniqueDocumentNumber = worldID;
@@ -272,6 +282,7 @@ std::function<int(CChooseNotepadDlg &)> CChooseNotepadDlg::modal;
 @GUARD@
 @DOCUMENT@
 @COMMAND@
+@FLIP@
 @NOTEPAD@
 @CHOOSER@
 @DEFER@
@@ -539,6 +550,84 @@ void switchNotepad() {
     cleanup();
 }
 
+void flipPending(bool withLive) {
+    CMUSHclientDoc world;
+    // The registry prepends documents. The pending document must be first.
+    auto *live = withLive ? create(world, "Live", "live text") : nullptr;
+    auto *old = create(world, "Notepad: Review World");
+    const auto oldID = old->m_iTextDocumentNumber;
+    CHECK(App.docs.head->doc == old);
+    old->view.command = [&] {
+        CHECK(old->m_iActiveOperations == 1);
+        CHECK(world.CloseNotepad("Notepad: Review World", false));
+        CHECK(old->m_bClosePending && old->m_bCloseQueued);
+        CHECK(registered(oldID) == old);
+        CHECK(!App.ProcessDeferredClose());
+        world.Activate();
+    };
+    CHECK(old->view.OnCmdMsg(1, 0, nullptr, nullptr));
+    CHECK(old->m_iActiveOperations == 0 && old->m_bClosePending);
+    CHECK(old->GetFirstViewPosition() != nullptr);
+    CHECK(world.activations == 1 && registered(oldID) == old);
+    CHECK(App.destroyed.empty());
+    CHECK(App.m_DeferredTextDocumentCloses == std::deque<__int64>{oldID});
+
+    // Model a queued keyboard command dispatched after the guarded command
+    // returns and before OnIdle processes the close. Native scheduling is not run.
+    const auto before = createdWindows;
+    world.OnEditFliptonotepad();
+    CHECK(old->view.frame.activations == 0);
+    auto *survivor = live ? live : world.FindNotepad("Notepad: Review World");
+    CHECK(survivor && survivor != old);
+    const auto survivorID = survivor->m_iTextDocumentNumber;
+    CHECK(survivorID != oldID);
+    CHECK(createdWindows == before + (withLive ? 0 : 1));
+    if (withLive) CHECK(live->view.frame.activations == 1);
+    CHECK(survivor->m_pRelatedWorld == &world);
+    CHECK(survivor->m_iUniqueDocumentNumber == world.m_iUniqueDocumentNumber);
+    CHECK(survivor->view.edit.text == (withLive ? "live text" : ""));
+    CHECK(registered(oldID) == old && old->view.edit.text == "old text");
+    CHECK(App.destroyed.empty());
+    CHECK(App.m_DeferredTextDocumentCloses == std::deque<__int64>{oldID});
+
+    drain();
+    CHECK(!registered(oldID));
+    CHECK(App.destroyed.size() == 1 && App.destroyed.at(oldID) == "old text");
+    CHECK(registered(survivorID) == survivor);
+    CHECK(!survivor->m_bClosePending && !survivor->m_bCloseQueued);
+    CHECK(world.FindNotepad(withLive ? "Live" : "Notepad: Review World") == survivor);
+    CHECK(survivor->view.edit.text == (withLive ? "live text" : ""));
+    CHECK(App.m_DeferredTextDocumentCloses.empty());
+    cleanup();
+}
+
+void flipControls(bool withLive) {
+    CMUSHclientDoc world, other;
+    auto *live = withLive ? create(world, "Live", "live text") : nullptr;
+    // Both non-matches precede any live match in the registry.
+    auto *foreign = create(other, "Foreign");
+    auto *wrongIdentity = create(world, "Old world identity");
+    ++wrongIdentity->m_iUniqueDocumentNumber;
+    const auto before = createdWindows;
+    world.OnEditFliptonotepad();
+    CHECK(foreign->view.frame.activations == 0);
+    CHECK(wrongIdentity->view.frame.activations == 0);
+    CHECK(createdWindows == before + (withLive ? 0 : 1));
+    if (withLive) {
+        CHECK(live->view.frame.activations == 1);
+        CHECK(world.FindNotepad("Live") == live);
+        CHECK(live->view.edit.text == "live text");
+    } else {
+        auto *created = world.FindNotepad("Notepad: Review World");
+        CHECK(created != nullptr);
+        CHECK(created->m_pRelatedWorld == &world);
+        CHECK(created->m_iUniqueDocumentNumber == world.m_iUniqueDocumentNumber);
+        CHECK(created->view.edit.text.empty());
+    }
+    CHECK(App.m_DeferredTextDocumentCloses.empty() && App.destroyed.empty());
+    cleanup();
+}
+
 void immediateClose() {
     CMUSHclientDoc world;
     auto *old = create(world, "Review");
@@ -564,6 +653,10 @@ int main(int argc, char **argv) {
     else if (name == "enumeration") enumeration();
     else if (name == "switch") switchNotepad();
     else if (name == "immediate_close") immediateClose();
+    else if (name == "flip_pending_only") flipPending(false);
+    else if (name == "flip_pending_before_live") flipPending(true);
+    else if (name == "flip_live") flipControls(true);
+    else if (name == "flip_absent") flipControls(false);
     else CHECK(false);
     CHECK(App.docs.head == nullptr && App.worlds.head == nullptr);
     CHECK(App.m_DeferredTextDocumentCloses.empty());

--- a/tests/notepad_close.cpp.in
+++ b/tests/notepad_close.cpp.in
@@ -1,0 +1,571 @@
+// MFC substitutes surround unmodified production functions. Close deletes the
+// document and its view so ASan can detect use after the operation ends.
+#ifdef NDEBUG
+#error Notepad closure tests require checks; do not define NDEBUG.
+#endif
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <deque>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#define CHECK(value) do { if (!(value)) { \
+    std::cerr << "CHECK failed: " #value << " at line " << __LINE__ << '\n'; \
+    std::abort(); } } while (false)
+#define ASSERT(value) CHECK(value)
+#define RUNTIME_CLASS(type) 1
+using BOOL = bool;
+using UINT = unsigned;
+using DWORD = unsigned long;
+using __int64 = long long;
+using LPCTSTR = const char *;
+constexpr bool TRUE = true, FALSE = false;
+constexpr int IDOK = 1, IDCANCEL = 2, LB_ERR = -1, LB_ERRSPACE = -2;
+constexpr int IDC_NOTEPAD_LIST = 10, VT_VARIANT = 12;
+enum {
+    eNotepadSaveDefault, eNotepadSaveAlways, eNotepadSaveNever
+};
+enum {
+    eNotepadScript, eNotepadMXPdebug, eNotepadPacketDebug, eNotepadLineInfo,
+    eNotepadWorldLoadError, eNotepadXMLcomments, eNotepadPluginInfo, eNotepadRecall
+};
+
+struct CString : std::string {
+    using std::string::string;
+    operator LPCTSTR() const { return c_str(); }
+    bool IsEmpty() const { return empty(); }
+    int CompareNoCase(const CString &other) const {
+        auto lower = [](std::string value) {
+            for (char &c : value) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+            return value;
+        };
+        return lower(*this).compare(lower(other));
+    }
+};
+struct VARIANT { std::vector<std::string> titles; };
+struct COleVariant {
+    CString title;
+    explicit COleVariant(const CString &value) : title(value) {}
+};
+struct COleSafeArray {
+    std::vector<std::optional<std::string>> slots;
+    void CreateOneDim(int type, long count) {
+        CHECK(type == VT_VARIANT && count > 0);
+        slots.resize(count);
+    }
+    void PutElement(long *index, COleVariant *value) {
+        CHECK(*index >= 0 && static_cast<size_t>(*index) < slots.size());
+        CHECK(!slots[*index].has_value());
+        slots[*index] = value->title;
+    }
+    VARIANT Detach() {
+        VARIANT result;
+        for (const auto &slot : slots) {
+            CHECK(slot.has_value());
+            result.titles.push_back(*slot);
+        }
+        return result;
+    }
+};
+
+struct CDocument {
+    bool saveAccepted = true;
+    int saveQueries = 0;
+    virtual ~CDocument() = default;
+    BOOL SaveModified() { ++saveQueries; return saveAccepted; }
+    void OnCloseDocument();
+};
+struct Node { CDocument *doc; Node *next = nullptr; };
+using POSITION = Node *;
+struct DocTemplate {
+    Node *head = nullptr;
+    ~DocTemplate() { CHECK(head == nullptr); }
+    POSITION GetFirstDocPosition() const { return head; }
+    CDocument *GetNextDoc(POSITION &pos) const {
+        auto *doc = pos->doc;
+        pos = pos->next;
+        return doc;
+    }
+    void add(CDocument *doc) { head = new Node{doc, head}; }
+    void remove(CDocument *doc) {
+        for (auto **link = &head; *link; link = &(*link)->next) {
+            if ((*link)->doc == doc) {
+                auto *removed = *link;
+                *link = removed->next;
+                delete removed;
+                return;
+            }
+        }
+        CHECK(false);
+    }
+};
+struct CMUSHclientApp {
+    DocTemplate docs, worlds;
+    DocTemplate *m_pNormalDocTemplate = &docs, *m_pWorldDocTemplate = &worlds;
+    std::deque<__int64> m_DeferredTextDocumentCloses;
+    std::map<__int64, std::string> destroyed;
+    __int64 nextID = 1;
+    bool m_bConfirmBeforeClosingMXPdebug = true;
+    void DeferTextDocumentClose(__int64);
+    BOOL ProcessDeferredClose();
+} App;
+// Progress-message dispatch has a separate fixture. These cases run through
+// the document operation guard, outside that dispatch scope.
+struct CProgressDlg {
+    static bool IsPumpingMessages() { return false; }
+};
+
+struct Edit {
+    CString text;
+    int start = 0, end = 0;
+    void SetSel(int first, int last, BOOL) {
+        start = first;
+        end = last < 0 ? static_cast<int>(text.size()) : last;
+    }
+    void ReplaceSel(const CString &value) { text.replace(start, end - start, value); }
+};
+CString GetText(const Edit &edit) { return edit.text; }
+struct Frame {
+    int activations = 0;
+    void ActivateFrame() { ++activations; }
+    void SetActiveView(void *) {}
+};
+struct CView {
+    virtual ~CView() = default;
+    bool IsKindOf(int) const { return true; }
+};
+struct CTextDocument;
+struct AFX_CMDHANDLERINFO {};
+struct CEditView : CView {
+    CTextDocument *doc = nullptr;
+    std::function<void()> command;
+    CTextDocument *GetDocument() const { return doc; }
+    virtual BOOL OnCmdMsg(UINT, int, void *, AFX_CMDHANDLERINFO *) {
+        CHECK(bool(command));
+        command();
+        return true;
+    }
+};
+struct CTextView : CEditView {
+    Edit edit;
+    Frame frame;
+    Edit &GetEditCtrl() { return edit; }
+    int GetWindowTextLength() const { return static_cast<int>(edit.text.size()); }
+    Frame *GetParentFrame() { return &frame; }
+    BOOL OnCmdMsg(UINT, int, void *, AFX_CMDHANDLERINFO *) override;
+};
+struct CMUSHclientDoc : CDocument {
+    __int64 m_iUniqueDocumentNumber = App.nextID++;
+    int m_input_font_name = 0, m_input_font_height = 0, m_input_font_weight = 0;
+    int m_input_font_charset = 0, m_input_text_colour = 0, m_input_background_colour = 0;
+    int activations = 0;
+    CMUSHclientDoc() { App.worlds.add(this); }
+    ~CMUSHclientDoc() { App.worlds.remove(this); }
+    CTextDocument *FindNotepad(const CString);
+    bool AppendToTheNotepad(const CString, const CString, const bool, const int = eNotepadScript);
+    BOOL AppendToNotepad(LPCTSTR, LPCTSTR);
+    BOOL ReplaceNotepad(LPCTSTR, LPCTSTR);
+    long CloseNotepad(LPCTSTR, BOOL);
+    VARIANT GetNotepadList(BOOL);
+    bool SwitchToNotepad();
+    void Activate() { ++activations; }
+};
+struct CTextDocument : CDocument {
+    int m_iActiveOperations = 0;
+    bool m_bClosePending = false, m_bCloseQueued = false, m_bFileChangedPending = false;
+    __int64 m_iMonitorToken = 0, m_iTextDocumentNumber = App.nextID++, m_iUniqueDocumentNumber = 0;
+    CMUSHclientDoc *m_pRelatedWorld = nullptr;
+    CString m_strTitle, path;
+    int m_iSaveOnChange = eNotepadSaveDefault, m_iNotepadType = eNotepadScript;
+    CTextView view;
+    Node viewPosition{this};
+    struct ViewList {
+        CTextView *view;
+        CTextView *GetHead() { return view; }
+    } m_viewList{&view};
+    CTextDocument() { view.doc = this; }
+    ~CTextDocument() {
+        CHECK(m_iActiveOperations == 0);
+        CHECK(App.destroyed.emplace(m_iTextDocumentNumber, view.edit.text).second);
+    }
+    POSITION GetFirstViewPosition() { return &viewPosition; }
+    CView *GetNextView(POSITION &pos) { pos = nullptr; return &view; }
+    CString GetPathName() const { return path; }
+    CString GetTitle() const { return m_strTitle; }
+    BOOL SaveModified();
+    void OnCloseDocument();
+    void BeginOperation();
+    void EndOperation();
+};
+void CDocument::OnCloseDocument() {
+    auto *doc = static_cast<CTextDocument *>(this);
+    App.docs.remove(doc);
+    delete doc;
+}
+void StopMonitoringThread(__int64 &token) { token = 0; }
+template <typename... Rest>
+BOOL CreateTextWindow(LPCTSTR text, LPCTSTR title, CMUSHclientDoc *world, __int64 worldID, Rest...) {
+    auto *doc = new CTextDocument;
+    doc->m_pRelatedWorld = world;
+    doc->m_iUniqueDocumentNumber = worldID;
+    doc->m_strTitle = title;
+    doc->view.edit.text = text;
+    App.docs.add(doc);
+    return true;
+}
+
+struct CDataExchange { bool m_bSaveAndValidate = false; };
+struct CDialog {
+    bool accepted = false;
+    void DoDataExchange(CDataExchange *) {}
+    void OnOK() { accepted = true; }
+};
+struct NumberArray : std::vector<__int64> {
+    void RemoveAll() { clear(); }
+    int GetSize() const { return static_cast<int>(size()); }
+    int Add(__int64 id) { push_back(id); return GetSize() - 1; }
+};
+struct ListBox {
+    struct Item { CString title; DWORD data = 0; };
+    std::vector<Item> items;
+    int selected = LB_ERR;
+    int AddString(const CString &title) {
+        auto pos = std::lower_bound(items.begin(), items.end(), title,
+                                   [](const Item &item, const CString &value) { return item.title < value; });
+        int index = static_cast<int>(pos - items.begin());
+        items.insert(pos, {title, 0});
+        return index;
+    }
+    void SetItemData(int index, DWORD data) { items.at(index).data = data; }
+    DWORD GetItemData(int index) const { return items.at(index).data; }
+    int GetCurSel() const { return selected; }
+    void DeleteString(int index) { items.erase(items.begin() + index); selected = LB_ERR; }
+};
+void DDX_Control(CDataExchange *, int, ListBox &) {}
+struct CChooseNotepadDlg : CDialog {
+    CMUSHclientDoc *m_pWorld = nullptr;
+    CTextDocument *m_pTextDocument = nullptr;
+    __int64 m_iWorldDocumentNumber = 0;
+    NumberArray m_NotepadDocumentNumbers;
+    ListBox m_ctlNotepadList;
+    static int modalCalls;
+    static std::function<int(CChooseNotepadDlg &)> modal;
+    void DoDataExchange(CDataExchange *);
+    CMUSHclientDoc *GetLiveWorld() const;
+    CTextDocument *GetNotepadForIndex(int) const;
+    void OnOpenExisting();
+    int DoModal() {
+        ++modalCalls;
+        CDataExchange dx;
+        DoDataExchange(&dx);
+        return modal ? modal(*this) : IDCANCEL;
+    }
+};
+int CChooseNotepadDlg::modalCalls = 0;
+std::function<int(CChooseNotepadDlg &)> CChooseNotepadDlg::modal;
+
+@GUARD@
+@DOCUMENT@
+@COMMAND@
+@NOTEPAD@
+@CHOOSER@
+@DEFER@
+BOOL CMUSHclientApp::ProcessDeferredClose() {
+    @IDLE_CLOSE@
+    return false;
+}
+
+CTextDocument *registered(__int64 id) {
+    for (POSITION pos = App.docs.GetFirstDocPosition(); pos;) {
+        auto *doc = static_cast<CTextDocument *>(App.docs.GetNextDoc(pos));
+        if (doc->m_iTextDocumentNumber == id) return doc;
+    }
+    return nullptr;
+}
+CTextDocument *create(CMUSHclientDoc &world, const char *title, const char *text = "old text") {
+    CHECK(CreateTextWindow(text, title, &world, world.m_iUniqueDocumentNumber));
+    auto *doc = world.FindNotepad(title);
+    CHECK(doc != nullptr);
+    return doc;
+}
+CChooseNotepadDlg chooser(CMUSHclientDoc &world) {
+    CChooseNotepadDlg dlg;
+    dlg.m_pWorld = &world;
+    dlg.m_iWorldDocumentNumber = world.m_iUniqueDocumentNumber;
+    CDataExchange dx;
+    dlg.DoDataExchange(&dx);
+    return dlg;
+}
+void expectList(CMUSHclientDoc &world, bool all, std::vector<std::string> expected) {
+    auto result = world.GetNotepadList(all).titles;
+    std::sort(result.begin(), result.end());
+    std::sort(expected.begin(), expected.end());
+    CHECK(result == expected);
+}
+void drain() {
+    int count = 0;
+    while (App.ProcessDeferredClose()) CHECK(++count < 20);
+}
+void cleanup() {
+    drain();
+    while (App.docs.head) {
+        auto *doc = static_cast<CTextDocument *>(App.docs.head->doc);
+        CHECK(doc->m_iActiveOperations == 0);
+        doc->OnCloseDocument();
+    }
+}
+
+void closeWrite(bool replace) {
+    CMUSHclientDoc world;
+    auto *old = create(world, "Review");
+    const auto oldID = old->m_iTextDocumentNumber;
+    __int64 replacementID = 0;
+    old->view.command = [&] {
+        CHECK(old->m_iActiveOperations == 1);
+        CHECK(world.CloseNotepad("rEvIeW", false));
+        CHECK(old->m_bClosePending);
+        CHECK(registered(oldID) == old);
+        CHECK(!world.FindNotepad("Review"));
+        expectList(world, false, {});
+        expectList(world, true, {});
+        CHECK(!world.CloseNotepad("Review", false));
+        CHECK(!App.ProcessDeferredClose());
+        CHECK(replace ? world.ReplaceNotepad("Review", "replacement text")
+                      : world.AppendToNotepad("Review", "replacement text"));
+        auto *replacement = world.FindNotepad("review");
+        CHECK(replacement && replacement != old);
+        replacementID = replacement->m_iTextDocumentNumber;
+        CHECK(replacementID != oldID);
+        CHECK(replacement->view.edit.text == "replacement text");
+        CHECK(old->view.edit.text == "old text");
+        expectList(world, false, {"Review"});
+        expectList(world, true, {"Review"});
+        auto dlg = chooser(world);
+        CHECK(dlg.m_ctlNotepadList.items.size() == 1);
+        CHECK(dlg.GetNotepadForIndex(0) == replacement);
+    };
+    CHECK(old->view.OnCmdMsg(1, 0, nullptr, nullptr));
+    CHECK(registered(oldID) == old);
+    CHECK(old->m_iActiveOperations == 0 && old->m_bCloseQueued);
+    CHECK(App.destroyed.count(oldID) == 0);
+    CHECK(App.m_DeferredTextDocumentCloses == std::deque<__int64>{oldID});
+    CHECK(!world.FindNotepad("missing"));
+    CHECK(world.FindNotepad("Review")->m_iTextDocumentNumber == replacementID);
+    // A duplicate stale close must also resolve only the old instance ID.
+    App.DeferTextDocumentClose(oldID);
+    drain();
+    CHECK(!registered(oldID));
+    CHECK(App.destroyed.at(oldID) == "old text");
+    CHECK(registered(replacementID) == world.FindNotepad("Review"));
+    CHECK(registered(replacementID)->view.edit.text == "replacement text");
+    cleanup();
+}
+
+void cancelledClose() {
+    CMUSHclientDoc world;
+    auto *doc = create(world, "Review");
+    doc->saveAccepted = false;
+    auto dlg = chooser(world);
+    const auto id = doc->m_iTextDocumentNumber;
+    doc->view.command = [&] {
+        CHECK(!world.CloseNotepad("Review", true));
+        CHECK(doc->saveQueries == 1);
+        CHECK(!doc->m_bClosePending && !doc->m_bCloseQueued);
+        CHECK(world.FindNotepad("Review") == doc);
+        expectList(world, false, {"Review"});
+        expectList(world, true, {"Review"});
+        CHECK(chooser(world).m_ctlNotepadList.items.size() == 1);
+        CHECK(dlg.GetNotepadForIndex(0) == doc);
+        dlg.m_ctlNotepadList.selected = 0;
+        dlg.OnOpenExisting();
+        CHECK(dlg.accepted && dlg.m_pTextDocument == doc);
+        CHECK(world.AppendToNotepad("Review", " appended"));
+        CHECK(doc->view.edit.text == "old text appended");
+        CHECK(world.ReplaceNotepad("Review", "replaced"));
+        CHECK(doc->view.edit.text == "replaced");
+        CHECK(world.FindNotepad("Review") == doc);
+        CHECK(world.SwitchToNotepad());
+        CHECK(CChooseNotepadDlg::modalCalls == 1);
+    };
+    CHECK(doc->view.OnCmdMsg(1, 0, nullptr, nullptr));
+    CHECK(App.m_DeferredTextDocumentCloses.empty());
+    drain();
+    CHECK(registered(id) == doc);
+    cleanup();
+}
+
+void repeatedClose() {
+    CMUSHclientDoc world;
+    auto *doc = create(world, "Review");
+    const auto id = doc->m_iTextDocumentNumber;
+    doc->view.command = [&] {
+        {
+            CTextDocumentOperationGuard nested(doc);
+            CHECK(doc->m_iActiveOperations == 2);
+            CHECK(world.CloseNotepad("Review", true));
+            CHECK(doc->saveQueries == 1);
+            CHECK(!world.CloseNotepad("Review", true));
+            CHECK(doc->saveQueries == 1);
+            doc->OnCloseDocument();
+            CHECK(!App.ProcessDeferredClose());
+        }
+        CHECK(doc->m_iActiveOperations == 1);
+        CHECK(registered(id) == doc);
+        CHECK(!App.ProcessDeferredClose());
+    };
+    CHECK(doc->view.OnCmdMsg(1, 0, nullptr, nullptr));
+    CHECK(App.m_DeferredTextDocumentCloses == std::deque<__int64>{id});
+    // A nested loop can see a queued close during another operation.
+    {
+        CTextDocumentOperationGuard nested(doc);
+        CHECK(!App.ProcessDeferredClose());
+        CHECK(registered(id) == doc);
+        CHECK(doc->m_bCloseQueued && doc->m_bClosePending);
+    }
+    CHECK(App.m_DeferredTextDocumentCloses == std::deque<__int64>{id});
+    CHECK(!world.CloseNotepad("Review", false));
+    drain();
+    CHECK(!registered(id) && App.destroyed.count(id) == 1);
+    cleanup();
+}
+
+void staleChooser() {
+    CMUSHclientDoc world;
+    auto *old = create(world, "Review");
+    const auto id = old->m_iTextDocumentNumber;
+    auto stale = chooser(world);
+    CHECK(stale.m_ctlNotepadList.items.size() == 1);
+    CHECK(stale.GetNotepadForIndex(0) == old);
+    CHECK(!stale.GetNotepadForIndex(-1) && !stale.GetNotepadForIndex(1));
+    old->view.command = [&] {
+        CHECK(world.CloseNotepad("Review", false));
+        CHECK(chooser(world).m_ctlNotepadList.items.empty());
+        CHECK(!stale.GetNotepadForIndex(0));
+        CHECK(world.AppendToNotepad("Review", "new"));
+        auto *replacement = world.FindNotepad("Review");
+        CHECK(replacement != old);
+        CHECK(!stale.GetNotepadForIndex(0));
+        stale.m_ctlNotepadList.selected = 0;
+        stale.OnOpenExisting();
+        CHECK(!stale.accepted && !stale.m_pTextDocument);
+        CHECK(stale.m_ctlNotepadList.items.empty());
+        auto fresh = chooser(world);
+        CHECK(fresh.m_ctlNotepadList.items.size() == 1);
+        CHECK(fresh.GetNotepadForIndex(0) == replacement);
+        // A recycled world pointer with a different identity is not a match.
+        ++fresh.m_iWorldDocumentNumber;
+        CHECK(!fresh.GetLiveWorld() && !fresh.GetNotepadForIndex(0));
+    };
+    CHECK(old->view.OnCmdMsg(1, 0, nullptr, nullptr));
+    CHECK(!stale.GetNotepadForIndex(0));
+    drain();
+    CHECK(!registered(id));
+    CHECK(!stale.GetNotepadForIndex(0));
+    CHECK(world.FindNotepad("Review")->view.edit.text == "new");
+    cleanup();
+}
+
+void enumeration() {
+    CMUSHclientDoc world, other;
+    auto *pending = create(world, "Pending");
+    auto *foreignPending = create(other, "Foreign pending");
+    const auto foreignID = foreignPending->m_iTextDocumentNumber;
+    create(world, "Z live");
+    create(world, "A live");
+    create(other, "Foreign live");
+    auto *unrelated = create(other, "Unrelated");
+    unrelated->m_pRelatedWorld = nullptr;
+    auto *wrongIdentity = create(world, "Old world identity");
+    ++wrongIdentity->m_iUniqueDocumentNumber;
+    CHECK(!world.FindNotepad("Foreign live"));
+    CHECK(!world.FindNotepad("Unrelated"));
+    CHECK(!world.FindNotepad("Old world identity"));
+    pending->view.command = [&] {
+        CTextDocumentOperationGuard foreignOperation(foreignPending);
+        CHECK(world.CloseNotepad("Pending", false));
+        CHECK(other.CloseNotepad("Foreign pending", false));
+        expectList(world, false, {"Z live", "A live"});
+        expectList(world, true, {"Z live", "A live", "Foreign live", "Unrelated", "Old world identity"});
+        expectList(other, false, {"Foreign live"});
+        auto dlg = chooser(world);
+        CHECK(dlg.m_ctlNotepadList.items.size() == 2);
+        CHECK(dlg.m_NotepadDocumentNumbers.GetSize() == 2);
+        for (int i = 0; i < 2; ++i) {
+            const auto &item = dlg.m_ctlNotepadList.items[i];
+            auto *doc = dlg.GetNotepadForIndex(static_cast<int>(item.data));
+            CHECK(doc && doc->m_strTitle == item.title);
+        }
+    };
+    CHECK(pending->view.OnCmdMsg(1, 0, nullptr, nullptr));
+    expectList(world, false, {"Z live", "A live"});
+    expectList(world, true, {"Z live", "A live", "Foreign live", "Unrelated", "Old world identity"});
+    CHECK(registered(foreignID));
+    drain();
+    CHECK(!registered(foreignID));
+    expectList(world, false, {"Z live", "A live"});
+    cleanup();
+}
+
+void switchNotepad() {
+    CMUSHclientDoc world, other;
+    auto *pending = create(world, "Review");
+    create(other, "Foreign");
+    auto *wrongIdentity = create(world, "Old world identity");
+    ++wrongIdentity->m_iUniqueDocumentNumber;
+    pending->view.command = [&] {
+        CHECK(world.CloseNotepad("Review", false));
+        CHECK(!world.SwitchToNotepad());
+        CHECK(CChooseNotepadDlg::modalCalls == 0);
+        auto *live = create(world, "Live");
+        CChooseNotepadDlg::modal = [&](CChooseNotepadDlg &dlg) {
+            CHECK(dlg.m_ctlNotepadList.items.size() == 1);
+            dlg.m_ctlNotepadList.selected = 0;
+            dlg.OnOpenExisting();
+            CHECK(dlg.accepted && dlg.m_pTextDocument == live);
+            return IDOK;
+        };
+        CHECK(world.SwitchToNotepad());
+        CHECK(CChooseNotepadDlg::modalCalls == 1);
+        CHECK(live->view.frame.activations == 1);
+        CHECK(pending->view.frame.activations == 0);
+        CChooseNotepadDlg::modal = {};
+    };
+    CHECK(pending->view.OnCmdMsg(1, 0, nullptr, nullptr));
+    cleanup();
+}
+
+void immediateClose() {
+    CMUSHclientDoc world;
+    auto *old = create(world, "Review");
+    const auto id = old->m_iTextDocumentNumber;
+    CHECK(world.CloseNotepad("Review", false));
+    CHECK(!registered(id) && App.destroyed.at(id) == "old text");
+    CHECK(App.m_DeferredTextDocumentCloses.empty());
+    CHECK(!world.CloseNotepad("Review", false));
+    CHECK(world.AppendToNotepad("Review", "new"));
+    CHECK(world.FindNotepad("Review")->m_iTextDocumentNumber != id);
+    CHECK(world.FindNotepad("Review")->view.edit.text == "new");
+    cleanup();
+}
+
+int main(int argc, char **argv) {
+    CHECK(argc == 2);
+    const std::string name = argv[1];
+    if (name == "close_append") closeWrite(false);
+    else if (name == "close_replace") closeWrite(true);
+    else if (name == "cancelled_close") cancelledClose();
+    else if (name == "repeated_close") repeatedClose();
+    else if (name == "stale_chooser") staleChooser();
+    else if (name == "enumeration") enumeration();
+    else if (name == "switch") switchNotepad();
+    else if (name == "immediate_close") immediateClose();
+    else CHECK(false);
+    CHECK(App.docs.head == nullptr && App.worlds.head == nullptr);
+    CHECK(App.m_DeferredTextDocumentCloses.empty());
+    std::cout << "PASS: " << name << '\n';
+}

--- a/tests/notepad_close.cpp.in
+++ b/tests/notepad_close.cpp.in
@@ -481,6 +481,56 @@ void staleChooser() {
     cleanup();
 }
 
+void staleMapping() {
+    CMUSHclientDoc world;
+    create(world, "A stale");
+    create(world, "B live");
+    create(world, "C stale");
+    create(world, "D live");
+    auto dlg = chooser(world);
+    CHECK(dlg.m_NotepadDocumentNumbers.GetSize() == 4);
+    CHECK(world.CloseNotepad("A stale", false));
+    CHECK(world.CloseNotepad("C stale", false));
+    create(world, "A stale"); // The same title has a different identity.
+    for (int row : {0, 1}) {
+        dlg.m_ctlNotepadList.selected = row;
+        dlg.OnOpenExisting();
+        CHECK(!dlg.accepted && !dlg.m_pTextDocument);
+    }
+    CHECK(dlg.m_ctlNotepadList.items.size() == 2);
+    for (int row : {0, 1}) {
+        const auto item = dlg.m_ctlNotepadList.items[row];
+        auto *expected = world.FindNotepad(item.title);
+        CHECK(expected && dlg.GetNotepadForIndex(static_cast<int>(item.data)) == expected);
+        dlg.m_ctlNotepadList.selected = row;
+        dlg.OnOpenExisting();
+        CHECK(dlg.accepted && dlg.m_pTextDocument == expected);
+    }
+    cleanup();
+}
+
+void switchClosedBeforeSelection() {
+    CMUSHclientDoc world;
+    create(world, "A closed");
+    auto *live = create(world, "B live");
+    CChooseNotepadDlg::modal = [&](CChooseNotepadDlg &dlg) {
+        CHECK(world.CloseNotepad("A closed", false));
+        auto *replacement = create(world, "A closed");
+        dlg.m_ctlNotepadList.selected = 0;
+        dlg.OnOpenExisting();
+        CHECK(!dlg.accepted && !dlg.m_pTextDocument);
+        CHECK(replacement->view.frame.activations == 0);
+        dlg.m_ctlNotepadList.selected = 0;
+        dlg.OnOpenExisting();
+        CHECK(dlg.accepted && dlg.m_pTextDocument == live);
+        return IDOK;
+    };
+    CHECK(world.SwitchToNotepad());
+    CHECK(live->view.frame.activations == 1);
+    CChooseNotepadDlg::modal = {};
+    cleanup();
+}
+
 void enumeration() {
     CMUSHclientDoc world, other;
     auto *pending = create(world, "Pending");
@@ -650,6 +700,8 @@ int main(int argc, char **argv) {
     else if (name == "cancelled_close") cancelledClose();
     else if (name == "repeated_close") repeatedClose();
     else if (name == "stale_chooser") staleChooser();
+    else if (name == "stale_mapping") staleMapping();
+    else if (name == "switch_closed_before_selection") switchClosedBeforeSelection();
     else if (name == "enumeration") enumeration();
     else if (name == "switch") switchNotepad();
     else if (name == "immediate_close") immediateClose();

--- a/tests/output_search_snapshot.cpp.in
+++ b/tests/output_search_snapshot.cpp.in
@@ -1,0 +1,435 @@
+#ifdef NDEBUG
+#error Output search checks require assertions
+#endif
+#include <algorithm>
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <functional>
+#include <iostream>
+#include <list>
+#include <map>
+#include <memory>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+using namespace std;
+using __int64 = long long;
+using LPCTSTR = const char *;
+using HWND = unsigned long;
+#define ASSERT_VALID(x) assert(x)
+#define IDOK 1
+#define IDCANCEL 2
+#define MB_ICONINFORMATION 0
+#define PCRE_CASELESS 1
+#define PCRE_UTF8 2
+struct CObject {};
+struct CString : string {
+  using string::string;
+  using string::operator=;
+  CString(const string & s) : string(s) {}
+  CString(const char * s, int n) : string(s, n) {}
+  operator LPCTSTR() const { return c_str(); }
+  bool IsEmpty() const { return empty(); }
+  int GetLength() const { return static_cast<int>(size()); }
+  void Empty() { clear(); }
+  void MakeLower() { for (char & c : *this) c = tolower(static_cast<unsigned char>(c)); }
+  int Find(const CString & s, int start) const {
+    size_t p = find(s, start); return p == npos ? -1 : static_cast<int>(p);
+  }
+};
+struct Node { Node * prev = nullptr, * next = nullptr; virtual ~Node() = default; };
+using POSITION = Node *;
+template<class T> struct ValueNode : Node { T value; explicit ValueNode(const T & v) : value(v) {} };
+template<class T> struct List {
+  Node * head = nullptr, * tail = nullptr;
+  int count = 0;
+  ~List() { RemoveAll(); }
+  int GetCount() const { return count; }
+  bool IsEmpty() const { return !head; }
+  POSITION GetHeadPosition() const { return head; }
+  POSITION GetTailPosition() const { return tail; }
+  T GetAt(POSITION p) const { assert(p); return static_cast<ValueNode<T> *>(p)->value; }
+  T GetNext(POSITION & p) const { T v = GetAt(p); p = p->next; return v; }
+  T GetPrev(POSITION & p) const { T v = GetAt(p); p = p->prev; return v; }
+  T GetHead() const { return GetAt(head); }
+  POSITION AddTail(const T & v) {
+    auto n = new ValueNode<T>(v); n->prev = tail;
+    if (tail) tail->next = n; else head = n;
+    tail = n; ++count; return n;
+  }
+  void AddHead(const T & v) {
+    auto n = new ValueNode<T>(v); n->next = head;
+    if (head) head->prev = n; else tail = n;
+    head = n; ++count;
+  }
+  T RemoveHead() {
+    T v = GetAt(head); Node * n = head; head = head->next;
+    if (head) head->prev = nullptr; else tail = nullptr;
+    delete n; --count; return v;
+  }
+  T RemoveTail() {
+    T v = GetAt(tail); Node * n = tail; tail = tail->prev;
+    if (tail) tail->next = nullptr; else head = nullptr;
+    delete n; --count; return v;
+  }
+  void RemoveAll() { while (head) RemoveHead(); }
+};
+using CStringList = List<CString>;
+
+// The substitute regexp has strict ownership and records its compile flags.
+struct t_regexp {
+  static int count;
+  regex pattern;
+  int flags;
+  int m_vOffsets[2] = {};
+  t_regexp(const char * s, int f) :
+    pattern(s, regex::ECMAScript | (f & PCRE_CASELESS ? regex::icase : regex::flag_type{})), flags(f) { ++count; }
+  ~t_regexp() { --count; }
+};
+int t_regexp::count = 0;
+t_regexp * regcomp(const CString & text, int flags) { return new t_regexp(text, flags); }
+bool regexec(t_regexp * compiled, const CString & line, int start) {
+  assert(compiled);
+  cmatch result;
+  if (!regex_search(line.c_str() + start, result, compiled->pattern)) return false;
+  compiled->m_vOffsets[0] = start + result.position();
+  compiled->m_vOffsets[1] = compiled->m_vOffsets[0] + result.length();
+  return true;
+}
+class CProgressDlg;
+@FIND_INFO@
+using InitiateSearch = void (*)(const CObject *, CFindInfo &);
+using GetNextLine = bool (*)(const CObject *, CFindInfo &, CString &);
+bool FindRoutine(const CObject *, CFindInfo &, InitiateSearch, GetNextLine, bool * = nullptr);
+
+function<void()> progressCallback, modalCallback, notFoundCallback, statusCallback, selectionCallback;
+bool cancelProgress = false, cancelDialog = false, failCreate = false;
+int progressCount = 0, notFoundCount = 0;
+void invokeOnce(function<void()> & slot) { auto callback = std::move(slot); slot = {}; if (callback) callback(); }
+CString dialogText;
+bool dialogRegexp = false, dialogForwards = true, dialogMatchCase = false;
+struct CFindDlg {
+  CString m_strFindText, m_strTitle;
+  bool m_bMatchCase = false, m_bForwards = true, m_bRegexp = false;
+  explicit CFindDlg(CStringList &) {}
+  int DoModal() {
+    invokeOnce(modalCallback);
+    if (cancelDialog) { cancelDialog = false; return IDCANCEL; }
+    m_strFindText = dialogText; m_bRegexp = dialogRegexp;
+    m_bForwards = dialogForwards; m_bMatchCase = dialogMatchCase;
+    return IDOK;
+  }
+};
+struct CProgressDlg {
+  static int count;
+  CProgressDlg() { ++count; }
+  ~CProgressDlg() { --count; }
+  bool Create() { if (failCreate) throw runtime_error("progress creation"); return true; }
+  void SetStatus(const CString &) {}
+  void SetRange(int, long) {}
+  void SetWindowText(const CString &) {}
+  void SetPos(long) { ++progressCount; invokeOnce(progressCallback); }
+  bool CheckCancelButton() { bool c = cancelProgress; cancelProgress = false; return c; }
+};
+int CProgressDlg::count = 0;
+struct FrameType {
+  void SetStatusNormal() {}
+  void SetStatusMessageNow(const CString &) { invokeOnce(statusCallback); }
+} Frame;
+struct CException { void ReportError() {} void Delete() { delete this; } };
+void AfxThrowResourceException() { throw runtime_error("resource"); }
+CString Translate(const char * s) { return s; }
+CString TFormat(const char * format, ...) {
+  char buffer[1024]; va_list args; va_start(args, format);
+  vsnprintf(buffer, sizeof buffer, format, args); va_end(args); return buffer;
+}
+void UMessageBox(const CString &, int) { ++notFoundCount; invokeOnce(notFoundCallback); }
+@FIND_ROUTINE@
+
+map<HWND, class CWnd *> windows;
+HWND nextWindow = 0;
+struct CWnd {
+  HWND window = ++nextWindow;
+  CWnd() { windows[window] = this; }
+  virtual ~CWnd() { windows.erase(window); }
+  HWND GetSafeHwnd() const { return window; }
+  static CWnd * FromHandlePermanent(HWND w) { auto p = windows.find(w); return p == windows.end() ? nullptr : p->second; }
+  void DestroyWindow() { windows.erase(window); }
+};
+bool IsWindow(HWND w) { return windows.count(w) != 0; }
+__int64 nextIdentity = 0;
+struct CLine {
+  __int64 nCreationNumber = ++nextIdentity;
+  string bytes;
+  const char * text;
+  int len;
+  bool hard_return;
+  CLine(string s, bool hard) : bytes(std::move(s)), text(bytes.data()), len(bytes.size()), hard_return(hard) {}
+  void Change(string s) { bytes = std::move(s); text = bytes.data(); len = bytes.size(); }
+};
+struct CMUSHclientDoc;
+map<CMUSHclientDoc *, __int64> documents;
+struct CMUSHclientDoc {
+  __int64 m_iUniqueDocumentNumber = ++nextIdentity, m_iOutputGeneration = 0;
+  bool m_bWorldClosePending = false;
+  int m_iActiveProgressOperations = 0;
+  List<CLine *> m_LineList;
+  CFindInfo m_DisplayFindInfo;
+  CMUSHclientDoc() { documents[this] = m_iUniqueDocumentNumber; m_DisplayFindInfo.m_bAgain = false; }
+  ~CMUSHclientDoc() { assert(m_iActiveProgressOperations == 0); ClearLines(); documents.erase(this); }
+  void BeginProgressOperation() { ++m_iActiveProgressOperations; }
+  void EndProgressOperation() { assert(m_iActiveProgressOperations > 0); --m_iActiveProgressOperations; }
+  void ClearLines() { while (!m_LineList.IsEmpty()) delete m_LineList.RemoveHead(); ++m_iOutputGeneration; }
+  CLine * Add(string s, bool hard = true) { auto line = new CLine(std::move(s), hard); m_LineList.AddTail(line); return line; }
+  CLine * At(int index) { auto pos = m_LineList.GetHeadPosition(); while (index--) m_LineList.GetNext(pos); return m_LineList.GetAt(pos); }
+  void Prune(int count) {
+    for (int i = 0; i < count; ++i) delete m_LineList.RemoveHead();
+    ++m_iOutputGeneration;
+    m_DisplayFindInfo.m_nCurrentLine = max(0L, m_DisplayFindInfo.m_nCurrentLine - count);
+  }
+  void ClearOutput() {
+    ClearLines(); Add("", false);
+    m_DisplayFindInfo.m_nCurrentLine = 0;
+    m_DisplayFindInfo.m_pFindPosition = nullptr;
+    m_DisplayFindInfo.m_bAgain = false;
+  }
+};
+bool IsWorldDocumentLive(const CMUSHclientDoc * doc, __int64 identity) {
+  auto p = documents.find(const_cast<CMUSHclientDoc *>(doc));
+  return p != documents.end() && p->second == identity;
+}
+@GUARD@
+struct CMUSHView : CWnd {
+  long m_selstart_line = -9, m_selend_line = -9;
+  int m_selstart_col = -9, m_selend_col = -9, ensured = 0, notified = 0, invalidated = 0;
+  void EnsureSelectionVisible() { ++ensured; }
+  void Invalidate() { ++invalidated; }
+  void NotifySelectionChanged() { ++notified; invokeOnce(selectionCallback); }
+};
+class COutputSearchSnapshot;
+struct CSendView : CWnd {
+  CMUSHclientDoc * doc;
+  CMUSHView * m_topview;
+  shared_ptr<COutputSearchSnapshot> m_pOutputSearchSnapshot;
+  CSendView(CMUSHclientDoc & d, CMUSHView & v) : doc(&d), m_topview(&v) {}
+  CMUSHclientDoc * GetDocument() { return doc; }
+  void DoFind(bool);
+  static void InitiateSearch(const CObject *, CFindInfo &);
+  static bool GetNextLine(const CObject *, CFindInfo &, CString &);
+};
+@PRODUCTION@
+
+struct Fixture {
+  CMUSHclientDoc doc;
+  CMUSHView top;
+  CSendView send{doc, top};
+  Fixture() {
+    progressCallback = modalCallback = notFoundCallback = statusCallback = selectionCallback = {};
+    cancelProgress = cancelDialog = failCreate = false;
+    dialogText = "target"; dialogRegexp = false; dialogForwards = true; dialogMatchCase = false;
+    progressCount = notFoundCount = 0;
+  }
+  ~Fixture() { assert(CProgressDlg::count == 0); assert(doc.m_iActiveProgressOperations == 0); }
+  void Noise(int count) { for (int i = 0; i < count; ++i) doc.Add("noise"); }
+  void Find(const char * text = "target", bool forwards = true, bool regexp = false) {
+    dialogText = text; dialogForwards = forwards; dialogRegexp = regexp; send.DoFind(false);
+  }
+  void Again(bool forwards = true) { doc.m_DisplayFindInfo.m_bForwards = forwards; send.DoFind(true); }
+  void Selected(long first, int start, long last, int end) {
+    assert(top.m_selstart_line == first); assert(top.m_selstart_col == start);
+    assert(top.m_selend_line == last); assert(top.m_selend_col == end);
+    assert(doc.m_DisplayFindInfo.m_pFindPosition == nullptr);
+  }
+  void Unselected() { assert(top.m_selstart_line == -9); assert(top.ensured == 0); }
+};
+int cases = 0;
+void run(const char * name, function<void()> test) {
+  test(); assert(t_regexp::count == 0); ++cases; cout << "PASS: " << name << endl;
+}
+int main() {
+  run("forward wrapped matches and Find Again", [] {
+    Fixture f; f.doc.Add("prefix ab", false); f.doc.Add("cd ef ab", false); f.doc.Add("cd end"); f.doc.Add("tail abcd");
+    f.Find("abcd"); f.Selected(0, 7, 1, 2);
+    f.Again(); f.Selected(1, 6, 2, 2);
+    f.Again(); f.Selected(3, 5, 3, 9);
+  });
+  run("backward wrapped matches and Find Again", [] {
+    Fixture f; f.doc.Add("ab", false); f.doc.Add("cd ab", false); f.doc.Add("cd"); f.doc.Add("last abcd");
+    f.Find("abcd", false); f.Selected(3, 5, 3, 9);
+    f.Again(false); f.Selected(1, 3, 2, 2);
+    f.Again(false); f.Selected(0, 0, 1, 2);
+  });
+  run("direction change uses the whole previous wrapped line", [] {
+    Fixture f; f.doc.Add("abcd"); f.doc.Add("ab", false); f.doc.Add("cd"); f.doc.Add("abcd");
+    f.Find("abcd", false); f.Again(false); f.Selected(1, 0, 2, 2);
+    f.Again(true); f.Selected(3, 0, 3, 4);
+    f.Again(false); f.Selected(1, 0, 2, 2);
+    f.Again(false); f.Selected(0, 0, 0, 4);
+  });
+  run("case flags, regexp ownership, and repeated regexp matches", [] {
+    Fixture f; f.doc.m_DisplayFindInfo.m_bUTF8 = true; f.doc.Add("AB12 ab34");
+    f.Find("ab[0-9]+", true, true); f.Selected(0, 0, 0, 4);
+    assert(f.doc.m_DisplayFindInfo.m_regexp->flags == (PCRE_CASELESS | PCRE_UTF8));
+    f.Again(); f.Selected(0, 5, 0, 9);
+    f.Find("aB", true, false); f.Selected(0, 0, 0, 2);
+    assert(f.doc.m_DisplayFindInfo.m_regexp == nullptr);
+  });
+  run("empty wrapped pieces and match boundary columns", [] {
+    Fixture f; f.doc.Add("", false); f.doc.Add("ab", false); f.doc.Add("", false); f.doc.Add("cd");
+    f.Find("ab"); f.Selected(1, 0, 1, 2);
+    f.Find("cd"); f.Selected(3, 0, 3, 2);
+    f.Find("$", true, true); f.Selected(3, 2, 3, 2);
+  });
+  run("UTF-8 selection uses byte offsets", [] {
+    Fixture f; f.doc.Add("\xc3\xa9" "ab", false); f.doc.Add("cd");
+    f.Find("abcd"); f.Selected(0, 2, 1, 2);
+  });
+  run("empty regexp match on empty wrapped pieces has ordered endpoints", [] {
+    Fixture f; f.doc.Add("", false); f.doc.Add("", false); f.doc.Add("");
+    f.Find("$", true, true); f.Selected(2, 0, 2, 0);
+  });
+  run("append during progress preserves existing match", [] {
+    Fixture f; f.Noise(620); f.doc.At(550)->Change("target");
+    progressCallback = [&] { assert(f.doc.m_iActiveProgressOperations == 1); f.doc.Add("target"); };
+    f.Find(); f.Selected(550, 0, 550, 6); assert(progressCount > 0);
+  });
+  run("new output is outside this invocation's snapshot", [] {
+    Fixture f; f.Noise(620); progressCallback = [&] { f.doc.Add("target"); };
+    f.Find(); f.Unselected(); assert(notFoundCount == 1);
+    f.Again(); f.Selected(620, 0, 620, 6);
+  });
+  run("empty source can be searched again after new output", [] {
+    Fixture f; f.Find(); f.Unselected(); f.doc.Add("target");
+    f.Again(); f.Selected(0, 0, 0, 6);
+  });
+  run("the saved snapshot retains only the matched logical line", [] {
+    Fixture f; f.Noise(620); f.doc.Add("tar", false); f.doc.Add("get target");
+    f.Find(); f.Selected(620, 0, 621, 3);
+    assert(f.send.m_pOutputSearchSnapshot->m_Lines.size() == 2);
+    f.Again(); f.Selected(621, 4, 621, 10);
+    f.Again(); assert(f.send.m_pOutputSearchSnapshot->m_Lines.empty());
+  });
+  run("prune before match remaps selection and cached Find Again", [] {
+    Fixture f; f.Noise(620); f.doc.At(550)->Change("target target");
+    progressCallback = [&] { f.doc.Prune(100); };
+    f.Find(); f.Selected(450, 0, 450, 6);
+    f.doc.Prune(100); f.Again(); f.Selected(350, 7, 350, 13);
+  });
+  run("backward prune remaps wrapped match", [] {
+    Fixture f; f.Noise(100); f.doc.Add("tar", false); f.doc.Add("get"); f.Noise(620);
+    progressCallback = [&] { f.doc.Prune(50); };
+    f.Find("target", false); f.Selected(50, 0, 51, 3);
+  });
+  run("pruned match is rejected", [] {
+    Fixture f; f.Noise(620); f.doc.At(31)->Change("target");
+    progressCallback = [&] { f.doc.Prune(32); };
+    f.Find(); f.Unselected(); assert(f.doc.m_DisplayFindInfo.m_MatchesOnLine.empty());
+  });
+  run("clear and same-text replacement cannot reuse a selection", [] {
+    Fixture f; f.Noise(620); f.doc.At(31)->Change("target");
+    progressCallback = [&] { f.doc.ClearOutput(); f.doc.At(0)->Change("target"); };
+    f.Find(); f.Unselected(); f.Again(); f.Selected(0, 0, 0, 6);
+  });
+  run("shared regexp deletion cannot affect the active find", [] {
+    Fixture f; f.Noise(620); f.doc.At(550)->Change("target42");
+    auto & state = f.doc.m_DisplayFindInfo;
+    state.m_strFindStringList.AddHead("target[0-9]+"); state.m_bRegexp = true;
+    state.m_nCurrentLine = -1; state.m_regexp = regcomp("target[0-9]+", 0);
+    progressCallback = [&] {
+      delete state.m_regexp; state.m_regexp = nullptr;
+      state.m_nCurrentLine = 0; state.m_pFindPosition = nullptr; state.m_bAgain = false;
+      state.m_MatchesOnLine.push_back({400, 500});
+    };
+    f.Again(); f.Selected(550, 0, 550, 8); assert(state.m_MatchesOnLine.empty());
+  });
+  run("same-length text change rejects the match", [] {
+    Fixture f; f.Noise(620); f.doc.At(31)->Change("target");
+    progressCallback = [&] { f.doc.At(31)->Change("change"); };
+    f.Find(); f.Unselected();
+  });
+  run("changed wrap boundary rejects the match", [] {
+    Fixture f; f.Noise(620); f.doc.At(31)->Change("target");
+    progressCallback = [&] { f.doc.At(30)->hard_return = false; };
+    f.Find(); f.Unselected();
+  });
+  run("append to the matched unterminated line rejects the match", [] {
+    Fixture f; f.Noise(31); f.doc.Add("target", false);
+    for (int i = 0; i < 600; ++i) f.doc.Add("suffix", false);
+    progressCallback = [&] { f.doc.At(631)->Change("suffix appended"); };
+    f.Find(); f.Unselected();
+  });
+  run("new wrapped tail fragment rejects the old logical line", [] {
+    Fixture f; f.Noise(31); f.doc.Add("target", false);
+    for (int i = 0; i < 600; ++i) f.doc.Add("suffix", false);
+    progressCallback = [&] { f.doc.Add("extra", false); };
+    f.Find(); f.Unselected();
+  });
+  run("ClearOutput between Find Again calls invalidates saved columns", [] {
+    Fixture f; f.doc.Add("target target"); f.Find(); f.Selected(0, 0, 0, 6);
+    f.doc.ClearOutput(); f.doc.At(0)->Change("xx target"); f.Again(); f.Selected(0, 3, 0, 9);
+  });
+  run("changed text between Find Again calls is searched again", [] {
+    Fixture f; f.doc.Add("target target"); f.Find();
+    f.doc.At(0)->Change("xx target"); f.Again(); f.Selected(0, 3, 0, 9);
+  });
+  run("nested search owns publication", [] {
+    Fixture f; f.Noise(620); f.doc.At(0)->Change("inner"); f.doc.At(550)->Change("target");
+    progressCallback = [&] { f.Find("inner"); f.Selected(0, 0, 0, 5); };
+    f.Find(); f.Selected(0, 0, 0, 5);
+    assert(f.doc.m_DisplayFindInfo.m_strFindStringList.GetHead() == string("inner"));
+  });
+  run("cancelled dialog preserves pending Find Again matches", [] {
+    Fixture f; f.doc.Add("target target"); f.Find();
+    cancelDialog = true; f.Find("different"); f.Again(); f.Selected(0, 7, 0, 13);
+  });
+  run("nested cancelled dialog lets the outer search finish", [] {
+    Fixture f; f.Noise(620); f.doc.At(550)->Change("target");
+    progressCallback = [&] { cancelDialog = true; f.Find("different"); };
+    f.Find(); f.Selected(550, 0, 550, 6);
+  });
+  run("dialog output replacement keeps the pre-dialog source immutable", [] {
+    Fixture f; f.doc.Add("target");
+    modalCallback = [&] { f.doc.ClearOutput(); f.doc.At(0)->Change("target"); };
+    f.Find(); f.Unselected();
+  });
+  run("not-found dialog can replace output without restoring a stale cursor", [] {
+    Fixture f; f.Noise(620); notFoundCallback = [&] { f.doc.ClearOutput(); };
+    f.Find(); f.Unselected(); assert(f.doc.m_DisplayFindInfo.m_nCurrentLine == 0);
+  });
+  run("progress cancellation releases progress and operation ownership", [] {
+    Fixture f; f.Noise(620); f.doc.At(550)->Change("target");
+    progressCallback = [&] { cancelProgress = true; };
+    f.Find(); f.Unselected(); assert(CProgressDlg::count == 0);
+  });
+  run("progress exception propagates and releases ownership", [] {
+    Fixture f; f.Noise(620); progressCallback = [] { throw runtime_error("callback"); };
+    bool threw = false;
+    try { f.Find(); } catch (const runtime_error & e) { threw = string(e.what()) == "callback"; }
+    assert(threw); assert(CProgressDlg::count == 0); assert(f.doc.m_iActiveProgressOperations == 0);
+  });
+  run("progress creation failure propagates", [] {
+    Fixture f; f.Noise(620); failCreate = true; bool threw = false;
+    try { f.Find(); } catch (const runtime_error & e) { threw = string(e.what()) == "progress creation"; }
+    assert(threw); assert(CProgressDlg::count == 0);
+  });
+  run("accepted document close prevents publication", [] {
+    Fixture f; f.Noise(620); f.doc.At(550)->Change("target");
+    progressCallback = [&] { assert(f.doc.m_iActiveProgressOperations == 1); f.doc.m_bWorldClosePending = true; };
+    f.Find(); f.Unselected(); assert(f.doc.m_DisplayFindInfo.m_strFindStringList.IsEmpty());
+  });
+  run("destroyed output window prevents publication", [] {
+    Fixture f; f.Noise(620); f.doc.At(550)->Change("target");
+    progressCallback = [&] { f.top.DestroyWindow(); };
+    f.Find(); f.Unselected();
+  });
+  run("selection callback runs after repaint and inside operation guard", [] {
+    Fixture f; f.doc.Add("target");
+    selectionCallback = [&] { assert(f.top.invalidated == 1); assert(f.doc.m_iActiveProgressOperations == 1); f.doc.ClearOutput(); f.top.DestroyWindow(); };
+    f.Find(); assert(f.top.notified == 1);
+  });
+  cout << cases << " output search cases passed" << endl;
+}

--- a/tests/output_search_snapshot.cpp.in
+++ b/tests/output_search_snapshot.cpp.in
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdarg>
+#include <chrono>
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <deque>
@@ -27,11 +29,40 @@ using HWND = unsigned long;
 #define PCRE_CASELESS 1
 #define PCRE_UTF8 2
 struct CObject {};
+// Count text blocks and length-based CString construction separately. These
+// are source-level allocation counts, not native MFC heap measurements.
+struct TextAllocationProbe {
+  bool active = false;
+  size_t arrays = 0, bytes = 0, largest = 0, strings = 0;
+  int failAfter = -1;
+} textAllocations;
+size_t liveTextArrays = 0;
+void * operator new[](size_t size) {
+  if (textAllocations.active) {
+    if (textAllocations.failAfter == 0) throw bad_alloc();
+    if (textAllocations.failAfter > 0) --textAllocations.failAfter;
+    ++textAllocations.arrays;
+    textAllocations.bytes += size;
+    textAllocations.largest = max(textAllocations.largest, size);
+  }
+  void * result = malloc(size ? size : 1);
+  if (!result) throw bad_alloc();
+  ++liveTextArrays;
+  return result;
+}
+void operator delete[](void * value) noexcept {
+  if (value) { --liveTextArrays; free(value); }
+}
+void operator delete[](void * value, size_t) noexcept { ::operator delete[](value); }
+
 struct CString : string {
   using string::string;
   using string::operator=;
   CString(const string & s) : string(s) {}
-  CString(const char * s, int n) : string(s, n) {}
+  CString(const char * s, int n) : string(s, n) {
+    if (textAllocations.active && n) ++textAllocations.strings;
+  }
+  void Append(const char * s, int n) { append(s, static_cast<size_t>(n)); }
   operator LPCTSTR() const { return c_str(); }
   bool IsEmpty() const { return empty(); }
   int GetLength() const { return static_cast<int>(size()); }
@@ -106,7 +137,7 @@ using InitiateSearch = void (*)(const CObject *, CFindInfo &);
 using GetNextLine = bool (*)(const CObject *, CFindInfo &, CString &);
 bool FindRoutine(const CObject *, CFindInfo &, InitiateSearch, GetNextLine, bool * = nullptr);
 
-function<void()> progressCallback, modalCallback, notFoundCallback, statusCallback, selectionCallback;
+function<void()> progressCallback, modalCallback, notFoundCallback, statusCallback, selectionCallback, ensureCallback;
 bool cancelProgress = false, cancelDialog = false, failCreate = false;
 int progressCount = 0, notFoundCount = 0;
 void invokeOnce(function<void()> & slot) { auto callback = std::move(slot); slot = {}; if (callback) callback(); }
@@ -206,7 +237,7 @@ bool IsWorldDocumentLive(const CMUSHclientDoc * doc, __int64 identity) {
 struct CMUSHView : CWnd {
   long m_selstart_line = -9, m_selend_line = -9;
   int m_selstart_col = -9, m_selend_col = -9, ensured = 0, notified = 0, invalidated = 0;
-  void EnsureSelectionVisible() { ++ensured; }
+  void EnsureSelectionVisible() { ++ensured; invokeOnce(ensureCallback); }
   void Invalidate() { ++invalidated; }
   void NotifySelectionChanged() { ++notified; invokeOnce(selectionCallback); }
 };
@@ -228,7 +259,7 @@ struct Fixture {
   CMUSHView top;
   CSendView send{doc, top};
   Fixture() {
-    progressCallback = modalCallback = notFoundCallback = statusCallback = selectionCallback = {};
+    progressCallback = modalCallback = notFoundCallback = statusCallback = selectionCallback = ensureCallback = {};
     cancelProgress = cancelDialog = failCreate = false;
     dialogText = "target"; dialogRegexp = false; dialogForwards = true; dialogMatchCase = false;
     progressCount = notFoundCount = 0;
@@ -431,5 +462,103 @@ int main() {
     selectionCallback = [&] { assert(f.top.invalidated == 1); assert(f.doc.m_iActiveProgressOperations == 1); f.doc.ClearOutput(); f.top.DestroyWindow(); };
     f.Find(); assert(f.top.notified == 1);
   });
+  run("packed snapshot owns empty, binary, UTF-8, and block-boundary text", [] {
+    Fixture f;
+    vector<string> expected = {"", string(65535, 'a'), string(65536, 'b'),
+      string(65537, 'c'), string("a\0b", 3), "UTF-8: \xe2\x82\xac"};
+    for (const auto & text : expected) f.doc.Add(text);
+    COutputSearchSnapshot snapshot(&f.doc, false);
+    f.doc.ClearLines();
+    CFindInfo find;
+    find.m_bForwards = true;
+    for (size_t i = 0; i < expected.size(); ++i) {
+      find.m_nCurrentLine = i;
+      CString actual;
+      assert(!CSendView::GetNextLine(&snapshot, find, actual));
+      assert(actual == expected[i]);
+    }
+  });
+  run("nested selection visibility preserves the newer compact snapshot", [] {
+    Fixture f; f.Noise(620); f.doc.Add("tar", false); f.doc.Add("get target");
+    ensureCallback = [&] { f.Again(); f.Selected(621, 4, 621, 10); };
+    f.Find(); f.Selected(621, 4, 621, 10);
+    assert(f.send.m_pOutputSearchSnapshot->m_Lines.size() == 2);
+    assert(liveTextArrays == 1);
+    f.doc.Prune(620); f.Again();
+    assert(f.send.m_pOutputSearchSnapshot->m_Lines.empty());
+  });
+  run("compact match allocation failure propagates before result publication", [] {
+    Fixture f; f.doc.Add("target target"); f.Find();
+    const auto matches = f.doc.m_DisplayFindInfo.m_MatchesOnLine;
+    modalCallback = [] {
+      textAllocations = TextAllocationProbe{};
+      textAllocations.active = true;
+      textAllocations.failAfter = 0;
+    };
+    bool threw = false;
+    try { f.Find(); } catch (const bad_alloc &) { threw = true; }
+    textAllocations.active = false;
+    assert(threw && f.doc.m_iActiveProgressOperations == 0);
+    assert(f.doc.m_DisplayFindInfo.m_MatchesOnLine == matches);
+    f.Selected(0, 0, 0, 6);
+    assert(f.doc.m_LineList.GetCount() == 1);
+    f.send.m_pOutputSearchSnapshot.reset();
+    assert(liveTextArrays == 0);
+    f.Find(); f.Selected(0, 0, 0, 6);
+  });
+  run("500000-line snapshot uses bounded text blocks", [] {
+    Fixture f;
+    for (int i = 0; i < 500000; ++i) f.doc.Add(string(80, 'x'));
+    textAllocations = TextAllocationProbe{};
+    textAllocations.active = true;
+    const auto started = chrono::steady_clock::now();
+    COutputSearchSnapshot snapshot(&f.doc, true);
+    const auto elapsed = chrono::steady_clock::now() - started;
+    textAllocations.active = false;
+    cout << "Snapshot text: strings=" << textAllocations.strings
+         << " arrays=" << textAllocations.arrays << " bytes=" << textAllocations.bytes
+         << " largest=" << textAllocations.largest
+         << " milliseconds=" << chrono::duration<double, milli>(elapsed).count() << endl;
+    assert(textAllocations.strings == 0);
+    assert(textAllocations.arrays > 0 && textAllocations.arrays < 1000);
+    assert(textAllocations.bytes >= 40000000 && textAllocations.bytes < 40000000 + 65536);
+    assert(textAllocations.largest <= 65536);
+    f.doc.ClearLines();
+    CFindInfo find;
+    find.m_nCurrentLine = 499999;
+    CString last;
+    assert(!CSendView::GetNextLine(&snapshot, find, last));
+    assert(last == string(80, 'x'));
+  });
+  run("snapshot allocation failure preserves output and pending matches", [] {
+    Fixture f;
+    f.doc.Add("target target"); f.Find();
+    for (int i = 0; i < 2000; ++i) f.doc.Add(string(80, 'x'));
+    const auto previous = f.send.m_pOutputSearchSnapshot;
+    const auto matches = f.doc.m_DisplayFindInfo.m_MatchesOnLine;
+    const auto arraysBefore = liveTextArrays;
+    textAllocations = TextAllocationProbe{};
+    textAllocations.active = true;
+    textAllocations.failAfter = 1;
+    bool threw = false;
+    try { f.Again(); } catch (const bad_alloc &) { threw = true; }
+    textAllocations.active = false;
+    assert(threw && f.doc.m_iActiveProgressOperations == 0);
+    assert(liveTextArrays == arraysBefore);
+    assert(f.send.m_pOutputSearchSnapshot == previous);
+    assert(f.doc.m_LineList.GetCount() == 2001);
+    assert(f.doc.m_DisplayFindInfo.m_MatchesOnLine == matches);
+    f.Again(); f.Selected(0, 7, 0, 13);
+  });
+  run("retained match owns only its compact text and survives Find Again", [] {
+    Fixture f; f.Noise(620); f.doc.Add("tar", false); f.doc.Add("get target");
+    f.Find();
+    assert(f.send.m_pOutputSearchSnapshot->m_TextBlocks.size() == 1);
+    assert(liveTextArrays == 1);
+    f.doc.Prune(620);
+    f.Again(); f.Selected(1, 4, 1, 10);
+    f.Again(); assert(f.send.m_pOutputSearchSnapshot->m_TextBlocks.empty());
+  });
+  assert(liveTextArrays == 0);
   cout << cases << " output search cases passed" << endl;
 }

--- a/tests/paste_file_cleanup.cpp.in
+++ b/tests/paste_file_cleanup.cpp.in
@@ -1,0 +1,208 @@
+// Only OnGamePastefile is extracted production code. All other code is a fixture.
+// CStdioFile owns a real C stream. Its destructor closes the stream once.
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+void Check(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << "CHECK failed: " << message << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+#define CHECK(condition, message) Check(static_cast<bool>(condition), message)
+
+using BOOL = int;
+constexpr int TRUE = 1, IDOK = 1, IDCANCEL = 2;
+constexpr unsigned OFN_HIDEREADONLY = 0x4, OFN_FILEMUSTEXIST = 0x1000;
+constexpr unsigned MB_ICONEXCLAMATION = 0x30;
+
+struct Harness {
+  std::string scenario, path;
+  int allocations = 0, deallocations = 0, constructed = 0, destroyed = 0;
+  int opens = 0, closes = 0, live = 0, helperCalls = 0;
+  int fileExceptions = 0, fileDeletes = 0, fileExceptionDestructors = 0;
+  int resourceExceptions = 0, resourceDeletes = 0, resourceExceptionDestructors = 0;
+  int propagatedResource = 0, propagatedOther = 0, messages = 0;
+  void* resourceIdentity = nullptr;
+} state;
+
+struct CString {
+  std::string value;
+  CString() = default;
+  CString(const char* text) : value(text) {}
+  operator const char*() const { return value.c_str(); }
+  CString& operator+=(const CString& text) { value += text.value; return *this; }
+  void ReleaseBuffer() {}
+};
+
+struct CException {
+  virtual ~CException() = default;
+  virtual void Delete() = 0;
+};
+struct CFileException : CException {
+  enum { fileNotFound = 2, hardIO = 10, endOfFile = 14 };
+  int m_cause;
+  explicit CFileException(int cause) : m_cause(cause) { ++state.fileExceptions; }
+  ~CFileException() override { ++state.fileExceptionDestructors; }
+  void Delete() override { ++state.fileDeletes; delete this; }
+};
+struct CResourceException : CException {
+  CResourceException() { ++state.resourceExceptions; }
+  ~CResourceException() override { ++state.resourceExceptionDestructors; }
+  void Delete() override { ++state.resourceDeletes; delete this; }
+};
+[[noreturn]] void AfxThrowResourceException() {
+  auto* exception = new CResourceException;
+  state.resourceIdentity = exception;
+  throw exception;
+}
+
+struct CFile {
+  enum { modeRead = 0, shareDenyWrite = 0x20 };
+  virtual ~CFile() = default;
+};
+struct CStdioFile : CFile {
+  std::FILE* stream = nullptr;
+  static void* operator new(std::size_t size) {
+    void* object = ::operator new(size);
+    ++state.allocations;
+    return object;
+  }
+  static void operator delete(void* object) noexcept {
+    ++state.deallocations;
+    ::operator delete(object);
+  }
+  CStdioFile(const CString& path, unsigned) {
+    if (state.scenario == "file_open_exception")
+      throw new CFileException(CFileException::fileNotFound);
+    stream = std::fopen(path, "rb");
+    CHECK(stream != nullptr, "real input stream opens");
+    ++state.opens;
+    ++state.live;
+    ++state.constructed;
+  }
+  ~CStdioFile() override {
+    ++state.destroyed;
+    Close();
+  }
+  void Close() {
+    CHECK(stream != nullptr, "file closes exactly once");
+    CHECK(std::fclose(stream) == 0, "real stream closes successfully");
+    stream = nullptr;
+    ++state.closes;
+    --state.live;
+  }
+};
+
+struct CFileDialog {
+  struct { const char* lpstrTitle = nullptr; } m_ofn;
+  CFileDialog(BOOL, const char*, const char*, unsigned, const char*, void*) {}
+  int DoModal() {
+    return state.scenario == "dialog_cancel" ? IDCANCEL : IDOK;
+  }
+  CString GetPathName() const { return state.path.c_str(); }
+};
+void SetFileDialogFileName(CFileDialog&, CString&, const char*) {}
+void ChangeToFileBrowsingDirectory() {}
+void ChangeToStartupDirectory() {}
+void TMessageBox(const char*, unsigned) { ++state.messages; }
+
+struct CMUSHclientDoc {
+  CString m_mush_name, m_file_preamble, m_line_preamble, m_line_postamble, m_file_postamble;
+  BOOL m_bFileCommentedSoftcode = 0, m_bConfirmOnSend = 0, m_bSendEcho = 0;
+  long m_nFileDelay = 0, m_nFileDelayPerLines = 0;
+  void OnGamePastefile();
+  bool SendToMushHelper(CFile* file, CString&, CString&, CString&, CString&,
+                       BOOL, long, long, BOOL, BOOL) {
+    ++state.helperCalls;
+    CHECK(file != nullptr && state.live == 1 && state.destroyed == 0,
+          "helper receives a live file");
+    auto* input = dynamic_cast<CStdioFile*>(file);
+    CHECK(input != nullptr, "helper receives the CStdioFile object");
+    char line[32];
+    CHECK(std::fgets(line, sizeof line, input->stream) != nullptr &&
+          std::strcmp(line, "first line\n") == 0, "helper can read the open stream");
+    if (state.scenario == "send_cancel") return false;
+    if (state.scenario == "file_read_exception") throw new CFileException(CFileException::hardIO);
+    if (state.scenario == "file_eof") throw new CFileException(CFileException::endOfFile);
+    if (state.scenario == "resource_exception") AfxThrowResourceException();
+    if (state.scenario == "other_exception") throw std::runtime_error("paste helper failure");
+    CHECK(std::fgets(line, sizeof line, input->stream) != nullptr &&
+          std::strcmp(line, "second line\n") == 0, "helper reads the second line");
+    CHECK(std::fgets(line, sizeof line, input->stream) == nullptr &&
+          std::feof(input->stream) && !std::ferror(input->stream), "normal input reaches EOF");
+    return true;
+  }
+};
+
+@PASTE_FILE@
+
+int main(int argc, char** argv) {
+  CHECK(argc == 3, "usage: paste_file_cleanup CASE INPUT_FILE");
+  state.scenario = argv[1];
+  state.path = argv[2];
+  const std::vector<std::string> cases = {
+      "normal", "dialog_cancel", "send_cancel", "file_open_exception",
+      "file_read_exception", "file_eof", "resource_exception", "other_exception"};
+  bool known = false;
+  for (const auto& scenario : cases) known = known || state.scenario == scenario;
+  CHECK(known, "known test case");
+
+  CMUSHclientDoc doc;
+  try {
+    doc.OnGamePastefile();
+  } catch (CResourceException* exception) {
+    CHECK(state.scenario == "resource_exception", "resource exception is expected");
+    CHECK(exception == state.resourceIdentity, "original resource exception propagates");
+    CHECK(state.resourceDeletes == 0, "production leaves resource exception ownership to caller");
+    ++state.propagatedResource;
+    exception->Delete();
+  } catch (const std::runtime_error& exception) {
+    CHECK(state.scenario == "other_exception", "other exception is expected");
+    CHECK(std::strcmp(exception.what(), "paste helper failure") == 0,
+          "other exception type and message propagate");
+    ++state.propagatedOther;
+  }
+
+  std::cout << "COUNTERS: allocations=" << state.allocations
+            << " deallocations=" << state.deallocations
+            << " constructed=" << state.constructed << " destroyed=" << state.destroyed
+            << " opens=" << state.opens << " closes=" << state.closes << " live=" << state.live
+            << " fileDeletes=" << state.fileDeletes << " messages=" << state.messages
+            << " resourcePropagated=" << state.propagatedResource
+            << " otherPropagated=" << state.propagatedOther << std::endl;
+  const bool cancelled = state.scenario == "dialog_cancel";
+  const bool openFailed = state.scenario == "file_open_exception";
+  const int opened = !cancelled && !openFailed;
+  CHECK(state.constructed == opened && state.opens == opened, "expected file construction and open count");
+  CHECK(state.destroyed == opened, "file destructor runs exactly once for each constructed file");
+  CHECK(state.closes == opened && state.live == 0, "all opened streams close exactly once");
+  CHECK(state.allocations == !cancelled && state.deallocations == state.allocations,
+        "file allocation is released, including failed construction");
+  CHECK(state.helperCalls == opened, "helper runs only after file open");
+  const int fileException = openFailed || state.scenario == "file_read_exception" ||
+                            state.scenario == "file_eof";
+  CHECK(state.fileExceptions == fileException && state.fileDeletes == fileException &&
+        state.fileExceptionDestructors == fileException, "file exception is caught and deleted once");
+  CHECK(state.messages == (openFailed || state.scenario == "file_read_exception"),
+        "only non-EOF file exceptions show the file error dialog");
+  const int resourceException = state.scenario == "resource_exception";
+  CHECK(state.propagatedResource == resourceException &&
+        state.resourceExceptions == resourceException && state.resourceDeletes == resourceException &&
+        state.resourceExceptionDestructors == resourceException,
+        "resource exception propagates and is deleted by the caller");
+  CHECK(state.propagatedOther == (state.scenario == "other_exception"), "other exception propagates");
+#ifdef NDEBUG
+  std::cout << "PASS NDEBUG: ";
+#else
+  std::cout << "PASS debug: ";
+#endif
+  std::cout << state.scenario << '\n';
+}

--- a/tests/progress_messages.cpp.in
+++ b/tests/progress_messages.cpp.in
@@ -1,0 +1,1035 @@
+// This fixture compiles production functions. The MFC and Lua substitutes model
+// synchronous callbacks, window invalidation and document deletion. CHECK stays
+// active in every build. Test operations never occur inside assert or CHECK.
+#include <algorithm>
+#include <chrono>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <deque>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+#ifdef PROGRESS_NATIVE_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <winsock2.h>
+#include <windows.h>
+#else
+using BOOL = int;
+using UINT = unsigned;
+using DWORD = unsigned long;
+using LONG = long;
+using HWND = void *;
+using HANDLE = void *;
+using WPARAM = uintptr_t;
+using LPARAM = intptr_t;
+using LRESULT = intptr_t;
+using __int64 = long long;
+using LPCTSTR = const char *;
+constexpr BOOL TRUE = 1, FALSE = 0;
+constexpr UINT WM_QUIT = 0x12, WM_CLOSE = 0x10, WM_COMMAND = 0x111, WM_APP = 0x8000;
+constexpr UINT PM_REMOVE = 1;
+constexpr int IDCANCEL = 2, SW_HIDE = 0, SOCKET_ERROR = -1, WSAEWOULDBLOCK = 10035;
+struct MSG { HWND hwnd{}; UINT message{}; WPARAM wParam{}; LPARAM lParam{}; };
+#endif
+using std::deque;
+using std::string;
+#define CHECK(value) do { if (!(value)) { \
+    std::cerr << "CHECK failed: " #value << " at line " << __LINE__ << '\n'; \
+    std::abort(); } } while (false)
+#define ASSERT(value) CHECK(value)
+#define _T(value) value
+#define BASED_CODE
+#define DEBUG_NEW new
+#define DECLARE_MESSAGE_MAP()
+#define BEGIN_MESSAGE_MAP(a, b)
+#define END_MESSAGE_MAP()
+#define RUNTIME_CLASS(a) 1
+constexpr UINT CG_IDS_PROGRESS_CAPTION = 10, CG_IDD_PROGRESS = 11;
+constexpr int CG_IDC_PROGDLG_PROGRESS = 12, CG_IDC_PROGDLG_STATUS = 13, CG_IDC_PROGDLG_PERCENT = 14;
+constexpr UINT callbackMessage = WM_APP + 21;
+#ifdef PROGRESS_NATIVE_WINDOWS
+constexpr UINT socketMessage = WM_APP + 22;
+#endif
+
+struct CString : std::string {
+    using std::string::string;
+    CString(const std::string &s) : std::string(s) {}
+    operator LPCTSTR() const { return c_str(); }
+    int GetLength() const { return static_cast<int>(size()); }
+    CString Mid(int n) const { return substr(n); }
+    void Empty() { clear(); }
+    void Format(const char *format, ...) {
+        char buffer[128];
+        va_list args;
+        va_start(args, format);
+        int count = vsnprintf(buffer, sizeof buffer, format, args);
+        va_end(args);
+        CHECK(count >= 0 && count < static_cast<int>(sizeof buffer));
+        assign(buffer);
+    }
+};
+struct CWnd;
+std::map<HWND, CWnd *> permanentWindows;
+std::map<HWND, HWND> windowParents;
+std::map<size_t, std::function<void()>> callbacks;
+std::function<void(const char *, HWND)> controlHook;
+std::function<void()> beforePeek;
+std::vector<std::string> controlTrace;
+size_t nextCallback = 0;
+int dialogDestructions = 0;
+int dialogConstructions = 0;
+bool failDialogCreate = false;
+std::function<void()> onDialogDestruction;
+std::function<void(WPARAM, LPARAM)> socketDispatch;
+void invoke_callback(size_t id) {
+    auto it = callbacks.find(id);
+    CHECK(it != callbacks.end());
+    auto callback = std::move(it->second);
+    callbacks.erase(it);
+    callback();
+}
+#ifdef PROGRESS_NATIVE_WINDOWS
+LRESULT CALLBACK queue_window_proc(HWND window, UINT message, WPARAM wp, LPARAM lp) {
+    if (message == callbackMessage) { invoke_callback(static_cast<size_t>(wp)); return 0; }
+    if (message == socketMessage) { CHECK(bool(socketDispatch)); socketDispatch(wp, lp); return 0; }
+    return DefWindowProcA(window, message, wp, lp);
+}
+HWND make_window(HWND parent = nullptr) {
+    static bool registered = false;
+    if (!registered) {
+        WNDCLASSA cls{};
+        cls.lpfnWndProc = queue_window_proc;
+        cls.hInstance = GetModuleHandleA(nullptr);
+        cls.lpszClassName = "MushProgressRegression";
+        ATOM atom = RegisterClassA(&cls);
+        CHECK(atom != 0);
+        registered = true;
+    }
+    HWND window = CreateWindowExA(0, "MushProgressRegression", "", parent ? WS_CHILD : 0,
+                                  0, 0, 0, 0, parent, nullptr, GetModuleHandleA(nullptr), nullptr);
+    CHECK(window != nullptr);
+    windowParents[window] = parent;
+    return window;
+}
+#else
+std::deque<MSG> messageQueue;
+uintptr_t nextWindow = 0;
+HWND make_window(HWND parent = nullptr) {
+    HWND window = reinterpret_cast<HWND>(++nextWindow);
+    windowParents[window] = parent;
+    return window;
+}
+BOOL IsWindow(HWND window) { return window != nullptr && windowParents.count(window) != 0; }
+BOOL PeekMessage(MSG *message, HWND window, UINT first, UINT last, UINT flags) {
+    CHECK(flags == PM_REMOVE);
+    if (beforePeek) {
+        auto callback = std::move(beforePeek);
+        beforePeek = nullptr;
+        callback();  // PeekMessage dispatches pending sent messages before retrieval.
+    }
+    for (auto it = messageQueue.begin(); it != messageQueue.end(); ++it) {
+        if (it->message == WM_QUIT ||
+            ((!window || it->hwnd == window) &&
+             ((!first && !last) || (it->message >= first && it->message <= last)))) {
+            *message = *it;
+            messageQueue.erase(it);
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+BOOL PostMessage(HWND window, UINT message, WPARAM wp, LPARAM lp) {
+    messageQueue.push_back({window, message, wp, lp});
+    return TRUE;
+}
+void PostQuitMessage(int code) { messageQueue.push_back({nullptr, WM_QUIT, static_cast<WPARAM>(code), 0}); }
+BOOL TranslateMessage(const MSG *) { return TRUE; }
+LRESULT DispatchMessage(const MSG *message) {
+    CHECK(message->message == callbackMessage);
+    invoke_callback(static_cast<size_t>(message->wParam));
+    return 0;
+}
+#endif
+void post_callback(HWND window, std::function<void()> callback) {
+    const size_t id = ++nextCallback;
+    callbacks.emplace(id, std::move(callback));
+    BOOL posted = PostMessage(window, callbackMessage, static_cast<WPARAM>(id), 0);
+    CHECK(posted);
+}
+void control_access(const char *operation, HWND window) {
+    CHECK(::IsWindow(window));
+    controlTrace.push_back(operation);
+    auto callback = controlHook;
+    if (callback) callback(operation, window);
+}
+void invalidate_window(HWND window);
+struct CWnd {
+    HWND m_hWnd = nullptr;
+    CString text;
+    BOOL enabled = TRUE;
+    virtual ~CWnd() {
+        if (m_hWnd && ::IsWindow(m_hWnd)) invalidate_window(m_hWnd);
+    }
+    HWND GetSafeHwnd() const { return m_hWnd; }
+    static CWnd *FromHandlePermanent(HWND window) {
+        auto it = permanentWindows.find(window);
+        return it == permanentWindows.end() ? nullptr : it->second;
+    }
+    static CWnd *GetSafeOwner(CWnd *parent) { return parent; }
+    void attach(HWND parent = nullptr) {
+        CHECK(!m_hWnd);
+        m_hWnd = make_window(parent);
+        permanentWindows[m_hWnd] = this;
+    }
+    BOOL IsWindowEnabled() const {
+        CHECK(::IsWindow(m_hWnd));
+#ifdef PROGRESS_NATIVE_WINDOWS
+        return ::IsWindowEnabled(m_hWnd);
+#else
+        return enabled;
+#endif
+    }
+    BOOL EnableWindow(BOOL value) {
+        enabled = value;
+#ifdef PROGRESS_NATIVE_WINDOWS
+        ::EnableWindow(m_hWnd, value);
+#endif
+        control_access("EnableWindow", m_hWnd);
+        return TRUE;
+    }
+    void SetWindowText(LPCTSTR value) {
+        text = value;
+        control_access("SetWindowText", m_hWnd);
+    }
+    void GetWindowText(CString &value) const {
+        value = text;
+        control_access("GetWindowText", m_hWnd);
+    }
+    void ShowWindow(int) { control_access("ShowWindow", m_hWnd); }
+    virtual BOOL DestroyWindow() {
+        CHECK(::IsWindow(m_hWnd));
+        control_access("DestroyWindow", m_hWnd);
+        invalidate_window(m_hWnd);
+        return TRUE;
+    }
+};
+void invalidate_window(HWND window) {
+    std::vector<HWND> children;
+    for (const auto &entry : windowParents)
+        if (entry.second == window) children.push_back(entry.first);
+    for (HWND child : children) invalidate_window(child);
+    auto found = permanentWindows.find(window);
+    if (found != permanentWindows.end()) {
+        found->second->m_hWnd = nullptr;
+        permanentWindows.erase(found);
+    }
+    windowParents.erase(window);
+#ifdef PROGRESS_NATIVE_WINDOWS
+    BOOL destroyed = ::DestroyWindow(window);
+    CHECK(destroyed);
+#endif
+}
+struct CProgressCtrl : CWnd {
+    int position = 0, step = 10;
+    void SetRange(int, int) { control_access("SetRange", m_hWnd); }
+    void SetRange32(int, int) { control_access("SetRange32", m_hWnd); }
+    int SetPos(int value) {
+        int previous = position; position = value;
+        control_access("SetPos", m_hWnd); return previous;
+    }
+    int OffsetPos(int value) {
+        int previous = position; position += value;
+        control_access("OffsetPos", m_hWnd); return previous;
+    }
+    int SetStep(int value) {
+        int previous = step; step = value;
+        control_access("SetStep", m_hWnd); return previous;
+    }
+    int StepIt() {
+        int previous = position; position += step;
+        control_access("StepIt", m_hWnd); return previous;
+    }
+};
+#ifndef PROGRESS_NATIVE_WINDOWS
+BOOL EnableWindow(HWND window, BOOL enabled) {
+    CWnd *owner = CWnd::FromHandlePermanent(window);
+    CHECK(owner != nullptr);
+    return owner->EnableWindow(enabled);
+}
+#endif
+struct CDataExchange {};
+struct CDialog : CWnd {
+    CWnd *m_pParentWnd = nullptr;
+    CWnd status, percent, cancel;
+    CDialog() { ++dialogConstructions; }
+    virtual ~CDialog() {
+        ++dialogDestructions;
+        if (onDialogDestruction) onDialogDestruction();
+    }
+    virtual void DoDataExchange(CDataExchange *) {}
+    virtual BOOL OnInitDialog() { return TRUE; }
+    virtual void OnCancel() {}
+    virtual void OnOK() {}
+    BOOL Create(UINT, CWnd *) {
+        if (failDialogCreate) return FALSE;
+        attach(); status.attach(m_hWnd); percent.attach(m_hWnd); cancel.attach(m_hWnd);
+        return TRUE;
+    }
+    CWnd *GetDlgItem(int id) {
+        control_access("GetDlgItem", m_hWnd);
+        if (id == CG_IDC_PROGDLG_STATUS) return &status;
+        if (id == CG_IDC_PROGDLG_PERCENT) return &percent;
+        CHECK(id == IDCANCEL);
+        return &cancel;
+    }
+    BOOL IsDialogMessage(MSG *message) {
+        control_access("IsDialogMessage", m_hWnd);
+        if (message->hwnd == m_hWnd && message->message == WM_COMMAND && message->wParam == IDCANCEL) {
+            OnCancel(); return TRUE;
+        }
+        return FALSE;
+    }
+};
+void DDX_Control(CDataExchange *, int, CProgressCtrl &) {}
+@PROGRESS_HEADER@
+@PROGRESS_BODY@
+struct TestProgress : CProgressDlg {
+    using CProgressDlg::PumpMessages;
+    using CProgressDlg::OnCancel;
+    void create(CWnd *parent = nullptr) {
+        BOOL created = Create(parent);
+        CHECK(created);
+        m_Progress.attach(m_hWnd);
+    }
+};
+
+// The userdata holds the real production CProgressDlg pointer. Only the Lua
+// argument stack and error API are substituted; all called wrappers are extracted.
+const char progress_dlg_handle[] = "mushclient.progress_dialog_handle";
+struct lua_State {
+    CProgressDlg *handle = nullptr;
+    std::string argument = "status";
+    int first = 4, second = 100;
+    bool boolean = false;
+    bool rejectArgument = false, rejectAllocation = false;
+    bool metatableInstalled = false;
+    std::function<void()> onStringConversion;
+};
+void *luaL_checkudata(lua_State *L, int index, const char *) { CHECK(index == 1); return &L->handle; }
+void luaL_argcheck(lua_State *, bool valid, int, const char *) {
+    if (!valid) throw std::runtime_error("closed Lua handle");
+}
+const char *luaL_checkstring(lua_State *L, int) {
+    if (L->rejectArgument) throw std::runtime_error("invalid Lua string");
+    auto callback = std::move(L->onStringConversion);
+    L->onStringConversion = nullptr;
+    if (callback) callback();
+    return L->argument.c_str();
+}
+int luaL_checkinteger(lua_State *L, int index) {
+    if (L->rejectArgument) throw std::runtime_error("invalid Lua integer");
+    return index == 2 ? L->first : L->second;
+}
+void lua_pushboolean(lua_State *L, BOOL value) { L->boolean = value != 0; }
+const char *luaL_optstring(lua_State *L, int index, const char *) { return luaL_checkstring(L, index); }
+void *lua_newuserdata(lua_State *L, size_t size) {
+    CHECK(size == sizeof(CProgressDlg *));
+    if (L->rejectAllocation) throw std::bad_alloc();
+    return &L->handle;
+}
+void luaL_getmetatable(lua_State *, const char *) {}
+void lua_setmetatable(lua_State *L, int) { CHECK(!L->handle); L->metatableInstalled = true; }
+int liveMfcExceptions = 0, deletedMfcExceptions = 0;
+struct CException {
+    const char *message;
+    explicit CException(const char *text) : message(text) { ++liveMfcExceptions; }
+    BOOL GetErrorMessage(char *buffer, size_t length) const {
+        int count = std::snprintf(buffer, length, "%s", message);
+        return count >= 0 && static_cast<size_t>(count) < length;
+    }
+    void Delete() { --liveMfcExceptions; ++deletedMfcExceptions; delete this; }
+};
+struct LuaError : std::runtime_error { using std::runtime_error::runtime_error; };
+[[noreturn]] int luaL_error(lua_State *L, const char *format, ...) {
+    CHECK(!L->handle && liveMfcExceptions == 0);
+    char message[1024];
+    va_list args;
+    va_start(args, format);
+    int count = std::vsnprintf(message, sizeof message, format, args);
+    va_end(args);
+    CHECK(count >= 0 && count < static_cast<int>(sizeof message));
+    throw LuaError(message); // Real Lua longjmp is covered by check_lua_progress_errors.py.
+}
+[[noreturn]] void AfxThrowResourceException() { throw new CException("Create failed"); }
+@LUA@
+
+// The transport boundary can return partial sends and WSAEWOULDBLOCK. OnSend is
+// production code. Native mode also runs this function against a real socket.
+constexpr int eChatConnection = 1;
+CString TFormat(const char *, const char *, int, const char *) { return "send failed"; }
+struct ChatDoc {
+    int m_nBytesOut = 0;
+    void ChatNote(int, CString) { CHECK(false); }
+    const char *GetSocketError(int) { return "unexpected socket error"; }
+};
+struct CChatSocket {
+    bool m_bDeleteMe = false;
+    CString m_outstanding_output = "pending chat payload", m_strServerName = "peer";
+    ChatDoc doc;
+    ChatDoc *m_pDoc = &doc;
+    int calls = 0, lastError = WSAEWOULDBLOCK;
+    std::function<int(const char *, int)> transport;
+    int Send(const char *data, int length) { ++calls; CHECK(bool(transport)); return transport(data, length); }
+    int GetLastError() const { return lastError; }
+    void OnClose(int) { CHECK(false); }
+    void OnSend(int);
+};
+void ShutDownSocket(CChatSocket &) { CHECK(false); }
+@SEND@
+
+struct CDocument;
+struct DocNode { CDocument *doc; DocNode *next; };
+using POSITION = DocNode *;
+struct DocTemplate {
+    DocNode *head = nullptr;
+    POSITION GetFirstDocPosition() const { return head; }
+    CDocument *GetNextDoc(POSITION &position) const {
+        CHECK(position); auto *doc = position->doc; position = position->next; return doc;
+    }
+    void add(CDocument *doc) { head = new DocNode{doc, head}; }
+    void remove(CDocument *doc) {
+        for (auto **node = &head; *node; node = &(*node)->next) {
+            if ((*node)->doc == doc) { auto *old = *node; *node = old->next; delete old; return; }
+        }
+        CHECK(false);
+    }
+};
+std::map<__int64, int> documentCloses;
+__int64 nextDocument = 0;
+struct CDocument {
+    __int64 identity = ++nextDocument;
+    DocTemplate *owner;
+    explicit CDocument(DocTemplate *registry) : owner(registry) { owner->add(this); }
+    virtual ~CDocument() { owner->remove(this); }
+    virtual int activeOperations() const = 0;
+    void OnCloseDocument() {
+        CHECK(activeOperations() == 0);
+        CHECK(!CProgressDlg::IsPumpingMessages());
+        ++documentCloses[identity]; delete this;
+    }
+};
+struct CMUSHclientDoc;
+struct CTextDocument;
+@DEFERRED_TYPE@
+struct CWinApp { BOOL OnIdle(LONG) { return FALSE; } };
+struct ActivityDoc { void UpdateAllViews(void *) { CHECK(false); } };
+struct CMUSHclientApp : CWinApp {
+    DocTemplate worlds, texts;
+    DocTemplate *m_pWorldDocTemplate = &worlds, *m_pNormalDocTemplate = &texts;
+    deque<CDeferredMessage> m_DeferredMessages;
+    deque<__int64> m_DeferredWorldDocumentCloses, m_DeferredTextDocumentCloses;
+    bool m_bUpdateActivity = false;
+    ActivityDoc *m_pActivityDoc = nullptr;
+    int m_nActivityWindowRefreshType = 0;
+    enum { eRefreshPeriodically = 1 };
+    void UpdateWorldCounts() { CHECK(false); }
+    void DeferMessageUntilIdle(const MSG &, __int64 = 0, HANDLE = nullptr, unsigned long = 0, long = 0);
+    void DeferWorldDocumentClose(__int64);
+    void DeferTextDocumentClose(__int64);
+    bool HasActiveDocumentOperations() const;
+    BOOL OnIdle(LONG);
+} App;
+struct CMUSHclientDoc : CDocument {
+    __int64 m_iUniqueDocumentNumber = identity;
+    int m_iActiveProgressOperations = 0;
+    bool m_bWorldClosePending = false, m_bWorldCloseQueued = false;
+    bool m_bPluginListChangedPending = false, m_bInPluginListChanged = false;
+    bool m_bScriptFileChangedPending = false, m_bInScriptFileChanged = false;
+    CMUSHclientDoc() : CDocument(&App.worlds) {}
+    int activeOperations() const override { return m_iActiveProgressOperations; }
+    void BeginProgressOperation(); void EndProgressOperation(); void OnCloseDocument();
+    void PluginListChanged() { CHECK(false); }
+    void OnScriptFileChanged() { CHECK(false); }
+};
+struct CTextDocument : CDocument {
+    __int64 m_iTextDocumentNumber = identity;
+    __int64 m_iMonitorToken = identity;
+    int m_iActiveOperations = 0;
+    bool m_bClosePending = false, m_bCloseQueued = false;
+    bool m_bFileChangedPending = false, m_bInFileChanged = false;
+    CTextDocument() : CDocument(&App.texts) {}
+    int activeOperations() const override { return m_iActiveOperations; }
+    void BeginOperation(); void EndOperation(); void OnCloseDocument();
+    void OnFileChanged() { CHECK(false); }
+};
+@WORLD_GUARD@
+@TEXT_GUARD@
+void StopMonitoringThread(__int64) {}
+void CollectMonitoringThreads() {}
+struct CFrameWnd { bool IsKindOf(int) { return false; } };
+struct CMUSHView { BOOL mouse_still_down() { CHECK(false); return FALSE; } };
+struct CChildFrame : CFrameWnd { CMUSHView *m_topview = nullptr; };
+struct CMainFrame : CWnd {
+    struct Tabs { bool InUse() { return false; } void Update() { CHECK(false); } } m_wndMDITabs;
+    std::vector<CDeferredMessage> delivered;
+    CFrameWnd *GetActiveFrame() { return nullptr; }
+    void ProcessDeferredMessage(const CDeferredMessage &message) {
+        CHECK(!CProgressDlg::IsPumpingMessages()); delivered.push_back(message);
+    }
+} Frame;
+#ifndef PROGRESS_NATIVE_WINDOWS
+HWND GetForegroundWindow() { return nullptr; }
+#endif
+@DOCUMENTS@
+@APP@
+
+void test_blocked_chat() {
+    TestProgress progress; progress.create();
+    CWnd socketWindow; socketWindow.attach();
+    CChatSocket chat;
+    bool writable = false;
+    std::string delivered;
+    chat.transport = [&](const char *bytes, int size) {
+        if (!writable) return SOCKET_ERROR;
+        // First ready notification sends only part of the buffer.
+        int count = std::min(size, 7); delivered.append(bytes, count); return count;
+    };
+    chat.OnSend(0);
+    CHECK(chat.calls == 1 && delivered.empty());
+    std::function<void()> ready = [&] {
+        CHECK(CProgressDlg::IsPumpingMessages());
+        writable = true; chat.OnSend(0);
+        if (chat.m_outstanding_output.GetLength()) post_callback(socketWindow.m_hWnd, ready);
+    };
+    post_callback(socketWindow.m_hWnd, ready);
+    progress.PumpMessages();
+    CHECK(delivered == "pending chat payload");
+    CHECK(chat.m_outstanding_output.empty());
+    CHECK(chat.doc.m_nBytesOut == static_cast<int>(delivered.size()));
+}
+void test_cancel_quit() {
+    TestProgress progress; progress.create();
+    BOOL posted = PostMessage(progress.m_hWnd, WM_COMMAND, IDCANCEL, 0); CHECK(posted);
+    BOOL cancelled = progress.CheckCancelButton(); CHECK(cancelled);
+    cancelled = progress.CheckCancelButton(); CHECK(!cancelled);
+    PostQuitMessage(73);
+    cancelled = progress.CheckCancelButton(); CHECK(cancelled);
+    MSG message{};
+    BOOL found = PeekMessage(&message, nullptr, WM_QUIT, WM_QUIT, PM_REMOVE);
+    CHECK(found && message.message == WM_QUIT && message.wParam == 73);
+    found = PeekMessage(&message, nullptr, WM_QUIT, WM_QUIT, PM_REMOVE); CHECK(!found);
+    CHECK(!CProgressDlg::IsPumpingMessages());
+}
+void test_late_quit() {
+    TestProgress progress; progress.create();
+    post_callback(Frame.m_hWnd, [] { PostQuitMessage(91); });
+    BOOL cancelled = progress.CheckCancelButton(); CHECK(cancelled);
+    MSG message{};
+    BOOL found = PeekMessage(&message, nullptr, WM_QUIT, WM_QUIT, PM_REMOVE);
+    CHECK(found && message.wParam == 91);
+    CHECK(!CProgressDlg::IsPumpingMessages());
+}
+void test_cancel_stops() {
+    TestProgress progress; progress.create();
+    bool delivered = false;
+    BOOL posted = PostMessage(progress.m_hWnd, WM_COMMAND, IDCANCEL, 0); CHECK(posted);
+    post_callback(Frame.m_hWnd, [&] { delivered = true; });
+    BOOL cancelled = progress.CheckCancelButton();
+    CHECK(cancelled && !delivered);
+    cancelled = progress.CheckCancelButton();
+    CHECK(!cancelled && delivered);
+}
+void test_nested_depth() {
+    TestProgress outer, inner; outer.create(); inner.create();
+    int count = 0;
+    post_callback(Frame.m_hWnd, [&] {
+        CHECK(CProgressDlg::IsPumpingMessages());
+        post_callback(Frame.m_hWnd, [&] { CHECK(CProgressDlg::IsPumpingMessages()); ++count; });
+        inner.PumpMessages();
+        CHECK(CProgressDlg::IsPumpingMessages()); ++count;
+    });
+    outer.PumpMessages();
+    CHECK(count == 2 && !CProgressDlg::IsPumpingMessages());
+}
+void test_exception_depth() {
+    TestProgress outer, inner; outer.create(); inner.create();
+    bool caught = false;
+    // Use the MFC IsDialogMessage boundary for exceptions. A C++ exception is
+    // not allowed to cross the native Windows WNDPROC ABI in native mode.
+    controlHook = [&](const char *name, HWND) {
+        if (std::string(name) != "IsDialogMessage") return;
+        controlHook = nullptr;
+        post_callback(Frame.m_hWnd, [] {});
+        controlHook = [&](const char *operation, HWND) {
+            if (std::string(operation) == "IsDialogMessage") throw std::runtime_error("MFC callback");
+        };
+        try { inner.PumpMessages(); } catch (const std::runtime_error &) {
+            CHECK(CProgressDlg::IsPumpingMessages());
+            controlHook = nullptr;
+            throw;
+        }
+    };
+    post_callback(Frame.m_hWnd, [] {});
+    try { outer.PumpMessages(); } catch (const std::runtime_error &) { caught = true; }
+    controlHook = nullptr;
+    CHECK(caught && !CProgressDlg::IsPumpingMessages());
+    // The failed IsDialogMessage retrieved, but did not dispatch, its callback.
+    callbacks.clear();
+}
+void test_lua_nested_close() {
+    lua_State L;
+    auto *progress = new TestProgress; progress->create(); L.handle = progress;
+    int destroyed = dialogDestructions;
+    bool innerReturned = false;
+    onDialogDestruction = [&] { CHECK(L.handle == nullptr); };
+    post_callback(Frame.m_hWnd, [&] {
+        post_callback(Frame.m_hWnd, [&] {
+            int result = Lprogress_gc(&L); CHECK(result == 0);
+            CHECK(L.handle == nullptr && dialogDestructions == destroyed);
+            result = Lprogress_gc(&L); CHECK(result == 0);
+        });
+        int result = Lprogress_setposition(&L); CHECK(result == 0);
+        CHECK(dialogDestructions == destroyed);
+        innerReturned = true;
+    });
+    int result = Lprogress_setposition(&L); CHECK(result == 0);
+    CHECK(innerReturned && L.handle == nullptr && dialogDestructions == destroyed + 1);
+    CHECK(!CProgressDlg::IsPumpingMessages());
+    onDialogDestruction = nullptr;
+}
+void test_lua_immediate_close() {
+    lua_State L;
+    auto *progress = new TestProgress; progress->create(); L.handle = progress;
+    int destroyed = dialogDestructions;
+    bool invalidBeforeDestroy = false;
+    controlHook = [&](const char *operation, HWND) {
+        if (std::string(operation) == "DestroyWindow") {
+            CHECK(L.handle == nullptr); invalidBeforeDestroy = true;
+            int result = Lprogress_gc(&L); CHECK(result == 0);
+        }
+    };
+    int result = Lprogress_gc(&L); CHECK(result == 0);
+    CHECK(invalidBeforeDestroy && dialogDestructions == destroyed + 1);
+    result = Lprogress_gc(&L); CHECK(result == 0);
+    controlHook = nullptr;
+}
+void test_lua_control_close() {
+    using Method = int (*)(lua_State *);
+    for (Method method : {Lprogress_setstatus, Lprogress_setrange, Lprogress_setposition,
+                          Lprogress_setstep, Lprogress_stepit, Lprogress_checkcancel}) {
+        lua_State L; L.first = 0;
+        auto *progress = new TestProgress; progress->create(); L.handle = progress;
+        int destroyed = dialogDestructions;
+        bool closed = false;
+        if (method == Lprogress_checkcancel) post_callback(Frame.m_hWnd, [&] {
+            int result = Lprogress_gc(&L); CHECK(result == 0); closed = true;
+            CHECK(dialogDestructions == destroyed);
+        });
+        else controlHook = [&](const char *operation, HWND) {
+            std::string name = operation;
+            if (closed || name == "GetDlgItem" || name == "IsDialogMessage") return;
+            closed = true;
+            int result = Lprogress_gc(&L); CHECK(result == 0);
+            CHECK(dialogDestructions == destroyed);
+        };
+        int result = method(&L); CHECK(result == (method == Lprogress_checkcancel ? 1 : 0));
+        CHECK(closed && !L.handle && dialogDestructions == destroyed + 1);
+        controlHook = nullptr;
+    }
+}
+void test_lua_exception() {
+    lua_State L;
+    auto *progress = new TestProgress; progress->create(); L.handle = progress;
+    int destroyed = dialogDestructions;
+    bool caught = false;
+    controlHook = [&](const char *operation, HWND) {
+        if (std::string(operation) != "SetPos") return;
+        controlHook = nullptr;
+        int result = Lprogress_gc(&L); CHECK(result == 0);
+        CHECK(dialogDestructions == destroyed);
+        throw std::runtime_error("synchronous control failure");
+    };
+    try { Lprogress_setposition(&L); } catch (const std::runtime_error &) { caught = true; }
+    CHECK(caught && !L.handle && dialogDestructions == destroyed + 1);
+    CHECK(!CProgressDlg::IsPumpingMessages());
+}
+void perform_update(TestProgress &progress, int method) {
+    if (method == 0) progress.SetPos(12);
+    else if (method == 1) progress.OffsetPos(12);
+    else if (method == 2) progress.StepIt();
+    else progress.CheckCancelButton();
+}
+void test_destroy_dispatch() {
+    for (int method = 0; method != 4; ++method) {
+        TestProgress progress; progress.create();
+        post_callback(Frame.m_hWnd, [&] { BOOL destroyed = progress.DestroyWindow(); CHECK(destroyed); });
+        perform_update(progress, method);
+        CHECK(!progress.m_hWnd && !CProgressDlg::IsPumpingMessages());
+    }
+}
+#ifdef PROGRESS_NATIVE_WINDOWS
+std::thread arrange_sent_message(HWND, std::function<void()>);
+#endif
+void test_destroy_sent() {
+    for (int method = 0; method != 4; ++method) {
+        TestProgress progress; progress.create();
+        auto destroy = [&] { BOOL destroyed = progress.DestroyWindow(); CHECK(destroyed); };
+#ifdef PROGRESS_NATIVE_WINDOWS
+        auto sender = arrange_sent_message(progress.m_hWnd, destroy);
+#else
+        beforePeek = destroy;
+#endif
+        perform_update(progress, method);
+#ifdef PROGRESS_NATIVE_WINDOWS
+        sender.join();
+#endif
+        CHECK(!progress.m_hWnd && !CProgressDlg::IsPumpingMessages());
+    }
+}
+void test_destroy_control() {
+    for (int method = 0; method != 3; ++method) {
+        for (const std::string point : {"update", "GetWindowText"}) {
+            TestProgress progress; progress.create();
+            bool destroyed = false;
+            controlHook = [&](const char *operation, HWND) {
+                std::string name = operation;
+                bool match = point == "update" ? (name == "SetPos" || name == "OffsetPos" || name == "StepIt")
+                                                : name == point;
+                if (destroyed || !match) return;
+                destroyed = true;
+                BOOL result = progress.DestroyWindow(); CHECK(result);
+            };
+            perform_update(progress, method);
+            CHECK(destroyed && !progress.m_hWnd);
+            controlHook = nullptr;
+        }
+    }
+}
+void test_sent_foreign() {
+    TestProgress progress; progress.create();
+    bool delivered = false;
+#ifdef PROGRESS_NATIVE_WINDOWS
+    std::thread sender;
+#endif
+    post_callback(Frame.m_hWnd, [&] {
+        auto destroy = [&] { BOOL result = progress.DestroyWindow(); CHECK(result); };
+#ifdef PROGRESS_NATIVE_WINDOWS
+        sender = arrange_sent_message(progress.m_hWnd, destroy);
+#else
+        beforePeek = destroy;
+#endif
+        post_callback(Frame.m_hWnd, [&] { delivered = true; });
+    });
+    progress.PumpMessages();
+#ifdef PROGRESS_NATIVE_WINDOWS
+    sender.join();
+#endif
+    CHECK(delivered && !progress.m_hWnd);
+}
+void test_window_identity() {
+    TestProgress progress; progress.create();
+    CWnd replacement;
+    permanentWindows[progress.m_hWnd] = &replacement;
+    controlTrace.clear();
+    progress.SetPos(12); progress.SetRange(0, 20); progress.SetStep(1); progress.SetStatus("closed");
+    CHECK(controlTrace.empty());
+    permanentWindows[progress.m_hWnd] = &progress;
+}
+void test_parent_lifetime() {
+    {
+        auto *parent = new CWnd; parent->attach();
+        TestProgress progress; progress.create(parent);
+        BOOL enabled = parent->IsWindowEnabled(); CHECK(!enabled);
+        delete parent;
+        BOOL destroyed = progress.DestroyWindow(); CHECK(destroyed);
+    }
+    {
+        CWnd parent; parent.attach();
+        TestProgress progress; progress.create(&parent);
+        CWnd replacement;
+        permanentWindows[parent.m_hWnd] = &replacement;
+        BOOL destroyed = progress.DestroyWindow(); CHECK(destroyed);
+        BOOL enabled = parent.IsWindowEnabled(); CHECK(!enabled);
+        permanentWindows[parent.m_hWnd] = &parent;
+    }
+    {
+        CWnd parent; parent.attach();
+        TestProgress progress; progress.create(&parent);
+        BOOL destroyed = progress.DestroyWindow(); CHECK(destroyed);
+        BOOL enabled = parent.IsWindowEnabled(); CHECK(enabled);
+    }
+}
+void test_lua_create() {
+    lua_State L;
+    int created = dialogConstructions, destroyed = dialogDestructions;
+    int result = Lprogress_new(&L);
+    CHECK(result == 1 && L.handle && L.metatableInstalled);
+    CHECK(dialogConstructions == created + 1 && dialogDestructions == destroyed);
+    result = Lprogress_gc(&L); CHECK(result == 0);
+    CHECK(dialogDestructions == destroyed + 1);
+}
+void test_lua_create_failure() {
+    for (int fault = 0; fault != 5; ++fault) {
+        lua_State L;
+        int created = dialogConstructions, destroyed = dialogDestructions;
+        int deleted = deletedMfcExceptions;
+        L.rejectArgument = fault == 0;
+        L.rejectAllocation = fault == 1;
+        failDialogCreate = fault == 2;
+        if (fault >= 3) controlHook = [fault](const char *name, HWND) {
+            if (std::string(name) == "SetWindowText") {
+                if (fault == 4) throw new CException("title callback");
+                throw std::runtime_error("title callback");
+            }
+        };
+        bool caught = false, luaError = false;
+        try { Lprogress_new(&L); }
+        catch (const LuaError &e) {
+            caught = luaError = true;
+            CHECK(std::string(e.what()) == (fault == 2 ? "Create failed" : "title callback"));
+        }
+        catch (const std::exception &) { caught = true; }
+        controlHook = nullptr; failDialogCreate = false;
+        CHECK(caught && !L.handle);
+        CHECK(luaError == (fault == 2 || fault == 4));
+        CHECK(liveMfcExceptions == 0);
+        CHECK(deletedMfcExceptions == deleted + (luaError ? 1 : 0));
+        CHECK(dialogConstructions == created + (fault >= 2 ? 1 : 0));
+        CHECK(dialogDestructions == destroyed + (fault >= 2 ? 1 : 0));
+    }
+}
+void test_lua_argument_failure() {
+    // C++ exceptions model argument rejection only. Lua longjmp itself is not
+    // covered. Closing after rejection detects a leaked operation depth.
+    using Method = int (*)(lua_State *);
+    for (Method method : {Lprogress_setstatus, Lprogress_setrange, Lprogress_setposition, Lprogress_setstep}) {
+        lua_State L;
+        auto *progress = new TestProgress; progress->create(); L.handle = progress;
+        int destroyed = dialogDestructions;
+        L.rejectArgument = true;
+        bool caught = false;
+        try { method(&L); } catch (const std::runtime_error &) { caught = true; }
+        CHECK(caught && L.handle == progress);
+        int result = Lprogress_gc(&L); CHECK(result == 0);
+        CHECK(!L.handle && dialogDestructions == destroyed + 1);
+    }
+}
+void test_lua_argument_conversion_close() {
+    // lua_tolstring can allocate while converting a number and run a finalizer.
+    // Invoke that callback at the argument API boundary, before it returns the
+    // converted string. The wrapper must resolve the handle after this callback.
+    lua_State L;
+    L.argument = "42";
+    auto *progress = new TestProgress; progress->create(); L.handle = progress;
+    int destroyed = dialogDestructions;
+    bool converted = false, rejectedClosedHandle = false;
+    L.onStringConversion = [&] {
+        converted = true;
+        int result = Lprogress_gc(&L); CHECK(result == 0);
+        CHECK(!L.handle && dialogDestructions == destroyed + 1);
+        controlTrace.clear();
+    };
+    try { Lprogress_setstatus(&L); }
+    catch (const std::runtime_error &error) {
+        rejectedClosedHandle = std::string(error.what()) == "closed Lua handle";
+    }
+    CHECK(converted && rejectedClosedHandle);
+    CHECK(!L.handle && dialogDestructions == destroyed + 1);
+    CHECK(controlTrace.empty());
+}
+void test_source_control_order() {
+    // A sent message can destroy the source dialog and its child before a
+    // queued callback returns. No later GetDlgItem or percentage update is safe.
+    TestProgress progress; progress.create();
+    CWnd *source = progress.GetDlgItem(CG_IDC_PROGDLG_STATUS);
+    HWND sourceWindow = source->m_hWnd;
+    post_callback(Frame.m_hWnd, [&] {
+        BOOL result = progress.DestroyWindow(); CHECK(result);
+        CHECK(!::IsWindow(sourceWindow));
+        controlTrace.clear();
+    });
+    progress.SetPos(37);
+    CHECK(controlTrace.empty());
+}
+
+template<class Doc, class Guard> void test_document_close(deque<__int64> &queue) {
+    auto *doc = new Doc;
+    __int64 identity = doc->identity;
+    TestProgress progress; progress.create();
+    {
+        Guard outer(doc);
+        {
+            Guard inner(doc);
+            post_callback(Frame.m_hWnd, [&] {
+                doc->OnCloseDocument(); doc->OnCloseDocument();
+                BOOL more = App.OnIdle(0); CHECK(!more);
+                CHECK(documentCloses[identity] == 0);
+            });
+            progress.PumpMessages();
+            CHECK(documentCloses[identity] == 0);
+        }
+        // OnIdle can run in another nested modal loop after progress pumping.
+        // It must retain this identity while the caller still uses the document.
+        App.OnIdle(0);
+        CHECK(documentCloses[identity] == 0 && doc->activeOperations() == 1);
+        CHECK(queue.size() == 1 && queue.front() == identity);
+    }
+    CHECK(documentCloses[identity] == 0);
+    CHECK(queue.size() == 1 && queue.front() == identity);
+    App.OnIdle(0);
+    CHECK(documentCloses[identity] == 1 && queue.empty());
+    App.OnIdle(0);
+    CHECK(documentCloses[identity] == 1);
+}
+void test_close_during_pump() {
+    auto *world = new CMUSHclientDoc; auto *text = new CTextDocument;
+    __int64 worldID = world->identity, textID = text->identity;
+    TestProgress progress; progress.create();
+    post_callback(Frame.m_hWnd, [&] {
+        world->OnCloseDocument(); world->OnCloseDocument();
+        text->OnCloseDocument(); text->OnCloseDocument();
+        CHECK(App.m_DeferredWorldDocumentCloses.size() == 1);
+        CHECK(App.m_DeferredTextDocumentCloses.size() == 1);
+        App.OnIdle(0);
+        CHECK(documentCloses[worldID] == 0 && documentCloses[textID] == 0);
+    });
+    progress.PumpMessages();
+    CHECK(documentCloses[worldID] == 0 && documentCloses[textID] == 0);
+    App.OnIdle(0); App.OnIdle(0);
+    CHECK(documentCloses[worldID] == 1 && documentCloses[textID] == 1);
+}
+void test_queued_then_active() {
+    auto *doc = new CMUSHclientDoc;
+    __int64 identity = doc->identity;
+    TestProgress progress; progress.create();
+    post_callback(Frame.m_hWnd, [&] { doc->OnCloseDocument(); });
+    progress.PumpMessages();
+    CHECK(App.m_DeferredWorldDocumentCloses.size() == 1);
+    {
+        CWorldDocumentOperationGuard operation(doc);
+        App.OnIdle(0); App.OnIdle(0);
+        CHECK(documentCloses[identity] == 0);
+        CHECK(App.m_DeferredWorldDocumentCloses.size() == 1);
+        doc->OnCloseDocument();
+        CHECK(App.m_DeferredWorldDocumentCloses.size() == 1);
+    }
+    CHECK(documentCloses[identity] == 0);
+    App.OnIdle(0);
+    CHECK(documentCloses[identity] == 1);
+}
+void test_stale_identity() {
+    // Reuse the exact address. A queue of pointers would close the replacement.
+    auto *world = new CMUSHclientDoc;
+    void *worldStorage = world;
+    __int64 oldWorld = world->identity;
+    App.DeferWorldDocumentClose(oldWorld);
+    world->~CMUSHclientDoc();
+    world = new (worldStorage) CMUSHclientDoc;
+    auto *text = new CTextDocument;
+    void *textStorage = text;
+    __int64 oldText = text->identity;
+    App.DeferTextDocumentClose(oldText);
+    text->~CTextDocument();
+    text = new (textStorage) CTextDocument;
+    __int64 newWorld = world->identity, newText = text->identity;
+    App.OnIdle(0); App.OnIdle(0);
+    CHECK(documentCloses[newWorld] == 0 && documentCloses[newText] == 0);
+    CHECK(App.m_DeferredWorldDocumentCloses.empty() && App.m_DeferredTextDocumentCloses.empty());
+    world->OnCloseDocument(); text->OnCloseDocument();
+}
+void test_document_exception() {
+    auto *world = new CMUSHclientDoc; auto *text = new CTextDocument;
+    __int64 worldID = world->identity, textID = text->identity;
+    bool caught = false;
+    try {
+        CWorldDocumentOperationGuard worldOperation(world);
+        CTextDocumentOperationGuard textOperation(text);
+        world->OnCloseDocument(); text->OnCloseDocument();
+        throw std::runtime_error("active operation failed");
+    } catch (const std::runtime_error &) { caught = true; }
+    CHECK(caught && world->activeOperations() == 0 && text->activeOperations() == 0);
+    CHECK(documentCloses[worldID] == 0 && documentCloses[textID] == 0);
+    App.OnIdle(0); App.OnIdle(0);
+    CHECK(documentCloses[worldID] == 1 && documentCloses[textID] == 1);
+}
+void test_deferred_messages() {
+    MSG message{}; message.hwnd = Frame.m_hWnd; message.message = WM_CLOSE;
+    TestProgress progress; progress.create();
+    post_callback(Frame.m_hWnd, [&] {
+        App.DeferMessageUntilIdle(message, 123);
+        App.DeferMessageUntilIdle(message, 123);
+        App.DeferMessageUntilIdle(message, 456);
+        CHECK(App.m_DeferredMessages.size() == 2);
+        App.OnIdle(0); CHECK(Frame.delivered.empty());
+    });
+    progress.PumpMessages(); CHECK(Frame.delivered.empty());
+    App.OnIdle(0); App.OnIdle(0);
+    CHECK(Frame.delivered.size() == 2);
+    CHECK(Frame.delivered[0].m_iDocumentNumber == 123 && Frame.delivered[1].m_iDocumentNumber == 456);
+    // OnIdle must also drop messages whose windows no longer exist. The frame's
+    // document identity validation itself is outside these extracted functions.
+    CWnd other; other.attach(); message.hwnd = other.m_hWnd;
+    App.DeferMessageUntilIdle(message, 789);
+    BOOL destroyed = other.DestroyWindow(); CHECK(destroyed);
+    App.OnIdle(0); CHECK(Frame.delivered.size() == 2);
+}
+@NATIVE@
+int main(int argc, char **argv) {
+#ifdef _DEBUG
+    (void) THIS_FILE; // Retain the production debug file marker without an unused warning.
+#endif
+    CHECK(argc == 2);
+    Frame.attach();
+    const std::string name = argv[1];
+    if (name == "blocked_chat") test_blocked_chat();
+    else if (name == "cancel_quit") test_cancel_quit();
+    else if (name == "cancel_stops") test_cancel_stops();
+    else if (name == "late_quit") test_late_quit();
+    else if (name == "nested_depth") test_nested_depth();
+    else if (name == "exception_depth") test_exception_depth();
+    else if (name == "lua_nested_close") test_lua_nested_close();
+    else if (name == "lua_immediate_close") test_lua_immediate_close();
+    else if (name == "lua_control_close") test_lua_control_close();
+    else if (name == "lua_exception") test_lua_exception();
+    else if (name == "destroy_dispatch") test_destroy_dispatch();
+    else if (name == "destroy_sent") test_destroy_sent();
+    else if (name == "sent_foreign") test_sent_foreign();
+    else if (name == "destroy_control") test_destroy_control();
+    else if (name == "source_control_order") test_source_control_order();
+    else if (name == "window_identity") test_window_identity();
+    else if (name == "parent_lifetime") test_parent_lifetime();
+    else if (name == "lua_create") test_lua_create();
+    else if (name == "lua_create_failure") test_lua_create_failure();
+    else if (name == "lua_argument_failure") test_lua_argument_failure();
+    else if (name == "lua_argument_conversion_close") test_lua_argument_conversion_close();
+    else if (name == "world_close") test_document_close<CMUSHclientDoc, CWorldDocumentOperationGuard>(App.m_DeferredWorldDocumentCloses);
+    else if (name == "text_close") test_document_close<CTextDocument, CTextDocumentOperationGuard>(App.m_DeferredTextDocumentCloses);
+    else if (name == "close_during_pump") test_close_during_pump();
+    else if (name == "queued_then_active") test_queued_then_active();
+    else if (name == "stale_identity") test_stale_identity();
+    else if (name == "document_exception") test_document_exception();
+    else if (name == "deferred_messages") test_deferred_messages();
+#ifdef PROGRESS_NATIVE_WINDOWS
+    else if (name == "native_socket") test_native_socket();
+#endif
+    else { std::cerr << "Unknown case: " << name << '\n'; return 2; }
+    CHECK(!CProgressDlg::IsPumpingMessages());
+    CHECK(App.worlds.head == nullptr && App.texts.head == nullptr);
+    CHECK(App.m_DeferredWorldDocumentCloses.empty() && App.m_DeferredTextDocumentCloses.empty());
+    CHECK(App.m_DeferredMessages.empty());
+    CHECK(callbacks.empty());
+    std::cout << "PASS: " << name << '\n';
+}

--- a/tests/progress_messages_native.cpp.in
+++ b/tests/progress_messages_native.cpp.in
@@ -1,0 +1,141 @@
+// Native supplement. This code requires Windows, user32.lib and ws2_32.lib.
+// The queue and socket APIs are real. MFC window wrappers, dialog navigation,
+// Lua argument errors, and document registries remain explicit test substitutes.
+#ifndef PROGRESS_NATIVE_WINDOWS
+#error Compile this supplement with PROGRESS_NATIVE_WINDOWS.
+#endif
+std::thread arrange_sent_message(HWND window, std::function<void()> callback) {
+    size_t id = ++nextCallback;
+    callbacks.emplace(id, std::move(callback));
+    std::thread sender([window, id] {
+        SendMessageA(window, callbackMessage, static_cast<WPARAM>(id), 0);
+    });
+    // Do not dispatch the sent message here. The production PeekMessage call
+    // must dispatch it. GetQueueStatus does not remove or dispatch messages.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    for (;;) {
+        DWORD status = GetQueueStatus(QS_SENDMESSAGE);
+        if (HIWORD(status) & QS_SENDMESSAGE) break;
+        CHECK(std::chrono::steady_clock::now() < deadline);
+        std::this_thread::yield();
+    }
+    return sender;
+}
+struct NativeSocketPair {
+    SOCKET writer = INVALID_SOCKET, reader = INVALID_SOCKET;
+    NativeSocketPair() {
+        WSADATA data{};
+        int error = WSAStartup(MAKEWORD(2, 2), &data); CHECK(error == 0);
+        SOCKET listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP); CHECK(listener != INVALID_SOCKET);
+        sockaddr_in address{};
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        int result = bind(listener, reinterpret_cast<sockaddr *>(&address), sizeof address); CHECK(result == 0);
+        int length = sizeof address;
+        result = getsockname(listener, reinterpret_cast<sockaddr *>(&address), &length); CHECK(result == 0);
+        result = listen(listener, 1); CHECK(result == 0);
+        writer = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP); CHECK(writer != INVALID_SOCKET);
+        result = connect(writer, reinterpret_cast<sockaddr *>(&address), sizeof address); CHECK(result == 0);
+        reader = accept(listener, nullptr, nullptr); CHECK(reader != INVALID_SOCKET);
+        result = closesocket(listener); CHECK(result == 0);
+        int bufferSize = 4096;
+        result = setsockopt(writer, SOL_SOCKET, SO_SNDBUF,
+                            reinterpret_cast<const char *>(&bufferSize), sizeof bufferSize); CHECK(result == 0);
+        u_long nonblocking = 1;
+        result = ioctlsocket(reader, FIONBIO, &nonblocking); CHECK(result == 0);
+    }
+    ~NativeSocketPair() {
+        int result = closesocket(reader); CHECK(result == 0);
+        result = closesocket(writer); CHECK(result == 0);
+        result = WSACleanup(); CHECK(result == 0);
+    }
+};
+void test_native_socket() {
+    NativeSocketPair sockets;
+    TestProgress progress; progress.create();
+    CWnd notificationWindow; notificationWindow.attach();
+    CChatSocket chat;
+    int writeNotifications = 0;
+    int lastSendResult = 0;
+    std::string accepted;
+    bool recordAccepted = true;
+    chat.transport = [&](const char *bytes, int size) {
+        int result = send(sockets.writer, bytes, size, 0);
+        lastSendResult = result;
+        if (result == SOCKET_ERROR) chat.lastError = WSAGetLastError();
+        else if (recordAccepted) accepted.append(bytes, result);
+        return result;
+    };
+    socketDispatch = [&](WPARAM socket, LPARAM event) {
+        CHECK(static_cast<SOCKET>(socket) == sockets.writer);
+        CHECK(WSAGETSELECTERROR(event) == 0);
+        CHECK(WSAGETSELECTEVENT(event) == FD_WRITE);
+        CHECK(CProgressDlg::IsPumpingMessages());
+        ++writeNotifications;
+        chat.OnSend(0);
+    };
+    int result = WSAAsyncSelect(sockets.writer, notificationWindow.m_hWnd, socketMessage, FD_WRITE);
+    CHECK(result == 0);
+    // Fill the real socket, then require OnSend itself to observe a blocked
+    // send. TCP can free capacity between two send calls without an application
+    // reader, so retry if the small chat payload gets through. Record every
+    // accepted byte. The final pending payload is small enough to fit after
+    // draining; partial-send scheduling is outside this queue smoke test.
+    const std::string payload = "pending chat payload";
+    const std::string filler(65536, 'F');
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
+    for (;;) {
+        for (;;) {
+            int sent = send(sockets.writer, filler.data(), static_cast<int>(filler.size()), 0);
+            if (sent == SOCKET_ERROR) {
+                int error = WSAGetLastError(); CHECK(error == WSAEWOULDBLOCK); break;
+            }
+            CHECK(sent > 0);
+            accepted.append(filler.data(), sent);
+            CHECK(accepted.size() < 128 * 1024 * 1024);
+            CHECK(std::chrono::steady_clock::now() < deadline);
+        }
+        if (chat.m_outstanding_output.empty()) chat.m_outstanding_output = payload;
+        chat.OnSend(0);
+        if (lastSendResult == SOCKET_ERROR) { CHECK(chat.lastError == WSAEWOULDBLOCK); break; }
+        CHECK(lastSendResult > 0);
+        CHECK(std::chrono::steady_clock::now() < deadline);
+    }
+    CHECK(!chat.m_outstanding_output.empty());
+    recordAccepted = false;
+    const size_t prefixBytes = accepted.size();
+    const int expectedChatBytes = chat.doc.m_nBytesOut + chat.m_outstanding_output.GetLength();
+    const std::string expected = accepted + chat.m_outstanding_output;
+    std::string received;
+    while (received.size() < prefixBytes) {
+        char bytes[65536];
+        int count = recv(sockets.reader, bytes, sizeof bytes, 0);
+        if (count == SOCKET_ERROR) {
+            int error = WSAGetLastError(); CHECK(error == WSAEWOULDBLOCK);
+        } else { CHECK(count > 0); received.append(bytes, count); }
+        CHECK(std::chrono::steady_clock::now() < deadline);
+        std::this_thread::yield();
+    }
+    // recv frees send capacity; only the production progress pump can dispatch
+    // FD_WRITE and call the extracted OnSend. There is no main-loop drain.
+    while (received.size() < expected.size() || !chat.m_outstanding_output.empty()) {
+        char bytes[65536];
+        int count = recv(sockets.reader, bytes, sizeof bytes, 0);
+        if (count == SOCKET_ERROR) {
+            int error = WSAGetLastError(); CHECK(error == WSAEWOULDBLOCK);
+        } else {
+            CHECK(count > 0); received.append(bytes, count);
+        }
+        progress.PumpMessages();
+        CHECK(std::chrono::steady_clock::now() < deadline);
+        std::this_thread::yield();
+    }
+    CHECK(writeNotifications > 0);
+    CHECK(chat.m_outstanding_output.empty());
+    CHECK(chat.doc.m_nBytesOut == expectedChatBytes);
+    CHECK(received == expected);
+    result = WSAAsyncSelect(sockets.writer, notificationWindow.m_hWnd, 0, 0); CHECK(result == 0);
+    // Dispatch any notification already posted before disabling registration.
+    progress.PumpMessages();
+    socketDispatch = nullptr;
+}

--- a/tests/progress_snapshots.cpp.in
+++ b/tests/progress_snapshots.cpp.in
@@ -1,0 +1,525 @@
+// Only the two inserted function bodies are production code. All other code is a fixture.
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+using std::size_t;
+using std::vector;
+
+void Check(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << "CHECK failed: " << message << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+}
+#define CHECK(condition, message) Check(static_cast<bool>(condition), message)
+#define ASSERT(condition) CHECK(condition, #condition)
+using LPCTSTR = const char*;
+using POSITION = void*;
+constexpr int FALSE = 0, MB_ICONINFORMATION = 1;
+constexpr int COMMENT = 1, USER_INPUT = 2, NOTE_OR_COMMAND = 3;
+constexpr int PCRE_CASELESS = 1, PCRE_UTF8 = 2;
+constexpr int IDC_BUFFER_LINES = 1, IDC_OUTPUT_MEMORY = 2, IDC_CALCULATE_MEMORY = 3;
+const char* const ENDLINE = "\r\n";
+
+struct CString {
+  std::string value;
+  CString() = default;
+  CString(const char* text) : value(text) {}
+  CString(std::string text) : value(std::move(text)) {}
+  CString(const char* text, int length) : value(text, static_cast<size_t>(length)) {}
+  operator LPCTSTR() const { return value.c_str(); }
+  CString& operator+=(const CString& text) { value += text.value; return *this; }
+  bool IsEmpty() const { return value.empty(); }
+  void Empty() { value.clear(); }
+  void MakeLower() {
+    for (char& c : value) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  int Find(const CString& text) const {
+    const auto pos = value.find(text.value);
+    return pos == std::string::npos ? -1 : static_cast<int>(pos);
+  }
+  // Typed adapters avoid passing LP64 longs to Windows %i varargs formats.
+  // Unsupported formats fail instead of approximating native CString behavior.
+  void Format(const char* format, long count) {
+    const bool supported = std::strcmp(format, "%ld Kb") == 0;
+    CHECK(supported, "supported integer format");
+    value = std::to_string(count) + " Kb";
+  }
+  void Format(const char* format, double count) {
+    const bool supported = std::strcmp(format, "%5.1f Mb") == 0;
+    CHECK(supported, "supported floating point format");
+    char buffer[80];
+    const int length = std::snprintf(buffer, sizeof buffer, "%5.1f Mb", count);
+    CHECK(length > 0 && length < static_cast<int>(sizeof buffer), "formatted memory fits");
+    value = buffer;
+  }
+  void Format(const char* format, const char* text, long count) {
+    const bool supported = std::strcmp(format, "%s (%i bytes/line)") == 0;
+    CHECK(supported, "supported memory average format");
+    value = std::string(text) + " (" + std::to_string(count) + " bytes/line)";
+  }
+  void Format(const char* format, const char* text) {
+    const bool supported = std::strcmp(format, "%s") == 0;
+    CHECK(supported, "supported string format");
+    value = text;
+  }
+};
+
+CString Translate(const char* text) { return text; }
+CString TFormat(const char* format, const char* text) {
+  const bool supported = std::strcmp(format, "Recalling: %s") == 0;
+  CHECK(supported, "supported recall status format");
+  return std::string("Recalling: ") + text;
+}
+CString TFormat(const char* format, int count) {
+  const bool supported = std::strcmp(format, " (%i styles)") == 0;
+  CHECK(supported, "supported style count format");
+  return " (" + std::to_string(count) + " styles)";
+}
+CString TFormat(const char* format, const char* kind, const char* text) {
+  const bool supported = std::strcmp(format, "The %s \"%s\" was not found") == 0;
+  CHECK(supported, "supported recall miss format");
+  return std::string("The ") + kind + " \"" + text + "\" was not found";
+}
+struct CTime { int seconds = 0; };
+struct CException {
+  void ReportError() { throw std::runtime_error("Unexpected MFC exception"); }
+  void Delete() { delete this; }
+};
+void AfxThrowResourceException() { throw std::runtime_error("Resource creation failed"); }
+struct t_regexp { std::regex pattern; };
+t_regexp* regcomp(const CString& text, int flags) {
+  auto mode = std::regex::ECMAScript;
+  if (flags & PCRE_CASELESS) mode |= std::regex::icase;
+  return new t_regexp{std::regex(text.value, mode)};
+}
+bool regexec(t_regexp* pattern, const CString& text) {
+  return std::regex_search(text.value, pattern->pattern);
+}
+
+// Each POSITION points to a real allocation. Removal frees the node and value.
+// A baseline that retains a removed POSITION therefore fails under ASan.
+template<class T> struct OwnedList {
+  struct Node { Node* previous; Node* next; T* value; };
+  Node* head = nullptr;
+  Node* tail = nullptr;
+  long count = 0;
+  OwnedList() = default;
+  OwnedList(const OwnedList&) = delete;
+  OwnedList& operator=(const OwnedList&) = delete;
+  ~OwnedList() { Clear(); }
+  long GetCount() const { return count; }
+  POSITION GetHeadPosition() const { return head; }
+  POSITION GetTailPosition() const { return tail; }
+  T* GetNext(POSITION& position) const {
+    CHECK(position != nullptr, "nonempty list position");
+    Node* node = static_cast<Node*>(position);
+    position = node->next;
+    return node->value;
+  }
+  T* GetPrev(POSITION& position) const {
+    CHECK(position != nullptr, "nonempty reverse list position");
+    Node* node = static_cast<Node*>(position);
+    position = node->previous;
+    return node->value;
+  }
+  void AddTail(T* value) {
+    Node* node = new Node{tail, nullptr, value};
+    if (tail) tail->next = node;
+    else head = node;
+    tail = node;
+    ++count;
+  }
+  void RemoveHead() {
+    CHECK(head != nullptr, "nonempty list removal");
+    Node* node = head;
+    head = node->next;
+    if (head) head->previous = nullptr;
+    else tail = nullptr;
+    delete node->value;
+    delete node;
+    --count;
+  }
+  void Clear() { while (head) RemoveHead(); }
+};
+struct CStyle { unsigned short length = 0, flags = 0; unsigned colour = 0; };
+struct CLine {
+  bool hard_return = true;
+  unsigned char flags = 0;
+  int len = 0;
+  char* text = nullptr;
+  OwnedList<CStyle> styleList;
+  CTime m_theTime;
+  int iMemoryAllocated = 0;
+  explicit CLine(const std::string& value) { SetText(value); }
+  ~CLine() { delete[] text; }
+  void SetText(const std::string& value) {
+    auto buffer = std::make_unique<char[]>(value.size() + 1);
+    std::memcpy(buffer.get(), value.data(), value.size());
+    buffer[value.size()] = '\0';
+    delete[] text;
+    text = buffer.release();
+    len = static_cast<int>(value.size());
+    iMemoryAllocated = len + 1;
+  }
+};
+
+struct Harness {
+  std::function<void(const std::string&)> callback;
+  int creates = 0, destroys = 0, live = 0, polls = 0, cancelAt = 0;
+  int messages = 0;
+  long range = -1;
+  vector<long> positions;
+  void Event(const std::string& name) { if (callback) callback(name); }
+} harness;
+struct FrameAdapter {
+  CString status;
+  void SetStatusMessageNow(const CString& text) { status = text; }
+} Frame;
+void UMessageBox(const CString&, int) { ++harness.messages; }
+struct CProgressDlg {
+  CProgressDlg() { ++harness.live; }
+  ~CProgressDlg() { --harness.live; ++harness.destroys; }
+  bool Create() { ++harness.creates; harness.Event("create"); return true; }
+  void SetStatus(const CString&) {}
+  void SetRange(int, long upper) { harness.range = upper; }
+  void SetWindowText(const CString&) {}
+  void SetPos(long position) {
+    harness.positions.push_back(position);
+    harness.Event("setpos");
+  }
+  bool CheckCancelButton() {
+    ++harness.polls;
+    harness.Event("poll");
+    return harness.cancelAt != 0 && harness.polls >= harness.cancelAt;
+  }
+};
+struct CMUSHclientDoc {
+  OwnedList<CLine> m_LineList;
+  bool m_bUTF_8 = false;
+  int operations = 0, statusRestores = 0;
+  void ShowStatusLine() { ++statusRestores; Frame.status = "Ready"; }
+  CString FormatTime(CTime time, const CString& format) {
+    CHECK(format.value == "[%H:%M:%S] ", "supported timestamp preamble");
+    char buffer[32];
+    const int length = std::snprintf(buffer, sizeof buffer, "[%02d:%02d:%02d] ",
+                                   time.seconds / 3600, (time.seconds / 60) % 60,
+                                   time.seconds % 60);
+    CHECK(length == 11, "timestamp preamble length");
+    return buffer;
+  }
+  CString RecallText(CString, bool, bool, bool, bool, bool, int, CString);
+};
+// Retention is a counter stub. Native world-close deferral has separate tests.
+struct CWorldDocumentOperationGuard {
+  CMUSHclientDoc* document;
+  explicit CWorldDocumentOperationGuard(CMUSHclientDoc* doc) : document(doc) { ++doc->operations; }
+  ~CWorldDocumentOperationGuard() { --document->operations; }
+};
+struct Control { bool enabled = true; void EnableWindow(int value) { enabled = value != 0; } };
+struct CWnd {
+  int m_hWnd = 1;
+  static CWnd* FromHandlePermanent(int handle);
+};
+struct PageWindow { bool exists = false; CWnd* permanent = nullptr; } pageWindow;
+CWnd replacementWindow;
+bool IsWindow(int handle) { return handle == 1 && pageWindow.exists; }
+CWnd* CWnd::FromHandlePermanent(int handle) {
+  return IsWindow(handle) ? pageWindow.permanent : nullptr;
+}
+struct CPrefsP15 : CWnd {
+  CMUSHclientDoc* m_doc;
+  CString m_strBufferLines;
+  CString lineLabel = "unchanged lines", memoryLabel = "unchanged memory";
+  Control calculate;
+  int writes = 0;
+  explicit CPrefsP15(CMUSHclientDoc* doc)
+      : m_doc(doc), m_strBufferLines(std::to_string(doc->m_LineList.count) + " lines") {
+    pageWindow = {true, this};
+  }
+  void CheckWindow() const {
+    const bool exists = IsWindow(m_hWnd);
+    const CWnd* owner = CWnd::FromHandlePermanent(m_hWnd);
+    CHECK(exists && owner == this, "page window result: no UI access after destruction or reuse");
+  }
+  void SetDlgItemText(int id, const CString& text) {
+    CheckWindow();
+    ++writes;
+    if (id == IDC_BUFFER_LINES) {
+      lineLabel = text;
+      harness.Event("publish");
+    } else {
+      CHECK(id == IDC_OUTPUT_MEMORY, "known result control");
+      memoryLabel = text;
+    }
+  }
+  Control* GetDlgItem(int id) {
+    CheckWindow();
+    CHECK(id == IDC_CALCULATE_MEMORY, "known calculation control");
+    return &calculate;
+  }
+  void CalculateMemoryUsage();
+};
+
+@RECALL@
+
+@MEMORY@
+
+void Mutate(CMUSHclientDoc& doc, const std::string& action) {
+  if (action == "clear" || action == "replace") {
+    doc.m_LineList.Clear();
+    if (action == "replace") {
+      for (int i = 0; i < 7; ++i) {
+        auto* line = new CLine("match replacement");
+        line->flags = COMMENT;
+        line->m_theTime.seconds = 86399;
+        line->styleList.AddTail(new CStyle);
+        doc.m_LineList.AddTail(line);
+      }
+    }
+  } else if (action == "prune") {
+    for (int i = 0; i < 128; ++i) doc.m_LineList.RemoveHead();
+  } else if (action == "rewrite") {
+    for (auto* node = doc.m_LineList.head; node; node = node->next) {
+      auto* line = node->value;
+      line->SetText("match changed");
+      line->hard_return = false;
+      line->flags = COMMENT;
+      line->m_theTime.seconds = 86399;
+      line->iMemoryAllocated = 9000;
+      line->styleList.Clear();
+    }
+  } else {
+    throw std::runtime_error("Unknown mutation: " + action);
+  }
+}
+
+struct Scenario {
+  std::string action, event;
+  bool cancel = false, empty = false;
+};
+Scenario Parse(const std::string& name) {
+  const auto suffix = name.substr(name.find('_') + 1);
+  if (suffix == "control") return {};
+  if (suffix == "empty") return {"", "", false, true};
+  if (suffix == "cancel") return {"", "", true, false};
+  if (suffix == "clear_cancel") return {"clear", "create", true, false};
+  const auto split = suffix.find('_');
+  CHECK(split != std::string::npos, "case has action and event");
+  return {suffix.substr(0, split), suffix.substr(split + 1), false, false};
+}
+
+void Arm(CMUSHclientDoc& doc, const Scenario& scenario, int& mutations, CPrefsP15* page = nullptr) {
+  harness.callback = [&doc, &scenario, &mutations, page](const std::string& event) {
+    if (!scenario.action.empty() && scenario.event == event && mutations == 0) {
+      CHECK(harness.live == 1, "callback runs with a live progress dialog");
+      if (scenario.action == "destroy") {
+        CHECK(page != nullptr, "page exists during destruction callback");
+        page->m_hWnd = 0;
+        pageWindow = {};
+      } else if (scenario.action == "reuse") {
+        CHECK(page != nullptr, "page exists during handle reuse callback");
+        pageWindow = {true, &replacementWindow};
+      } else {
+        Mutate(doc, scenario.action);
+      }
+      ++mutations;
+    }
+  };
+}
+
+void CheckCleanup(const CMUSHclientDoc& doc, const Scenario& scenario, int mutations) {
+  CHECK(mutations == (scenario.action.empty() ? 0 : 1), "requested callback ran once");
+  CHECK(doc.operations == 0, "document operation count restored");
+  CHECK(harness.live == 0, "progress dialog destroyed");
+  CHECK(harness.creates == (scenario.empty ? 0 : 1), "progress creation count");
+  CHECK(harness.destroys == harness.creates, "progress destruction count");
+}
+
+void FillRecall(CMUSHclientDoc& doc) {
+  for (int i = 0; i < 544; ++i) {
+    auto* line = new CLine("filler");
+    line->m_theTime.seconds = i;
+    // Different metadata on the two wrap fragments verifies the final fragment
+    // supplies the logical line's flags and timestamp.
+    if (i == 0) { line->SetText("Ma"); line->flags = COMMENT; line->hard_return = false; }
+    if (i == 1) { line->SetText("tch early"); line->m_theTime.seconds = 3723; }
+    if (i == 2) { line->SetText("MATCH cmd"); line->flags = USER_INPUT; line->m_theTime.seconds = 7384; }
+    if (i == 3) { line->SetText("match note"); line->flags = COMMENT; line->m_theTime.seconds = 11045; }
+    if (i == 31) { line->SetText("ma"); line->flags = COMMENT; line->hard_return = false; }
+    if (i == 32) { line->SetText("tch wrapped"); line->m_theTime.seconds = 14706; }
+    if (i == 70) { line->SetText("match late"); line->flags = USER_INPUT; line->m_theTime.seconds = 18367; }
+    if (i == 543) {
+      // Explicit length must preserve embedded NUL text. The tail has no hard return.
+      line->SetText(std::string("match tail\0end", 14));
+      line->flags = COMMENT;
+      line->hard_return = false;
+      line->m_theTime.seconds = 22028;
+    }
+    doc.m_LineList.AddTail(line);
+  }
+}
+
+std::string ExpectedRecall(int filter, bool cancelled, bool preamble, bool sensitive, int limit) {
+  struct Result { const char* stamp; std::string text; int category; bool afterCancel; bool recent; };
+  const vector<Result> records = {
+    {"[01:02:03] ", "Match early", 2, false, false},
+    {"[02:03:04] ", "MATCH cmd", 1, false, false},
+    {"[03:04:05] ", "match note", 3, false, false},
+    {"[04:05:06] ", "match wrapped", 2, true, false},
+    {"[05:06:07] ", "match late", 1, true, false},
+    {"[06:07:08] ", std::string("match tail\0end", 14), 3, true, true},
+  };
+  std::string expected;
+  for (const auto& record : records) {
+    if (filter != 0 && filter != record.category) continue;
+    if (cancelled && record.afterCancel) continue;
+    if (sensitive && (record.text == "Match early" || record.text == "MATCH cmd")) continue;
+    if (limit != 0 && !record.recent) continue;
+    if (preamble) expected += record.stamp;
+    expected += record.text + "\r\n";
+  }
+  return expected;
+}
+
+void RecallCase(const Scenario& scenario) {
+  // Filters: all, commands, output, notes. Both regex and literal paths run.
+  // Additional passes check case-sensitive matching, no preamble, and iLines.
+  const int variants = scenario.cancel || scenario.empty ? 1 : 11;
+  for (int variant = 0; variant < variants; ++variant) {
+    harness = Harness{};
+    CMUSHclientDoc doc;
+    if (!scenario.empty) FillRecall(doc);
+    int mutations = 0;
+    Arm(doc, scenario, mutations);
+    harness.cancelAt = scenario.cancel ? 1 : 0;
+    const int filter = variant < 8 ? variant % 4 : 0;
+    const bool regexp = variant >= 4 && variant < 8;
+    const bool sensitive = variant == 8;
+    const bool preamble = variant != 9;
+    const int limit = variant == 10 ? 10 : 0;
+    const CString needle = regexp ? "^match" : (sensitive ? "match" : "mAtCh");
+    const auto result = doc.RecallText(needle, sensitive, regexp,
+                                      filter == 0 || filter == 1,
+                                      filter == 0 || filter == 2,
+                                      filter == 0 || filter == 3,
+                                      limit, preamble ? "[%H:%M:%S] " : "");
+    const auto expected = scenario.empty ? std::string{} :
+        ExpectedRecall(filter, scenario.cancel, preamble, sensitive, limit);
+    if (result.value != expected) {
+      std::cerr << "Recall variant " << variant << ": expected " << expected.size()
+                << " bytes, got " << result.value.size() << " bytes\n";
+    }
+    CHECK(result.value == expected, "snapshot result: recall text, wrapping, flags, time, and range");
+    CHECK(Frame.status.value == "Ready", "recall status restored");
+    CHECK(harness.messages == (scenario.empty ? 1 : 0), "recall no-match message count");
+    if (scenario.cancel) {
+      CHECK(harness.polls == 1, "cancellation result: recall stops on first cancellation");
+    }
+    if (!scenario.empty) CHECK(harness.range == 544, "snapshot result: recall progress range");
+    // iLines=10 has no SetPos or cancellation poll. The create callback still runs.
+    if (limit && scenario.event != "create" && !scenario.action.empty()) {
+      CHECK(mutations == 0, "short recall does not reach the progress interval");
+      CHECK(doc.operations == 0 && harness.live == 0, "short recall cleanup");
+    } else {
+      CheckCleanup(doc, scenario, mutations);
+    }
+  }
+}
+
+struct MemoryExpected { long lines = 0, allocations = 0, styles = 0; };
+MemoryExpected FillMemory(CMUSHclientDoc& doc, bool empty) {
+  MemoryExpected expected;
+  if (empty) return expected;
+  expected.lines = 1104;
+  for (int i = 0; i < expected.lines; ++i) {
+    auto* line = new CLine("memory line");
+    line->iMemoryAllocated = 64 + (i % 7) * 31;
+    const int styles = 1 + i % 4;
+    for (int j = 0; j < styles; ++j) line->styleList.AddTail(new CStyle);
+    expected.allocations += line->iMemoryAllocated;
+    expected.styles += styles;
+    doc.m_LineList.AddTail(line);
+  }
+  return expected;
+}
+
+void MemoryCase(const Scenario& scenario) {
+  harness = Harness{};
+  CMUSHclientDoc doc;
+  const auto expected = FillMemory(doc, scenario.empty);
+  CPrefsP15 page(&doc);
+  int mutations = 0;
+  Arm(doc, scenario, mutations, &page);
+  harness.cancelAt = scenario.cancel ? 70 : 0;
+  const auto initialBufferLines = page.m_strBufferLines.value;
+  page.CalculateMemoryUsage();
+  if (scenario.action == "destroy" || scenario.action == "reuse") {
+    CHECK(page.writes == 0 && page.calculate.enabled && doc.statusRestores == 0,
+          "page window result: no UI publication after window identity changes");
+    CHECK(page.m_strBufferLines.value == initialBufferLines &&
+          page.lineLabel.value == "unchanged lines" && page.memoryLabel.value == "unchanged memory",
+          "page window result: page data stays unchanged");
+    CHECK(harness.polls == expected.lines, "page window result: calculation reaches publication guard");
+  } else if (scenario.cancel) {
+    CHECK(page.writes == 0, "cancellation result: no partial result is published");
+    CHECK(page.lineLabel.value == "unchanged lines" && page.memoryLabel.value == "unchanged memory",
+          "cancellation result: controls keep their prior values");
+    CHECK(page.m_strBufferLines.value == initialBufferLines,
+          "cancellation result: saved line label is unchanged");
+    CHECK(page.calculate.enabled && doc.statusRestores == 0,
+          "cancellation result: calculation can be retried");
+    CHECK(harness.polls == 70, "cancellation result: iteration stops at cancellation");
+    const vector<long> positions = {64};
+    CHECK(harness.positions == positions, "cancellation result: one progress update before stop");
+  } else {
+    // Aggregate oracle uses the fixture's original input counts, not live lines.
+    const long bytes = expected.allocations + expected.lines * (sizeof(CLine) + 3 * sizeof(void*))
+                       + expected.styles * (sizeof(CStyle) + 3 * sizeof(void*));
+    char units[80];
+    int length;
+    if (bytes < 1024 * 1024) length = std::snprintf(units, sizeof units, "%ld Kb", bytes / 1024);
+    else length = std::snprintf(units, sizeof units, "%5.1f Mb", bytes / (1024.0 * 1024.0));
+    CHECK(length > 0 && length < static_cast<int>(sizeof units), "expected memory units fit");
+    std::string memory = units;
+    if (expected.lines) memory += " (" + std::to_string(bytes / expected.lines) + " bytes/line)";
+    const std::string lines = initialBufferLines + " (" + std::to_string(expected.styles) + " styles)";
+    if (page.memoryLabel.value != memory || page.lineLabel.value != lines) {
+      std::cerr << "Expected memory: " << memory << "; got: " << page.memoryLabel.value
+                << "\nExpected lines: " << lines << "; got: " << page.lineLabel.value << '\n';
+    }
+    CHECK(page.memoryLabel.value == memory && page.lineLabel.value == lines,
+          "snapshot result: captured memory, styles, and average denominator");
+    CHECK(page.writes == 2 && !page.calculate.enabled && doc.statusRestores == 1,
+          "memory calculation publishes one complete result");
+    CHECK(page.m_strBufferLines.value == lines, "saved line label matches result");
+    CHECK(harness.polls == expected.lines, "snapshot result: all captured memory records visited");
+    vector<long> positions;
+    for (long i = 64; i <= expected.lines; i += 64) positions.push_back(i);
+    CHECK(harness.positions == positions, "snapshot result: memory progress uses captured count");
+    CHECK(Frame.status.value == "Ready", "completed memory status restored");
+  }
+  if (!scenario.empty) CHECK(harness.range == expected.lines, "snapshot result: memory progress range");
+  CheckCleanup(doc, scenario, mutations);
+}
+
+int main(int argc, char** argv) {
+  CHECK(argc == 2, "one case argument required");
+  const std::string name = argv[1];
+  const Scenario scenario = Parse(name);
+  if (name.rfind("recall_", 0) == 0) RecallCase(scenario);
+  else if (name.rfind("memory_", 0) == 0) MemoryCase(scenario);
+  else throw std::runtime_error("Unknown case: " + name);
+  harness.callback = nullptr;
+  std::cout << "PASS: " << name << '\n';
+}

--- a/tests/progress_snapshots.cpp.in
+++ b/tests/progress_snapshots.cpp.in
@@ -31,14 +31,43 @@ constexpr int PCRE_CASELESS = 1, PCRE_UTF8 = 2;
 constexpr int IDC_BUFFER_LINES = 1, IDC_OUTPUT_MEMORY = 2, IDC_CALCULATE_MEMORY = 3;
 const char* const ENDLINE = "\r\n";
 
+// Count snapshot text allocations before the first message-pumping boundary.
+// This measures call counts and payload sizes, not native CString heap overhead.
+struct TextAllocationProbe {
+  bool active = false;
+  size_t arrays = 0, bytes = 0, largest = 0, strings = 0;
+  int failAfter = -1;
+} textAllocations;
+size_t liveTextArrays = 0;
+void* operator new[](size_t size) {
+  if (textAllocations.active) {
+    if (textAllocations.failAfter == 0) throw std::bad_alloc();
+    if (textAllocations.failAfter > 0) --textAllocations.failAfter;
+    ++textAllocations.arrays;
+    textAllocations.bytes += size;
+    textAllocations.largest = std::max(textAllocations.largest, size);
+  }
+  void* result = std::malloc(size ? size : 1);
+  if (!result) throw std::bad_alloc();
+  ++liveTextArrays;
+  return result;
+}
+void operator delete[](void* value) noexcept {
+  if (value) { --liveTextArrays; std::free(value); }
+}
+void operator delete[](void* value, size_t) noexcept { ::operator delete[](value); }
+
 struct CString {
   std::string value;
   CString() = default;
   CString(const char* text) : value(text) {}
   CString(std::string text) : value(std::move(text)) {}
-  CString(const char* text, int length) : value(text, static_cast<size_t>(length)) {}
+  CString(const char* text, int length) : value(text, static_cast<size_t>(length)) {
+    if (textAllocations.active && length) ++textAllocations.strings;
+  }
   operator LPCTSTR() const { return value.c_str(); }
   CString& operator+=(const CString& text) { value += text.value; return *this; }
+  void Append(const char* text, int length) { value.append(text, static_cast<size_t>(length)); }
   bool IsEmpty() const { return value.empty(); }
   void Empty() { value.clear(); }
   void MakeLower() {
@@ -513,9 +542,83 @@ void MemoryCase(const Scenario& scenario) {
   CheckCleanup(doc, scenario, mutations);
 }
 
+void RecallStorageCase(const std::string& name) {
+  harness = Harness{};
+  CMUSHclientDoc doc;
+  const bool shortRange = name == "recall_storage_short";
+  const bool fail = name == "recall_storage_failure";
+  const bool cancel = name == "recall_storage_cancel";
+  const int count = cancel ? 500000 : 5000;
+  std::string expected;
+  size_t payload = 0;
+  for (int i = 0; i < count; ++i) {
+    std::string text(80, 'x');
+    if (!cancel && !shortRange && !fail) {
+      // Empty lines and lines around the block boundary test byte preservation.
+      if (i == 0) text.clear();
+      if (i == 1) text.assign(65535, 'a');
+      if (i == 2) text.assign(65536, 'b');
+      if (i == 3) text.assign(65537, 'c');
+      if (i == 4) text = "UTF-8: \xe2\x82\xac";
+    }
+    doc.m_LineList.AddTail(new CLine(text));
+    if (!shortRange || i >= count - 2) {
+      payload += text.size();
+      if (!cancel && !fail) expected += text + "\r\n";
+    }
+  }
+  const size_t arraysBefore = liveTextArrays;
+  textAllocations = TextAllocationProbe{};
+  textAllocations.active = true;
+  textAllocations.failAfter = fail ? 1 : -1;
+  harness.cancelAt = cancel ? 1 : 0;
+  harness.callback = [&](const std::string& event) {
+    if (event != "create") return;
+    textAllocations.active = false;
+    CHECK(textAllocations.strings == 0, "snapshot storage: no per-line string allocations");
+    CHECK(textAllocations.arrays > 0 && textAllocations.arrays < size_t(count) / 8,
+          "snapshot storage: text allocation count is below line count");
+    CHECK(textAllocations.bytes >= payload && textAllocations.bytes < payload + 256 * 1024,
+          "snapshot storage: bounded text allocation overhead");
+    CHECK(textAllocations.largest <= 256 * 1024, "snapshot storage: bounded text blocks");
+    if (shortRange) CHECK(textAllocations.bytes <= 256, "short snapshot uses selected range");
+    std::cout << "Snapshot text: " << payload << " bytes in " << textAllocations.arrays
+              << " allocations, " << textAllocations.bytes << " allocated bytes\n";
+    // All source text goes away before the snapshot is read.
+    doc.m_LineList.Clear();
+  };
+  bool threw = false;
+  try {
+    const auto result = doc.RecallText(cancel ? "missing" : "", true, false,
+                                      true, true, true, shortRange ? 1 : 0, "");
+    CHECK(result.value == expected, "snapshot storage: retained exact bytes");
+  } catch (const std::bad_alloc&) {
+    threw = true;
+  }
+  textAllocations.active = false;
+  CHECK(threw == fail, "snapshot allocation failure propagates");
+  CHECK(doc.operations == 0 && harness.live == 0 && Frame.status.value == "Ready",
+        "snapshot storage: exception and normal cleanup");
+  if (fail) {
+    CHECK(harness.creates == 0 && doc.m_LineList.GetCount() == count,
+          "snapshot failure leaves original output intact");
+    CHECK(liveTextArrays == arraysBefore, "snapshot failure releases retained blocks");
+  } else {
+    CHECK(harness.creates == 1 && doc.m_LineList.GetCount() == 0 && liveTextArrays == 0,
+          "snapshot storage releases source and copied text");
+  }
+  if (cancel) CHECK(harness.polls == 1, "snapshot storage preserves first-poll cancellation");
+  harness.callback = nullptr;
+}
+
 int main(int argc, char** argv) {
   CHECK(argc == 2, "one case argument required");
   const std::string name = argv[1];
+  if (name.rfind("recall_storage_", 0) == 0) {
+    RecallStorageCase(name);
+    std::cout << "PASS: " << name << '\n';
+    return 0;
+  }
   const Scenario scenario = Parse(name);
   if (name.rfind("recall_", 0) == 0) RecallCase(scenario);
   else if (name.rfind("memory_", 0) == 0) MemoryCase(scenario);

--- a/tests/world_callback_lifetime.cpp.in
+++ b/tests/world_callback_lifetime.cpp.in
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -21,7 +22,7 @@ using POSITION = std::size_t;
 using BOOL = int;
 constexpr int SOCKET_ERROR=-1, TRUE=1, FALSE=0, WM_CLOSE=16;
 constexpr int MB_YESNO=4, MB_ICONQUESTION=32, IDYES=6, IDNO=7;
-constexpr int eOK=0, eCommandsNestedTooDeeply=1, eWorldClosed=2, MAX_EXECUTION_DEPTH=20;
+constexpr int eOK=0, eCommandsNestedTooDeeply=1, eWorldClosed=2, eChatIDNotFound=3, MAX_EXECUTION_DEPTH=20;
 enum { eReloadNever, eReloadAlways, eReloadConfirm };
 enum { eChatAwaitingConnectConfirm, eChatAwaitingConnectionRequest, eChatConnected,
        eChatClosed, eChatMudMaster, eChatZMud, eChatConnection, eChatSession,
@@ -91,6 +92,16 @@ struct MSG { void* hwnd=nullptr; int message=0; };
 struct CPlugin {};
 struct CChatSocket;
 struct CMUSHclientDoc;
+// Minimal MFC list substitute. Cleanup always breaks after removing one node.
+struct ChatList {
+    std::vector<CChatSocket*> items;
+    POSITION GetHeadPosition() const { return items.empty()?0:1; }
+    CChatSocket* GetNext(POSITION& p) const {
+        auto socket=items.at(p-1);p=p==items.size()?0:p+1;return socket;
+    }
+    void RemoveAt(POSITION p) { items.erase(items.begin()+p-1); }
+};
+std::function<void(CMUSHclientDoc*)> commandHook;
 struct State {
     bool worldDestroyed=false,chatDestroyed=false,throwCommand=false,throwReload=false;
     bool throwPrompt=false,closeDuringCommand=true,closeDuringPrompt=true;
@@ -108,6 +119,8 @@ struct ScriptEngine {
 };
 struct CMUSHclientDoc: CDocument {
     CChatSocket* chat=nullptr;
+    ChatList m_ChatList;
+    int timerContinuations=0;
     CPlugin plugin;
     CPlugin* m_CurrentPlugin=&plugin;
     ScriptEngine engine{this};
@@ -127,6 +140,9 @@ struct CMUSHclientDoc: CDocument {
     void OnCloseDocument();
     void OnScriptFileChanged(bool force=false);
     long Execute(LPCTSTR);
+    long ChatDisconnect(long);
+    CChatSocket* GetChatSocket(const long) const;
+    void CleanupTick();
     template<class... T> bool SendToAllPluginCallbacks(T...) { return true; }
     void ChatNote(int kind,const CString&);
     void Activate(){}
@@ -197,11 +213,15 @@ struct CChatSocket {
     CString m_outstanding_input;
     string incoming;
     explicit CChatSocket(CMUSHclientDoc* p):m_pDoc(p){}
-    ~CChatSocket() { state->chatDestroyed=true; }
+    bool* destructionFlag=nullptr;
+    ~CChatSocket() {
+        if(destructionFlag)*destructionFlag=true;
+        else state->chatDestroyed=true;
+    }
     int Receive(char* buffer,int size) { CHECK(incoming.size()<=static_cast<std::size_t>(size),"packet fits");
         std::memcpy(buffer,incoming.data(),incoming.size());return static_cast<int>(incoming.size()); }
     int GetLastError() { return 0; }
-    void OnClose(int) { m_bDeleteMe=true; }
+    void OnClose(int);
     void SendData(const CString&){}
     void SendChatMessage(int,const CString&){}
     void OnReceive(int);
@@ -224,12 +244,22 @@ struct CChatSocket {
     UNUSED_HANDLER(Process_PGPkey)
 #undef UNUSED_HANDLER
 };
-CMUSHclientDoc::~CMUSHclientDoc() { state->worldDestroyed=true;delete chat; }
+CMUSHclientDoc::~CMUSHclientDoc() {
+    state->worldDestroyed=true;delete chat;
+    for(auto socket:m_ChatList.items)delete socket;
+}
+// List ownership is a substitute. Lookup, disconnect, and close use extracted source.
+void CMUSHclientDoc::CleanupTick() {
+    @CHAT_CLEANUP@
+    // The rest of CheckTimerList is outside this fixture. A return above is a failure.
+    ++timerContinuations;
+}
 void ScriptEngine::Parse(const CString&,const char*) {
     ++state->commands;
     CHECK(doc->m_iExecutionDepth==1,"remote execution depth reset");
     CHECK(doc->m_CurrentPlugin==nullptr,"Execute clears current plugin");
     if(state->closeDuringCommand)ExpectRetained(doc,"world retained during command");
+    if(commandHook)commandHook(doc);
     if(state->throwCommand)throw std::runtime_error("command callback failure");
     ++state->completedCommands;
 }
@@ -247,7 +277,7 @@ int UMessageBox(const CString&,int) {
 @GUARDS@
 @FUNCTIONS@
 
-void Reset(State& s) { state=&s;App=AppStub{};App.doc=new CMUSHclientDoc; }
+void Reset(State& s) { state=&s;commandHook={};App=AppStub{};App.doc=new CMUSHclientDoc; }
 void Finish() {
     CHECK(!state->worldDestroyed,"world alive until callback returns");
     CHECK(App.doc->m_iActiveProgressOperations==0,"operation depth restored");
@@ -316,7 +346,96 @@ void ScriptCases() {
     }
     std::puts("PASS: reload yes, no, force, throw, close request, and early returns");
 }
+CChatSocket* AddChat(CMUSHclientDoc* doc,int id,bool& destroyed) {
+    auto socket=new CChatSocket(doc);socket->m_iChatID=id;socket->destructionFlag=&destroyed;
+    doc->m_ChatList.items.push_back(socket);return socket;
+}
+void TimerCases() {
+    for(int protocol:{eChatMudMaster,eChatZMud})for(bool throws:{false,true})for(bool outerOperation:{false,true}) {
+        State s;Reset(s);s.closeDuringCommand=false;s.throwCommand=throws;
+        auto doc=App.doc;
+        bool liveDeleted=false,activeDeleted=false,markedDeleted=false;
+        bool otherLiveDeleted=false,otherFirstDeleted=false,otherSecondDeleted=false;
+        AddChat(doc,10,liveDeleted);
+        auto active=AddChat(doc,11,activeDeleted);
+        AddChat(doc,12,markedDeleted);
+        CHECK(doc->ChatDisconnect(12)==eOK,"existing marked chat disconnects");
+        auto other=new CMUSHclientDoc;
+        AddChat(other,20,otherLiveDeleted);AddChat(other,21,otherFirstDeleted);AddChat(other,22,otherSecondDeleted);
+        CHECK(other->ChatDisconnect(21)==eOK && other->ChatDisconnect(22)==eOK,"other world chats disconnect");
+        active->m_iChatConnectionType=protocol;
+        active->incoming=Packet(protocol,CHAT_SEND_COMMAND,"/disconnect")+Packet(protocol,CHAT_MESSAGE,"next");
+        std::unique_ptr<CWorldDocumentOperationGuard> outer;
+        if(outerOperation)outer=std::make_unique<CWorldDocumentOperationGuard>(doc);
+        commandHook=[&](CMUSHclientDoc* current) {
+            CHECK(current==doc,"command uses its owning world");
+            CHECK(doc->m_iActiveProgressOperations==1+outerOperation,"receive guard nests in prior operation");
+            CHECK(doc->ChatDisconnect(11)==eOK,"command disconnects its own chat");
+            CHECK(active->m_bDeleteMe && active->m_iChatStatus==eChatClosed,"real OnClose marks the active chat");
+            CHECK(doc->GetChatSocket(11)==nullptr && doc->ChatDisconnect(11)==eChatIDNotFound,
+                  "disconnected chat becomes unavailable before physical deletion");
+            CHECK(!activeDeleted && doc->m_ChatList.items.size()==3,"disconnect preserves allocation until safe cleanup");
+            CHECK(doc->GetChatSocket(10)!=nullptr && doc->GetChatSocket(12)==nullptr,
+                  "live chat remains available and marked chat stays unavailable");
+            // Model a modal script callback that dispatches a timer while Parse is active.
+            {
+                CWorldDocumentOperationGuard nested(doc);
+                CHECK(doc->m_iActiveProgressOperations==2+outerOperation,"nested operation depth retained");
+                const int before=doc->timerContinuations;
+                doc->CleanupTick();
+                CHECK(!activeDeleted,"marked chat survives modal timer cleanup");
+                CHECK(doc->timerContinuations==before+1,"timer work continues during an active operation");
+                CHECK(!markedDeleted && !liveDeleted,"same-world marked and live chats survive active operation");
+                other->CleanupTick();
+                CHECK(otherFirstDeleted && !otherSecondDeleted && !otherLiveDeleted,"other world cleans one marked chat during active receive");
+                CHECK(other->timerContinuations==1,"other world continues timer work after deletion");
+                other->CleanupTick();
+                CHECK(otherSecondDeleted && !otherLiveDeleted,"other world next tick cleans remaining marked chat");
+                CHECK(other->timerContinuations==2,"other world timer work continues on each tick");
+            }
+            CHECK(doc->m_iActiveProgressOperations==1+outerOperation,"inner guard restores prior operation depth");
+            doc->CleanupTick();
+            CHECK(!activeDeleted && !markedDeleted,"receive guard retains marked chats after inner scope");
+            CHECK(doc->timerContinuations==2,"timer work continues after inner scope");
+        };
+        bool caught=false;
+        try { active->OnReceive(0); }
+        catch(const std::runtime_error& error) {
+            caught=true;CHECK(string(error.what())=="command callback failure","timer callback preserves original exception");
+        }
+        commandHook={};
+        CHECK(caught==throws,"timer callback exception propagates");
+        CHECK(!activeDeleted,"marked socket survives receive return or throw");
+        CHECK(doc->GetChatSocket(11)==nullptr,"marked socket stays unavailable while cleanup is deferred");
+        CHECK(doc->m_iActiveProgressOperations==outerOperation,"receive unwind restores outer depth");
+        CHECK(doc->m_iExecutionDepth==7 && doc->m_CurrentPlugin==&doc->plugin && doc->m_bInSendToScript,
+              "command state restores before marked socket deletion");
+        CHECK(s.commands==1 && s.completedCommands==(throws?0:1),"accepted command completes or propagates its error");
+        CHECK(s.afterCommands==0 && !active->m_outstanding_input.IsEmpty(),"real receive loop stops buffered input after chat disconnect");
+        if(outerOperation) {
+            doc->CleanupTick();
+            CHECK(!activeDeleted && !markedDeleted,"outer operation defers cleanup after receive returns");
+            CHECK(doc->timerContinuations==3,"outer operation does not stop timer work");
+            outer.reset();
+        }
+        CHECK(doc->m_iActiveProgressOperations==0,"all operation guards release before later tick");
+        const int before=doc->timerContinuations;
+        doc->CleanupTick();
+        CHECK(activeDeleted && !markedDeleted && !liveDeleted,"later tick deletes active marked chat only");
+        CHECK(doc->m_ChatList.items.size()==2 && doc->timerContinuations==before+1,"deletion removes one list entry and continues timers");
+        doc->CleanupTick();
+        CHECK(markedDeleted && !liveDeleted,"next tick deletes remaining marked chat only");
+        doc->CleanupTick();
+        CHECK(doc->m_ChatList.items.size()==1 && !liveDeleted,"live unmarked chat remains on later ticks");
+        CHECK(doc->timerContinuations==before+3,"timer work continues after all marked chats are gone");
+        CHECK(!s.worldDestroyed,"chat cleanup does not close either world");
+        Finish();CHECK(liveDeleted,"world teardown releases surviving chat");
+        delete other;CHECK(otherLiveDeleted,"other world teardown releases surviving chat");
+    }
+    std::puts("PASS: timer cleanup retains active chat, preserves other worlds and timer work, and deletes on later ticks after return or throw");
+}
 int main(int argc,char** argv) {
     if(argc==1 || string(argv[1])=="chat")ChatCases();
     if(argc==1 || string(argv[1])=="script")ScriptCases();
+    if(argc==1 || string(argv[1])=="timer")TimerCases();
 }

--- a/tests/world_callback_lifetime.cpp.in
+++ b/tests/world_callback_lifetime.cpp.in
@@ -1,0 +1,322 @@
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+using std::string;
+#define CHECK(condition, message) do { if (!(condition)) { \
+    std::fprintf(stderr, "FAIL: %s\n", message); std::exit(2); } } while (false)
+#define ASSERT(condition) CHECK(condition, #condition)
+#define _T(text) text
+#define CHAT_DEBUG 0
+#define MUSHCLIENT_VERSION "test"
+#define ENDLINE "\r\n"
+using LPCTSTR = const char*;
+using __int64 = long long;
+using POSITION = std::size_t;
+using BOOL = int;
+constexpr int SOCKET_ERROR=-1, TRUE=1, FALSE=0, WM_CLOSE=16;
+constexpr int MB_YESNO=4, MB_ICONQUESTION=32, IDYES=6, IDNO=7;
+constexpr int eOK=0, eCommandsNestedTooDeeply=1, eWorldClosed=2, MAX_EXECUTION_DEPTH=20;
+enum { eReloadNever, eReloadAlways, eReloadConfirm };
+enum { eChatAwaitingConnectConfirm, eChatAwaitingConnectionRequest, eChatConnected,
+       eChatClosed, eChatMudMaster, eChatZMud, eChatConnection, eChatSession,
+       eChatCommand, eChatInformation, eChatMessage };
+enum { CHAT_TEXT_EVERYBODY=1, CHAT_TEXT_PERSONAL, CHAT_MESSAGE, CHAT_TEXT_GROUP,
+       CHAT_PING_REQUEST, CHAT_PING_RESPONSE, CHAT_VERSION, CHAT_REQUEST_CONNECTIONS,
+       CHAT_CONNECTION_LIST, CHAT_PEEK_CONNECTIONS, CHAT_PEEK_LIST, CHAT_SNOOP,
+       CHAT_SNOOP_DATA, CHAT_NAME_CHANGE, CHAT_SEND_COMMAND, CHAT_FILE_START,
+       CHAT_FILE_DENY, CHAT_FILE_BLOCK_REQUEST, CHAT_FILE_BLOCK, CHAT_FILE_END,
+       CHAT_FILE_CANCEL, CHAT_ICON, CHAT_STATUS, CHAT_EMAIL_ADDRESS, CHAT_STAMP,
+       CHAT_REQUEST_PGP_KEY, CHAT_PGP_KEY, CHAT_END_OF_COMMAND=255 };
+enum { ON_PLUGIN_CHAT_NEWUSER, ON_PLUGIN_CHAT_ACCEPT, ON_PLUGIN_CHAT_MESSAGE,
+       ON_PLUGIN_COMMAND };
+
+struct CString {
+    string value;
+    CString()=default;
+    CString(const char* p):value(p){}
+    CString(string p):value(std::move(p)){}
+    CString(const char* p,int n):value(p,n){}
+    CString(char c):value(1,c){}
+    operator const char*() const { return value.c_str(); }
+    bool IsEmpty() const { return value.empty(); }
+    int GetLength() const { return static_cast<int>(value.size()); }
+    char operator[](int n) const { return value.at(n); }
+    CString Left(int n) const { return value.substr(0,n); }
+    CString Right(int n) const { return value.substr(value.size()-n); }
+    CString Mid(int n,int count=-1) const { return value.substr(n,count<0?string::npos:count); }
+    int Find(char c) const { auto n=value.find(c); return n==string::npos?-1:static_cast<int>(n); }
+    void Delete(int start,int count) { value.erase(start,count); }
+    void TrimLeft() { value.erase(0,value.find_first_not_of(" \t")); }
+    int CompareNoCase(const char* p) const {
+        string a=value,b=p;
+        for(char& c:a)c=static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        for(char& c:b)c=static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        return a.compare(b);
+    }
+    void Replace(const CString& from,const CString& to) {
+        std::size_t pos=0;
+        while((pos=value.find(from.value,pos))!=string::npos) {
+            value.replace(pos,from.value.size(),to.value); pos+=to.value.size();
+        }
+    }
+    CString& operator+=(const CString& rhs) { value+=rhs.value; return *this; }
+    bool operator==(const CString& rhs) const { return value==rhs.value; }
+};
+CString Replace(CString input,const CString& from,const CString& to) { input.Replace(from,to);return input; }
+template<class... T> CString TFormat(const char* text,T...) { return text; }
+template<class... T> CString CFormat(const char* text,T...) { return text; }
+const char* Translate(const char* text) { return text; }
+struct CStringList {
+    std::vector<CString> items;
+    bool IsEmpty() const { return items.empty(); }
+    void AddTail(const CString& item) { items.push_back(item); }
+    POSITION GetHeadPosition() const { return items.empty()?0:1; }
+    CString GetNext(POSITION& p) { auto result=items.at(p-1);p=p==items.size()?0:p+1;return result; }
+};
+void StringToList(const CString& input,const char*,CStringList& list) { if(!input.IsEmpty())list.AddTail(input); }
+struct CTime { static int GetCurrentTime() { return 1; } };
+struct CFileStatus { int m_mtime=2; };
+struct CFile { static void GetStatus(const CString&,CFileStatus& status) { status.m_mtime=2; } };
+struct Address { int sin_addr=0; };
+const char* inet_ntoa(int) { return "127.0.0.1"; }
+CString MakeStamp(int) { return "stamp"; }
+struct CProgressDlg { static bool IsPumpingMessages() { return false; } };
+struct MSG { void* hwnd=nullptr; int message=0; };
+struct CPlugin {};
+struct CChatSocket;
+struct CMUSHclientDoc;
+struct State {
+    bool worldDestroyed=false,chatDestroyed=false,throwCommand=false,throwReload=false;
+    bool throwPrompt=false,closeDuringCommand=true,closeDuringPrompt=true;
+    int commands=0,afterCommands=0,disabled=0,created=0,prompts=0,answer=IDYES;
+    int commandNotes=0,closeRequests=0,completedCommands=0;
+};
+State* state=nullptr;
+struct CDocument {
+    virtual ~CDocument()=default;
+    void OnCloseDocument() { delete this; }
+};
+struct ScriptEngine {
+    CMUSHclientDoc* doc;
+    void Parse(const CString&,const char*);
+};
+struct CMUSHclientDoc: CDocument {
+    CChatSocket* chat=nullptr;
+    CPlugin plugin;
+    CPlugin* m_CurrentPlugin=&plugin;
+    ScriptEngine engine{this};
+    ScriptEngine* m_ScriptEngine=&engine;
+    int m_iActiveProgressOperations=0,m_iExecutionDepth=7,m_nReloadOption=eReloadConfirm;
+    int m_timeScriptFileMod=1;
+    __int64 m_iUniqueDocumentNumber=1;
+    bool m_bWorldCloseQueued=false,m_bWorldClosePending=false;
+    bool m_bInScriptFileChanged=false,m_bSyntaxErrorOnly=false,m_bEnableScripts=true;
+    bool m_bInSendToScript=true,m_bPluginProcessingCommand=false,m_enable_command_stack=false;
+    bool m_display_my_input=false,m_bValidateIncomingCalls=false;
+    CString m_strScriptFilename="world.lua",m_strScriptPrefix="/",m_strCommandStackCharacter=";";
+    CString m_mush_name="world",m_strOurChatName="local";
+    ~CMUSHclientDoc() override;
+    void BeginProgressOperation();
+    void EndProgressOperation();
+    void OnCloseDocument();
+    void OnScriptFileChanged(bool force=false);
+    long Execute(LPCTSTR);
+    template<class... T> bool SendToAllPluginCallbacks(T...) { return true; }
+    void ChatNote(int kind,const CString&);
+    void Activate(){}
+    void ColourNote(const char*,const char*,const char*){}
+    bool CheckConnected() { return false; }
+    bool LoggingInput() { return false; }
+    void SendMsg(const char*,bool,bool,bool){}
+    bool EvaluateCommand(const CString&,bool,bool&) { return false; }
+    void DisableScripting() { ++state->disabled; }
+    void CreateScriptEngine();
+};
+struct AppStub {
+    CMUSHclientDoc* doc=nullptr;
+    bool documentClose=false,frameClose=false;
+    void DeferWorldDocumentClose(__int64) { documentClose=true; }
+    void DeferMessageUntilIdle(const MSG& msg,__int64) { CHECK(msg.message==WM_CLOSE,"frame close queued");frameClose=true; }
+    // Model the application's idle gate. Never drain while a document operation is active.
+    void Drain() {
+        if(doc->m_iActiveProgressOperations) return;
+        if(documentClose || frameClose) {
+            documentClose=frameClose=false;
+            doc->OnCloseDocument();
+        }
+    }
+} App;
+struct CMDIChildWnd {
+    CMUSHclientDoc* doc;
+    explicit CMDIChildWnd(CMUSHclientDoc* p):doc(p){}
+    void OnClose() { doc->OnCloseDocument(); }
+};
+struct CChildFrame: CMDIChildWnd {
+    CMUSHclientDoc* m_pDoc;
+    explicit CChildFrame(CMUSHclientDoc* p):CMDIChildWnd(p),m_pDoc(p){}
+    void* GetSafeHwnd() { return this; }
+    void OnClose();
+};
+bool closeThroughFrame=false;
+void RequestClose(CMUSHclientDoc* doc) {
+    ++state->closeRequests;
+    if(closeThroughFrame) { CChildFrame frame(doc);frame.OnClose(); }
+    else doc->OnCloseDocument();
+}
+void ExpectRetained(CMUSHclientDoc* doc,const char* message) {
+    RequestClose(doc);
+    CHECK(!state->worldDestroyed,message);
+    App.Drain();
+    CHECK(!state->worldDestroyed,message);
+    CHECK(!state->chatDestroyed,"owned chat retained");
+}
+// ChatNote can call OnPluginChatDisplay. This hook models a close request
+// from that callback on the second packet, after the command has returned.
+void CMUSHclientDoc::ChatNote(int kind,const CString&) {
+    if(kind==eChatCommand)++state->commandNotes;
+    if(kind!=eChatMessage)return;
+    ++state->afterCommands;
+    CHECK(m_iExecutionDepth==7,"command depth restored before next packet");
+    CHECK(m_CurrentPlugin==&plugin,"plugin restored before next packet");
+    ExpectRetained(this,"world retained after command");
+}
+struct CChatSocket {
+    CMUSHclientDoc* m_pDoc;
+    int m_iChatStatus=eChatConnected,m_iChatConnectionType=eChatMudMaster;
+    int m_tLastIncoming=0,m_iChatID=3,m_iFileBlockSize=500,m_iAllegedPort=0,m_zChatStamp=0;
+    bool m_bDeleteMe=false,m_bWasConnected=false,m_bCanSendCommands=true,m_bIgnore=false;
+    int m_iCountMessages=0;
+    Address m_ServerAddr;
+    CString m_strRemoteUserName="remote",m_strAllegedAddress;
+    CString m_outstanding_input;
+    string incoming;
+    explicit CChatSocket(CMUSHclientDoc* p):m_pDoc(p){}
+    ~CChatSocket() { state->chatDestroyed=true; }
+    int Receive(char* buffer,int size) { CHECK(incoming.size()<=static_cast<std::size_t>(size),"packet fits");
+        std::memcpy(buffer,incoming.data(),incoming.size());return static_cast<int>(incoming.size()); }
+    int GetLastError() { return 0; }
+    void OnClose(int) { m_bDeleteMe=true; }
+    void SendData(const CString&){}
+    void SendChatMessage(int,const CString&){}
+    void OnReceive(int);
+    void ProcessChatMessage(int,const CString);
+    void Process_Send_command(const CString);
+    void Process_Message(const CString);
+#define UNUSED_HANDLER(name) void name(const CString&){}
+    UNUSED_HANDLER(Process_Text_everybody) UNUSED_HANDLER(Process_Text_personal)
+    UNUSED_HANDLER(Process_Text_group) UNUSED_HANDLER(Process_Ping_request)
+    UNUSED_HANDLER(Process_Ping_response) UNUSED_HANDLER(Process_Version)
+    UNUSED_HANDLER(Process_Request_connections) UNUSED_HANDLER(Process_Connection_list)
+    UNUSED_HANDLER(Process_Peek_connections) UNUSED_HANDLER(Process_Peek_list)
+    UNUSED_HANDLER(Process_Snoop) UNUSED_HANDLER(Process_Snoop_data)
+    UNUSED_HANDLER(Process_Name_change) UNUSED_HANDLER(Process_File_start)
+    UNUSED_HANDLER(Process_File_deny) UNUSED_HANDLER(Process_File_block_request)
+    UNUSED_HANDLER(Process_File_block) UNUSED_HANDLER(Process_File_end)
+    UNUSED_HANDLER(Process_File_cancel) UNUSED_HANDLER(Process_Icon)
+    UNUSED_HANDLER(Process_Status) UNUSED_HANDLER(Process_EmailAddress)
+    UNUSED_HANDLER(Process_Stamp) UNUSED_HANDLER(Process_RequestPGPkey)
+    UNUSED_HANDLER(Process_PGPkey)
+#undef UNUSED_HANDLER
+};
+CMUSHclientDoc::~CMUSHclientDoc() { state->worldDestroyed=true;delete chat; }
+void ScriptEngine::Parse(const CString&,const char*) {
+    ++state->commands;
+    CHECK(doc->m_iExecutionDepth==1,"remote execution depth reset");
+    CHECK(doc->m_CurrentPlugin==nullptr,"Execute clears current plugin");
+    if(state->closeDuringCommand)ExpectRetained(doc,"world retained during command");
+    if(state->throwCommand)throw std::runtime_error("command callback failure");
+    ++state->completedCommands;
+}
+void CMUSHclientDoc::CreateScriptEngine() {
+    ++state->created;
+    ExpectRetained(this,"world retained during script reload");
+    if(state->throwReload)throw std::runtime_error("reload callback failure");
+}
+int UMessageBox(const CString&,int) {
+    ++state->prompts;
+    if(state->closeDuringPrompt)ExpectRetained(App.doc,"world retained during script reload");
+    if(state->throwPrompt)throw std::runtime_error("prompt callback failure");
+    return state->answer;
+}
+@GUARDS@
+@FUNCTIONS@
+
+void Reset(State& s) { state=&s;App=AppStub{};App.doc=new CMUSHclientDoc; }
+void Finish() {
+    CHECK(!state->worldDestroyed,"world alive until callback returns");
+    CHECK(App.doc->m_iActiveProgressOperations==0,"operation depth restored");
+    CHECK(App.doc->m_iExecutionDepth==7,"execution depth restored");
+    CHECK(App.doc->m_CurrentPlugin==&App.doc->plugin,"plugin restored");
+    CHECK(App.doc->m_bInSendToScript,"script-send state restored");
+    CHECK(!App.doc->m_bInScriptFileChanged,"reload state restored");
+    if(App.documentClose || App.frameClose)App.Drain();
+    else App.doc->OnCloseDocument();
+    CHECK(state->worldDestroyed,"world closes after callback returns");
+}
+string Packet(int protocol,int command,const string& payload) {
+    if(protocol==eChatMudMaster)return string(1,static_cast<char>(command))+payload+static_cast<char>(CHAT_END_OF_COMMAND);
+    return string{static_cast<char>(command),0,static_cast<char>(payload.size()),0}+payload;
+}
+void ChatCases() {
+    for(int protocol:{eChatMudMaster,eChatZMud})for(bool throughFrame:{false,true})for(bool throws:{false,true}) {
+        State s;Reset(s);closeThroughFrame=throughFrame;s.throwCommand=throws;
+        auto chat=App.doc->chat=new CChatSocket(App.doc);
+        chat->m_iChatConnectionType=protocol;
+        chat->incoming=Packet(protocol,CHAT_SEND_COMMAND,"/test")+Packet(protocol,CHAT_MESSAGE,"next");
+        bool caught=false;
+        try { chat->OnReceive(0); }
+        catch(const std::runtime_error& error) { caught=true;CHECK(string(error.what())=="command callback failure","original exception preserved"); }
+        CHECK(caught==throws,"command exception propagates");
+        CHECK(s.commands==1 && s.commandNotes==1,"accepted command runs once");
+        CHECK(s.completedCommands==(throws?0:1),"accepted command completes after close request");
+        CHECK(s.afterCommands==(throws?0:1),"remaining chat packet runs after command");
+        CHECK(chat->m_iCountMessages==(throws?0:1),"real message handler updates owned socket");
+        Finish();CHECK(s.chatDestroyed,"world deletes owned chat after receive returns");
+    }
+    // The guard must release on empty input and on the denied-command path.
+    for(bool denied:{false,true}) {
+        State s;Reset(s);auto chat=App.doc->chat=new CChatSocket(App.doc);
+        if(denied) { chat->m_bCanSendCommands=false;chat->incoming=Packet(eChatMudMaster,CHAT_SEND_COMMAND,"/test"); }
+        chat->OnReceive(0);CHECK(s.commands==0,"empty or denied input does not execute");Finish();
+    }
+    std::puts("PASS: chat success, throw, close request, both protocols, outer processing, early return");
+}
+void ScriptCases() {
+    for(bool throughFrame:{false,true})for(int mode=0;mode<5;++mode) {
+        State s;Reset(s);closeThroughFrame=throughFrame;
+        const bool force=mode==3;
+        s.throwReload=mode==1;s.answer=mode==2?IDNO:IDYES;s.throwPrompt=mode==4;
+        bool caught=false;
+        try { App.doc->OnScriptFileChanged(force); }
+        catch(const std::runtime_error& error) { caught=true;
+            CHECK(string(error.what())==(s.throwPrompt?"prompt callback failure":"reload callback failure"),"reload exception preserved"); }
+        CHECK(caught==(s.throwReload || s.throwPrompt),"reload exception propagates");
+        CHECK(s.prompts==(force?0:1),"force preserves prompt behavior");
+        const int reloads=(s.answer==IDNO || s.throwPrompt)?0:1;
+        CHECK(s.disabled==reloads && s.created==reloads,"accepted reload runs after close request");
+        Finish();
+    }
+    for(int mode=0;mode<5;++mode) {
+        State s;Reset(s);
+        if(mode==0)App.doc->m_bInScriptFileChanged=true;
+        if(mode==1)App.doc->m_ScriptEngine=nullptr;
+        if(mode==2)App.doc->m_strScriptFilename="";
+        if(mode==3)App.doc->m_nReloadOption=eReloadNever;
+        if(mode==4)App.doc->m_timeScriptFileMod=2;
+        App.doc->OnScriptFileChanged();
+        CHECK(s.prompts==0 && s.created==0,"reload early return preserves behavior");
+        CHECK(App.doc->m_bInScriptFileChanged==(mode==0),"existing reload state preserved");
+        App.doc->m_bInScriptFileChanged=false;Finish();
+    }
+    std::puts("PASS: reload yes, no, force, throw, close request, and early returns");
+}
+int main(int argc,char** argv) {
+    if(argc==1 || string(argv[1])=="chat")ChatCases();
+    if(argc==1 || string(argv[1])=="script")ScriptCases();
+}

--- a/textchildfrm.cpp
+++ b/textchildfrm.cpp
@@ -3,6 +3,7 @@
 
 #include "stdafx.h"
 #include "MUSHclient.h"
+#include "dialogs\ProgDlg.h"
 #include "mainfrm.h"
 #include "TextDocument.h"
 #include "textchildfrm.h"
@@ -19,6 +20,7 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 IMPLEMENT_DYNCREATE(CTextChildFrame, CMDIChildWnd)
 
 BEGIN_MESSAGE_MAP(CTextChildFrame, CMDIChildWnd)
+	ON_WM_CLOSE()
 	//{{AFX_MSG_MAP(CTextChildFrame)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
@@ -55,6 +57,19 @@ void CTextChildFrame::Dump(CDumpContext& dc) const
 /////////////////////////////////////////////////////////////////////////////
 // CTextChildFrame message handlers
 
+
+void CTextChildFrame::OnClose()
+{
+  if (m_pDoc && (CProgressDlg::IsPumpingMessages () || m_pDoc->m_iActiveOperations != 0))
+    {
+    MSG msg = {};
+    msg.hwnd = GetSafeHwnd ();
+    msg.message = WM_CLOSE;
+    App.DeferMessageUntilIdle (msg, m_pDoc->m_iTextDocumentNumber);
+    return;
+    }
+  CMDIChildWnd::OnClose ();
+}
 
 BOOL CTextChildFrame::PreCreateWindow(CREATESTRUCT& cs) 
 {

--- a/textchildfrm.h
+++ b/textchildfrm.h
@@ -36,6 +36,7 @@ public:
 
 // Generated message map functions
 protected:
+	afx_msg void OnClose();
 	//{{AFX_MSG(CTextChildFrame)
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/timers.cpp
+++ b/timers.cpp
@@ -75,7 +75,8 @@ CmcDateTimeSpan tsOneDay (1, 0, 0, 0);
     {
     POSITION oldpos = chatpos;
     CChatSocket * pSocket = m_ChatList.GetNext (chatpos);
-    if (pSocket->m_bDeleteMe)
+    // A modal callback can run timers while a chat socket is still in use.
+    if (pSocket->m_bDeleteMe && m_iActiveProgressOperations == 0)
       {
       m_ChatList.RemoveAt (oldpos);
       delete pSocket;


### PR DESCRIPTION
Dispatch file-change, hostname, and other deferred notifications after active document operations finish. Keep notepads and world documents alive during nested progress operations, preserve socket dispatch, and use output snapshots during search, recall, and memory reports. Close paste files on exceptions and report progress-dialog failures through Lua after C++ cleanup.

Depends on #72. Review and merge in this order: #71, #72, then #16.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when closing worlds, notepads, and text documents during active operations or progress dialogs.
  * Prevented stale file-change, hostname, and security prompts from affecting the wrong document or connection.
  * Improved progress dialog behavior during cancellation, window closure, and nested message processing.
  * Fixed notepad selection and listing for documents pending closure.
  * Improved output search, file monitoring, paste handling, memory calculations, and resource cleanup.

* **Tests**
  * Added regression coverage for deferred processing, monitoring, progress dialogs, notepads, connection lookups, and output search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->