### PR TITLE
Create replacement input brushes before deleting old brushes

### DIFF
--- a/TextView.cpp
+++ b/TextView.cpp
@@ -186,11 +186,17 @@ void CTextView::OnInitialUpdate()
 	
   SetTheFont ();
 	
+  CBrush * pNewBrush = new CBrush (pDoc->m_backColour);
+  if (!pNewBrush->GetSafeHandle ())
+    {
+    delete pNewBrush;
+    AfxThrowResourceException ();
+    }
   if (m_backbr)
     m_backbr->DeleteObject ();
   delete m_backbr;
 
-  m_backbr = new CBrush (pDoc->m_backColour);
+  m_backbr = pNewBrush;
   m_backcolour = pDoc->m_backColour;
 
 }
@@ -761,10 +767,16 @@ CRect rect;
   // recreate background colour if necessary  
   if (m_backcolour != pDoc->m_backColour)
     {
+    CBrush * pNewBrush = new CBrush (pDoc->m_backColour);
+    if (!pNewBrush->GetSafeHandle ())
+      {
+      delete pNewBrush;
+      AfxThrowResourceException ();
+      }
     if (m_backbr)
       m_backbr->DeleteObject ();
     delete m_backbr;
-    m_backbr = new CBrush (pDoc->m_backColour);
+    m_backbr = pNewBrush;
     m_backcolour = pDoc->m_backColour;
     }
  

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -1157,10 +1157,16 @@ CRect rect;
   // recreate background colour if necessary  
   if (m_backcolour != pDoc->m_input_background_colour)
     {
+    CBrush * pNewBrush = new CBrush (pDoc->m_input_background_colour);
+    if (!pNewBrush->GetSafeHandle ())
+      {
+      delete pNewBrush;
+      AfxThrowResourceException ();
+      }
     if (m_backbr)
       m_backbr->DeleteObject ();
     delete m_backbr;
-    m_backbr = new CBrush (pDoc->m_input_background_colour);
+    m_backbr = pNewBrush;
     m_backcolour = pDoc->m_input_background_colour;
     }
 
@@ -1240,10 +1246,16 @@ void CSendView::OnInitialUpdate()
 
   m_owner_frame->FixUpSplitterBar ();
   
+  CBrush * pNewBrush = new CBrush (pDoc->m_input_background_colour);
+  if (!pNewBrush->GetSafeHandle ())
+    {
+    delete pNewBrush;
+    AfxThrowResourceException ();
+    }
   if (m_backbr)
     m_backbr->DeleteObject ();
   delete m_backbr;
-  m_backbr = new CBrush (pDoc->m_input_background_colour);
+  m_backbr = pNewBrush;
   m_backcolour = pDoc->m_input_background_colour;
 
   // if they want auto-command size, put back to 1


### PR DESCRIPTION
Keep the existing input and notepad background brushes until replacement brush creation succeeds.

Related change set: #6.
