### PR TITLE
Resolve notepad selections by document identity

### DIFF
--- a/MUSHclient.cpp
+++ b/MUSHclient.cpp
@@ -1984,7 +1984,7 @@ CTextDocument * pTextDoc = NULL;
   for (POSITION docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
       docPos != NULL; )
     {
-    pTextDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+    pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
     // ignore related worlds
     if (pTextDoc->m_pRelatedWorld == NULL &&

--- a/dialogs/ChooseNotepadDlg.cpp
+++ b/dialogs/ChooseNotepadDlg.cpp
@@ -25,6 +25,7 @@ CChooseNotepadDlg::CChooseNotepadDlg(CWnd* pParent /*=NULL*/)
 	//}}AFX_DATA_INIT
  m_pWorld = NULL;
  m_pTextDocument = NULL;
+ m_iWorldDocumentNumber = 0;
 
 }
 
@@ -41,16 +42,22 @@ void CChooseNotepadDlg::DoDataExchange(CDataExchange* pDX)
   if (!pDX->m_bSaveAndValidate)
     {   // loading
 
+    CMUSHclientDoc * pWorld = GetLiveWorld ();
+    if (!pWorld)
+      return;
+
+    m_NotepadDocumentNumbers.RemoveAll ();
+
     for (docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
         docPos != NULL; )
       {
       int nItem;
 
-      CTextDocument * pDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+      CTextDocument * pDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
       // ignore unrelated worlds
-      if (pDoc->m_pRelatedWorld != m_pWorld ||
-          pDoc->m_iUniqueDocumentNumber != m_pWorld->m_iUniqueDocumentNumber)
+      if (pDoc->m_pRelatedWorld != pWorld ||
+          pDoc->m_iUniqueDocumentNumber != m_iWorldDocumentNumber)
         continue;
 
       CString strTitle = pDoc->GetPathName ();
@@ -62,13 +69,53 @@ void CChooseNotepadDlg::DoDataExchange(CDataExchange* pDX)
       nItem = m_ctlNotepadList.AddString (strTitle);
 
       if (nItem != LB_ERR  && nItem != LB_ERRSPACE )
-         m_ctlNotepadList.SetItemData (nItem, (DWORD) pDoc);
+        {
+        int iDocument = m_NotepadDocumentNumbers.Add (pDoc->m_iTextDocumentNumber);
+        m_ctlNotepadList.SetItemData (nItem, (DWORD) iDocument);
+        }
 
       } // end of doing each document
 
     }   // end of loading
 
 }
