### PR TITLE
Preserve queued command order during callbacks

### DIFF
--- a/TimerWnd.cpp
+++ b/TimerWnd.cpp
@@ -18,6 +18,8 @@ CTimerWnd::CTimerWnd(CMUSHclientDoc * pDoc)
 {
   m_pDoc = pDoc;
   m_iTimer = 0;
+  m_bProcessingQueue = false;
+  m_bDrainQueue = false;
 }
 
 CTimerWnd::~CTimerWnd()
@@ -38,25 +40,83 @@ END_MESSAGE_MAP()
 
 void CTimerWnd::OnTimer(UINT nIDEvent) 
 {
+  DrainQueue (true);
+
+  if (m_iTimer && m_pDoc->m_iSpeedWalkDelay == 0)
+    {
+    KillTimer (m_iTimer);
+    m_iTimer = 0;
+    }
+}
+
+void CTimerWnd::DrainQueue (const bool bStopAfterDelayedCommand)
+{
+  if (m_bProcessingQueue)
+    {
+    if (!bStopAfterDelayedCommand)
+      m_bDrainQueue = true;
+    return;
+    }
+
   // no queued commands - don't update status line
   if (m_pDoc->m_QueuedCommandsList.IsEmpty ())
-    return;
-
-  while (!m_pDoc->m_QueuedCommandsList.IsEmpty ())
     {
-    CString strCommand = m_pDoc->m_QueuedCommandsList.RemoveHead ();
-
-    char cMessageType = strCommand [0];
-  
-    m_pDoc->DoSendMsg (strCommand.Mid (1), 
-                       toupper (cMessageType) == QUEUE_WITH_ECHO ||
-                       toupper (cMessageType) == IMMEDIATE_WITH_ECHO,
-                       cMessageType >= 'A');      // log flag
-
-    if (toupper (cMessageType) == QUEUE_WITH_ECHO ||
-        toupper (cMessageType) == QUEUE_WITHOUT_ECHO)
-        break;    // if we need to wait, don't keep pulling them out
+    m_bDrainQueue = false;
+    return;
     }
+
+  m_bProcessingQueue = true;
+  bool bStopAfterDelay = bStopAfterDelayedCommand;
+
+  try
+    {
+    while (!m_pDoc->m_QueuedCommandsList.IsEmpty ())
+      {
+      CString strCommand = m_pDoc->m_QueuedCommandsList.RemoveHead ();
+
+      unsigned char cQueueFlags = (unsigned char) strCommand [0];
+      bool bSuppressPluginSend =
+        (cQueueFlags & QUEUE_SUPPRESS_PLUGIN_SEND) != 0;
+      char cMessageType =
+        (char) (cQueueFlags & ~QUEUE_SUPPRESS_PLUGIN_SEND);
+      bool bEcho = toupper ((unsigned char) cMessageType) == QUEUE_WITH_ECHO ||
+                   toupper ((unsigned char) cMessageType) == IMMEDIATE_WITH_ECHO;
+      bool bLog = cMessageType >= 'A';
+
+      if (bSuppressPluginSend)
+        {
+        CBoolStateGuard processingGuard
+          (m_pDoc->m_bPluginProcessingSend, true);
+        m_pDoc->DoSendMsg (strCommand.Mid (1), bEcho, bLog);
+        }
+      else
+        m_pDoc->DoSendMsg (strCommand.Mid (1), bEcho, bLog);
+
+      if (m_bDrainQueue)
+        {
+        bStopAfterDelay = false;
+        m_bDrainQueue = false;
+        }
+
+      if (bStopAfterDelay &&
+          (toupper ((unsigned char) cMessageType) == QUEUE_WITH_ECHO ||
+           toupper ((unsigned char) cMessageType) == QUEUE_WITHOUT_ECHO))
+        break;    // if we need to wait, don't keep pulling them out
+      }
+    }
+  catch (...)
+    {
+    bool bDrainQueue = m_bDrainQueue || !bStopAfterDelayedCommand;
+    m_bProcessingQueue = false;
+    m_bDrainQueue = bDrainQueue;
+    if (bDrainQueue && !m_pDoc->m_QueuedCommandsList.IsEmpty () && !m_iTimer)
+      m_iTimer = SetTimer (COMMAND_QUEUE_TIMER_ID,
+                           MAX ((int) m_pDoc->m_iSpeedWalkDelay, 1), NULL);
+    throw;
+    }
+
+  m_bProcessingQueue = false;
+  m_bDrainQueue = false;
   m_pDoc->ShowQueuedCommands ();    // update status line
 }
 
