### PR TITLE
Preserve working directory state when path operations fail

### DIFF
--- a/MUSHclient.cpp
+++ b/MUSHclient.cpp
@@ -249,7 +249,8 @@ BOOL CMUSHclientApp::InitInstance()
 
 // find the working directory at startup time
 
-  _getdcwd (0, working_dir, sizeof (working_dir) - 1);
+  if (!_getdcwd (0, working_dir, sizeof (working_dir) - 1))
+    AfxThrowFileException (CFileException::genericException, errno);
 
 // make sure directory name ends in a slash
 

--- a/Utilities.cpp
+++ b/Utilities.cpp
@@ -3345,7 +3345,9 @@ extern char file_browsing_dir [_MAX_PATH];
 void ChangeToFileBrowsingDirectory ()
   {
 
-  _chdir(file_browsing_dir);
+  if (_chdir(file_browsing_dir) != 0)
+    AfxThrowFileException (CFileException::genericException, errno,
+                           file_browsing_dir);
 
   }  // end of ChangeToFileBrowsingDirectory
 
@@ -3354,18 +3356,28 @@ void ChangeToStartupDirectory ()
 
 // first, remember the file_browsing directory
 
-  _getdcwd (0, file_browsing_dir, sizeof (file_browsing_dir) - 1);
+  char strCurrentDirectory [_MAX_PATH];
+  if (!_getdcwd (0, strCurrentDirectory, sizeof (strCurrentDirectory) - 1))
+    {
+    int iError = errno;
+    _chdir (working_dir);
+    AfxThrowFileException (CFileException::genericException, iError);
+    }
 
 // make sure directory name ends in a slash
 
-  file_browsing_dir [sizeof (file_browsing_dir) - 2] = 0;
+  strCurrentDirectory [sizeof (strCurrentDirectory) - 2] = 0;
 
-  if (file_browsing_dir [strlen (file_browsing_dir) - 1] != '\\')
-    strcat (file_browsing_dir, "\\");
+  if (strCurrentDirectory [strlen (strCurrentDirectory) - 1] != '\\')
+    strcat (strCurrentDirectory, "\\");
+
+  strcpy (file_browsing_dir, strCurrentDirectory);
 
 
   // now change back to startup directory
-  _chdir(working_dir);
+  if (_chdir(working_dir) != 0)
+    AfxThrowFileException (CFileException::genericException, errno,
+                           working_dir);
 
   } // end of ChangeToStartupDirectory
 

--- a/Utilities.cpp
+++ b/Utilities.cpp
@@ -3346,8 +3346,19 @@ void ChangeToFileBrowsingDirectory ()
   {
 
   if (_chdir(file_browsing_dir) != 0)
-    AfxThrowFileException (CFileException::genericException, errno,
-                           file_browsing_dir);
+    {
+    int iError = errno;
+    char strFailedDirectory [_MAX_PATH];
+    strcpy (strFailedDirectory, file_browsing_dir);
+
+    // Keep the error visible, but use a valid directory on the next attempt.
+    if (_chdir (working_dir) != 0)
+      AfxThrowFileException (CFileException::genericException, errno,
+                             working_dir);
+    strcpy (file_browsing_dir, working_dir);
+    AfxThrowFileException (CFileException::genericException, iError,
+                           strFailedDirectory);
+    }
 
   }  // end of ChangeToFileBrowsingDirectory
 

--- a/dialogs/TipDlg.cpp
+++ b/dialogs/TipDlg.cpp
@@ -26,26 +26,7 @@ static const TCHAR szIntStartup[] = _T("Tip_StartUp");
 CTipDlg::CTipDlg(CWnd* pParent /*=NULL*/)
 	: CDialog(IDD_TIP, pParent)
 {
-char fullfilename[MAX_PATH];
-char filename [MAX_PATH];
-char * p;
-
-  // look for tips.txt in the same directory as the executable file
-  if (GetModuleFileName (NULL, fullfilename, sizeof (fullfilename)))
-   {
-
-// remove last part of file name to get working directory
-
-    strcpy (filename, fullfilename);
-
-    p = strrchr (filename, '\\');
-    if (p)
-      *p = 0;
-
-    strcat (filename, "\\tips.txt");
-    }
-  else
-    strcpy (filename, "tips.txt");
+CString filename = ExtractDirectory (App.m_strMUSHclientFileName) + "tips.txt";
 
 	//{{AFX_DATA_INIT(CTipDlg)
 	m_bStartup = TRUE;

--- a/scripting/methods/methods_utilities.cpp
+++ b/scripting/methods/methods_utilities.cpp
@@ -355,14 +355,26 @@ long CMUSHclientDoc::ChangeDir(LPCTSTR Path)
     {
     // find the new working directory
 
-    _getdcwd (0, working_dir, sizeof (working_dir) - 1);
+    char strNewWorkingDirectory [_MAX_PATH];
+    if (!_getdcwd (0, strNewWorkingDirectory,
+                   sizeof (strNewWorkingDirectory) - 1))
+      {
+      int iError = errno;
+      if (_chdir (working_dir) != 0)
+        AfxThrowFileException (CFileException::genericException, errno,
+                               working_dir);
+      errno = iError;
+      return false;
+      }
 
     // make sure directory name ends in a slash
 
-    working_dir [sizeof (working_dir) - 2] = 0;
+    strNewWorkingDirectory [sizeof (strNewWorkingDirectory) - 2] = 0;
 
-    if (working_dir [strlen (working_dir) - 1] != '\\')
-      strcat (working_dir, "\\");
+    if (strNewWorkingDirectory [strlen (strNewWorkingDirectory) - 1] != '\\')
+      strcat (strNewWorkingDirectory, "\\");
+
+    strcpy (working_dir, strNewWorkingDirectory);
     
     return true;  // did it OK
     }


### PR DESCRIPTION
Check working directory reads and changes before publishing path state. Construct the tips path from the executable directory without a fixed-size concatenation buffer.

Related change set: #6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when the application cannot access or change directories, with clear file-related errors instead of continuing with invalid paths.
  * Directory changes now attempt to restore the previous location if an operation fails.
  * Improved reliability when retrieving the current working directory.
  * Tips are now loaded from the MUSHclient file’s directory, ensuring the expected tips file is found when installation and document locations differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->