+
+CMUSHclientDoc * CChooseNotepadDlg::GetLiveWorld (void) const
+  {
+  if (!m_pWorld)
+    return NULL;
+
+  for (POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition(); pos; )
+    {
+    CMUSHclientDoc * pWorld =
+      (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (pos);
+    if (pWorld == m_pWorld &&
+        pWorld->m_iUniqueDocumentNumber == m_iWorldDocumentNumber)
+      return pWorld;
+    }
+
+  return NULL;
+  }
+
+CTextDocument * CChooseNotepadDlg::GetNotepadForIndex (const int iIndex) const
+  {
+  CMUSHclientDoc * pWorld = GetLiveWorld ();
+  if (!pWorld || iIndex < 0 || iIndex >= m_NotepadDocumentNumbers.GetSize ())
+    return NULL;
+
+  __int64 iDocumentNumber = m_NotepadDocumentNumbers [iIndex];
+  for (POSITION pos = App.m_pNormalDocTemplate->GetFirstDocPosition(); pos; )
+    {
+    CTextDocument * pDoc =
+      (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc (pos);
+    if (pDoc->m_iTextDocumentNumber == iDocumentNumber &&
+        pDoc->m_pRelatedWorld == pWorld &&
+        pDoc->m_iUniqueDocumentNumber == m_iWorldDocumentNumber)
+      return pDoc;
+    }
+
+  return NULL;
+  }
 
 
 BEGIN_MESSAGE_MAP(CChooseNotepadDlg, CDialog)
@@ -90,7 +137,12 @@ int nItem = m_ctlNotepadList.GetCurSel ();
   if (nItem == LB_ERR)
     return;
 
-  m_pTextDocument = (CTextDocument *) m_ctlNotepadList.GetItemData (nItem);
+  m_pTextDocument = GetNotepadForIndex ((int) m_ctlNotepadList.GetItemData (nItem));
+  if (!m_pTextDocument)
+    {
+    m_ctlNotepadList.DeleteString (nItem);
+    return;
+    }
 
   OnOK ();
 	

--- a/dialogs/ChooseNotepadDlg.h
+++ b/dialogs/ChooseNotepadDlg.h
@@ -24,6 +24,8 @@ public:
 
   CMUSHclientDoc * m_pWorld;
   CTextDocument  * m_pTextDocument;
+  __int64 m_iWorldDocumentNumber;
+  CArray<__int64, __int64> m_NotepadDocumentNumbers;
 
 // Overrides
 	// ClassWizard generated virtual function overrides
@@ -34,6 +36,9 @@ public:
 
 // Implementation
 protected:
+
+  CMUSHclientDoc * GetLiveWorld (void) const;
+  CTextDocument * GetNotepadForIndex (const int iIndex) const;
 
 	// Generated message map functions
 	//{{AFX_MSG(CChooseNotepadDlg)

--- a/doc.cpp
+++ b/doc.cpp
@@ -5879,7 +5879,7 @@ CTextDocument * pTextDoc = NULL;
   for (POSITION docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
       docPos != NULL; )
     {
-    pTextDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+    pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
     // ignore unrelated worlds
     if (pTextDoc->m_pRelatedWorld == this &&

--- a/scripting/methods/methods_notepad.cpp
+++ b/scripting/methods/methods_notepad.cpp
@@ -34,12 +34,14 @@
 
 bool CMUSHclientDoc::SwitchToNotepad (void)
   {
+  CMUSHclientDoc * pThisDocument = this;
+  __int64 iThisDocumentNumber = m_iUniqueDocumentNumber;
   int iCount = 0;
 
   for (POSITION docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
       docPos != NULL; )
     {
-    CTextDocument * pTextDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+    CTextDocument * pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
     // ignore unrelated worlds
     if (pTextDoc->m_pRelatedWorld == this &&
@@ -52,9 +54,26 @@ bool CMUSHclientDoc::SwitchToNotepad (void)
     CChooseNotepadDlg dlg;
 
     dlg.m_pWorld = this;
+    dlg.m_iWorldDocumentNumber = iThisDocumentNumber;
 
     if (dlg.DoModal () != IDOK)
       return true;   // they gave up
+
+    bool bDocumentLive = false;
+    for (POSITION worldPos = App.m_pWorldDocTemplate->GetFirstDocPosition(); worldPos; )
+      {
+      CMUSHclientDoc * pWorld =
+        (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (worldPos);
+      if (pWorld == pThisDocument &&
+          pWorld->m_iUniqueDocumentNumber == iThisDocumentNumber)
+        {
+        bDocumentLive = true;
+        break;
+        }
+      }
+
+    if (!bDocumentLive)
+      return true;
 
     if (dlg.m_pTextDocument)  // they chose an existing one
       {
@@ -213,7 +232,7 @@ CTextDocument * pTextDoc = NULL;
   for (POSITION docPos = App.m_pNormalDocTemplate->GetFirstDocPosition();
       docPos != NULL; )
     {
-    pTextDoc = (CTextDocument *) App.m_pWorldDocTemplate->GetNextDoc(docPos);
+    pTextDoc = (CTextDocument *) App.m_pNormalDocTemplate->GetNextDoc(docPos);
 
     // ignore unrelated worlds
     if (pTextDoc->m_pRelatedWorld == this &&


### PR DESCRIPTION
Store document identities in notepad selection rows and resolve each selection against live text documents. Use the text document template when enumerating notepads.

Review base: #16. Merge that prerequisite first.

Related change set: #6.