@@ -82,28 +142,16 @@ void CTimerWnd::ChangeTimerRate (const int iRate)
 
   // get rid of old timer
   if (m_iTimer)
-      KillTimer (m_iTimer);
+    {
+    KillTimer (m_iTimer);
+    m_iTimer = 0;
+    }
 
   // if zero, no timer wanted
   if (iNewRate)
     m_iTimer = SetTimer(COMMAND_QUEUE_TIMER_ID, iNewRate, NULL); 
   else
-    {
-
-    // if no delay any more, send all outstanding lines
-    while (!m_pDoc->m_QueuedCommandsList.IsEmpty ())
-      {
-      CString strCommand = m_pDoc->m_QueuedCommandsList.RemoveHead ();
-  
-      char cMessageType = strCommand [0];
-     
-      m_pDoc->DoSendMsg (strCommand.Mid (1), 
-                         cMessageType == QUEUE_WITH_ECHO ||
-                         cMessageType == IMMEDIATE_WITH_ECHO,
-                         cMessageType >= 'A');  // log flag
-      }   // end of sending all lines
-
-    }
+    DrainQueue (false);
 
   }  // end of ChangeTimerRate
 

--- a/TimerWnd.cpp
+++ b/TimerWnd.cpp
@@ -20,6 +20,7 @@ CTimerWnd::CTimerWnd(CMUSHclientDoc * pDoc)
   m_iTimer = 0;
   m_bProcessingQueue = false;
   m_bDrainQueue = false;
+  m_nCommandsToDrain = 0;
 }
 
 CTimerWnd::~CTimerWnd()
