### PR TITLE
Release the notepad buffer if locking fails

### DIFF
--- a/TextView.cpp
+++ b/TextView.cpp
@@ -698,12 +698,16 @@ bool CTextView::SetText(const char * sText)
     {
     int nLen = strlen (sText);
 
-	  LPVOID hText = LocalAlloc(LMEM_MOVEABLE, (nLen+1)*sizeof(TCHAR));
+	  HLOCAL hText = LocalAlloc(LMEM_MOVEABLE, (nLen+1)*sizeof(TCHAR));
 	  if (hText == NULL)
 		  AfxThrowMemoryException();
 
 	  LPTSTR lpszText = (LPTSTR)LocalLock(hText);
-	  ASSERT(lpszText != NULL);
+	  if (lpszText == NULL)
+      {
+      LocalFree (hText);
+      AfxThrowMemoryException ();
+      }
 
     strcpy (lpszText, sText);
 


### PR DESCRIPTION
Use the HLOCAL handle type for the replacement notepad text buffer. If LocalLock fails, free the buffer and report the memory error before the edit control receives the handle.

Related change set: #6.
