### PR TITLE
Handle an escape character at the end of a string

### DIFF
--- a/Utilities.cpp
+++ b/Utilities.cpp
@@ -195,6 +195,11 @@ int i;
     // look for escape sequences ...
     if (c == '\\')
       {
+      if (p [1] == 0)
+        {
+        *pNew++ = c;
+        break;
+        }
       c = *(++p);
       switch (c)
         {


### PR DESCRIPTION
Stop escape-sequence conversion safely when the input ends immediately after the escape character.

Related change set: #6.