@@ -51,28 +52,37 @@ void CTimerWnd::OnTimer(UINT nIDEvent)
 
 void CTimerWnd::DrainQueue (const bool bStopAfterDelayedCommand)
 {
-  if (m_bProcessingQueue)
+  if (!bStopAfterDelayedCommand)
     {
-    if (!bStopAfterDelayedCommand)
-      m_bDrainQueue = true;
-    return;
+    m_bDrainQueue = true;
+    m_nCommandsToDrain = m_pDoc->m_QueuedCommandsList.GetCount ();
     }
+
+  if (m_bProcessingQueue)
+    return;
 
   // no queued commands - don't update status line
   if (m_pDoc->m_QueuedCommandsList.IsEmpty ())
     {
     m_bDrainQueue = false;
+    m_nCommandsToDrain = 0;
     return;
     }
 
   m_bProcessingQueue = true;
-  bool bStopAfterDelay = bStopAfterDelayedCommand;
+  bool bSentDelayedCommand = false;
 
   try
     {
     while (!m_pDoc->m_QueuedCommandsList.IsEmpty ())
       {
+      // A restored rate applies after the commands covered by the flush.
+      if (!m_bDrainQueue && bSentDelayedCommand && m_nCommandsToDrain == 0)
+        break;
+
       CString strCommand = m_pDoc->m_QueuedCommandsList.RemoveHead ();
+      if (m_nCommandsToDrain > 0)
+        --m_nCommandsToDrain;
 
       unsigned char cQueueFlags = (unsigned char) strCommand [0];
       bool bSuppressPluginSend =
@@ -86,6 +96,10 @@ void CTimerWnd::DrainQueue (const bool bStopAfterDelayedCommand)
                   cMessageType == IMMEDIATE_WITH_ECHO ||
                   cMessageType == IMMEDIATE_WITHOUT_ECHO;
 
+      if (toupper ((unsigned char) cMessageType) == QUEUE_WITH_ECHO ||
+          toupper ((unsigned char) cMessageType) == QUEUE_WITHOUT_ECHO)
+        bSentDelayedCommand = true;
+
       if (bSuppressPluginSend)
         {
         CBoolStateGuard processingGuard
@@ -95,24 +109,13 @@ void CTimerWnd::DrainQueue (const bool bStopAfterDelayedCommand)
       else
         m_pDoc->DoSendMsg (strCommand.Mid (1), bEcho, bLog);
 
-      if (m_bDrainQueue)
-        {
-        bStopAfterDelay = false;
-        m_bDrainQueue = false;
-        }
-
-      if (bStopAfterDelay &&
-          (toupper ((unsigned char) cMessageType) == QUEUE_WITH_ECHO ||
-           toupper ((unsigned char) cMessageType) == QUEUE_WITHOUT_ECHO))
-        break;    // if we need to wait, don't keep pulling them out
       }
     }
   catch (...)
     {
-    bool bDrainQueue = m_bDrainQueue || !bStopAfterDelayedCommand;
     m_bProcessingQueue = false;
-    m_bDrainQueue = bDrainQueue;
-    if (bDrainQueue && !m_pDoc->m_QueuedCommandsList.IsEmpty () && !m_iTimer)
+    if ((m_bDrainQueue || m_nCommandsToDrain > 0) &&
+        !m_pDoc->m_QueuedCommandsList.IsEmpty () && !m_iTimer)
       m_iTimer = SetTimer (COMMAND_QUEUE_TIMER_ID,
                            MAX ((int) m_pDoc->m_iSpeedWalkDelay, 1), NULL);
     throw;
@@ -120,6 +123,7 @@ void CTimerWnd::DrainQueue (const bool bStopAfterDelayedCommand)
 
   m_bProcessingQueue = false;
   m_bDrainQueue = false;
+  m_nCommandsToDrain = 0;
   m_pDoc->ShowQueuedCommands ();    // update status line
 }
 
@@ -152,7 +156,10 @@ void CTimerWnd::ChangeTimerRate (const int iRate)
 
   // if zero, no timer wanted
   if (iNewRate)
-    m_iTimer = SetTimer(COMMAND_QUEUE_TIMER_ID, iNewRate, NULL); 
+    {
+    m_bDrainQueue = false;
+    m_iTimer = SetTimer(COMMAND_QUEUE_TIMER_ID, iNewRate, NULL);
+    }
   else
     DrainQueue (false);
 

--- a/TimerWnd.cpp
+++ b/TimerWnd.cpp
@@ -81,7 +81,10 @@ void CTimerWnd::DrainQueue (const bool bStopAfterDelayedCommand)
         (char) (cQueueFlags & ~QUEUE_SUPPRESS_PLUGIN_SEND);
       bool bEcho = toupper ((unsigned char) cMessageType) == QUEUE_WITH_ECHO ||
                    toupper ((unsigned char) cMessageType) == IMMEDIATE_WITH_ECHO;
-      bool bLog = cMessageType >= 'A';
+      bool bLog = cMessageType == QUEUE_WITH_ECHO ||
+                  cMessageType == QUEUE_WITHOUT_ECHO ||
+                  cMessageType == IMMEDIATE_WITH_ECHO ||
+                  cMessageType == IMMEDIATE_WITHOUT_ECHO;
 
       if (bSuppressPluginSend)
         {

--- a/TimerWnd.h
+++ b/TimerWnd.h
@@ -23,6 +23,8 @@ public:
 
   CMUSHclientDoc * m_pDoc;
   int m_iTimer;
+  bool m_bProcessingQueue;
+  bool m_bDrainQueue;
 
 // Operations
 public:
@@ -37,6 +39,7 @@ public:
 	virtual ~CTimerWnd();
 
   void ChangeTimerRate (const int iRate);
+  void DrainQueue (const bool bStopAfterDelayedCommand);
 
 	// Generated message map functions
 protected:

--- a/TimerWnd.h
+++ b/TimerWnd.h
@@ -25,6 +25,7 @@ public:
   int m_iTimer;
   bool m_bProcessingQueue;
   bool m_bDrainQueue;
+  INT_PTR m_nCommandsToDrain;
 
 // Operations
 public:

--- a/doc.cpp
+++ b/doc.cpp
@@ -1220,8 +1220,10 @@ void CMUSHclientDoc::SendMsg(CString strText,
     // it needs to be queued if queuing is requested
     // it also needs to be queued regardless if there is already something in the queue
 
-    if (m_iSpeedWalkDelay &&
-        (bQueueIt || !m_QueuedCommandsList.IsEmpty ()) )
+    bool bQueueIsDraining = m_pTimerWnd && m_pTimerWnd->m_bProcessingQueue;
+    if (bQueueIsDraining ||
+        (m_iSpeedWalkDelay &&
+         (bQueueIt || !m_QueuedCommandsList.IsEmpty ())))
       {
       CString strEchoFlag;
 
@@ -1243,7 +1245,12 @@ void CMUSHclientDoc::SendMsg(CString strText,
         strEchoFlag.MakeLower ();
 
       // queue it
-      m_QueuedCommandsList.AddTail (strEchoFlag + strLine);
+      CString strQueuedCommand = strEchoFlag + strLine;
+      if (m_bPluginProcessingSend)
+        strQueuedCommand.SetAt (0,
+          (char) ((unsigned char) strQueuedCommand [0] |
+                  QUEUE_SUPPRESS_PLUGIN_SEND));
+      m_QueuedCommandsList.AddTail (strQueuedCommand);
 
       }    // end of having a speedwalk delay
     else

--- a/doc.h
+++ b/doc.h
@@ -264,6 +264,8 @@ enum {
 #define IMMEDIATE_WITH_ECHO_NOLOG     'i'
 #define IMMEDIATE_WITHOUT_ECHO_NOLOG  'w'
 
+#define QUEUE_SUPPRESS_PLUGIN_SEND     0x80
+
 
 // reload script file options
 enum {

--- a/scripting/methods/methods_speedwalks.cpp
+++ b/scripting/methods/methods_speedwalks.cpp
@@ -356,9 +356,10 @@ short CMUSHclientDoc::GetSpeedWalkDelay()
 
 void CMUSHclientDoc::SetSpeedWalkDelay(short nNewValue) 
 {
+  // Store the rate before a synchronous flush can change it in a callback.
+  m_iSpeedWalkDelay = nNewValue;
   if (m_pTimerWnd)
     m_pTimerWnd->ChangeTimerRate (nNewValue);
-  m_iSpeedWalkDelay = nNewValue;
 }   // end of CMUSHclientDoc::SetSpeedWalkDelay
 
 

--- a/scripting/methods/methods_speedwalks.cpp
+++ b/scripting/methods/methods_speedwalks.cpp
@@ -342,6 +342,8 @@ long CMUSHclientDoc::DiscardQueue()
 long iCount = m_QueuedCommandsList.GetCount ();
      
   m_QueuedCommandsList.RemoveAll ();	
+  if (m_pTimerWnd)
+    m_pTimerWnd->m_nCommandsToDrain = 0;
   ShowQueuedCommands ();    // update status line
 
 	return iCount;
@@ -363,6 +365,8 @@ void CMUSHclientDoc::SetSpeedWalkDelay(short nNewValue)
 void CMUSHclientDoc::OnInputDiscardqueuedcommands() 
 {
   m_QueuedCommandsList.RemoveAll ();	
+  if (m_pTimerWnd)
+    m_pTimerWnd->m_nCommandsToDrain = 0;
   ShowQueuedCommands ();    // update status line
 	
 }  // end of CMUSHclientDoc::OnInputDiscardqueuedcommands


### PR DESCRIPTION
Drain queued commands without recursive dispatch. Retain echo, logging, delay, and plugin-send suppression flags when callbacks enqueue more commands or change the timer rate.

Related change set: #6.
