### PR TITLE
Copy PNG rows using their decoded widths

### DIFF
--- a/Utilities.cpp
+++ b/Utilities.cpp
@@ -3052,6 +3052,7 @@ unsigned char header [8];
   int png_transforms = PNG_TRANSFORM_STRIP_16 |    // Strip 16-bit samples to 8 bits
                        PNG_TRANSFORM_PACKING |     // Expand 1, 2 and 4-bit samples to bytes
                        PNG_TRANSFORM_EXPAND  |     // expand out to 8 bits if less
+                       PNG_TRANSFORM_GRAY_TO_RGB | // convert grayscale samples to RGB
                        PNG_TRANSFORM_BGR;          // Flip RGB to BGR, RGBA to BGRA
 
   // read the file
@@ -3090,7 +3091,21 @@ unsigned char header [8];
   hbmp = CreateDIBSection(NULL, &bmiB, DIB_RGB_COLORS, (void**) &pB, NULL, 0);
 
   if (!hbmp)
+    {
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+    fclose(fp);
     return eUnableToLoadImage;
+    }
+
+  png_size_t rowBytes = png_get_rowbytes (png_ptr, info_ptr);
+  if (rowBytes > (png_size_t) bpl)
+    {
+    DeleteObject (hbmp);
+    hbmp = NULL;
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+    fclose(fp);
+    return eUnableToLoadImage;
+    }
 
   long row;
   unsigned char * p = pB;
@@ -3099,7 +3114,10 @@ unsigned char header [8];
 
   png_uint_32 iHeight = png_get_image_height (png_ptr, info_ptr);
   for (row = 0; row < iHeight; row++, p += bpl)
-     memcpy (p, row_pointers [iHeight - row - 1], bpl);
+    {
+    memset (p, 0, bpl);
+    memcpy (p, row_pointers [iHeight - row - 1], rowBytes);
+    }
 
   // done with data
   png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
@@ -3201,6 +3219,8 @@ long LoadPngMemory (unsigned char * Buffer, const size_t Length, HBITMAP & hbmp,
 
   int png_transforms = PNG_TRANSFORM_STRIP_16 |    // Strip 16-bit samples to 8 bits
                        PNG_TRANSFORM_PACKING |     // Expand 1, 2 and 4-bit samples to bytes
+                       PNG_TRANSFORM_EXPAND |      // expand palettes and low-bit samples
+                       PNG_TRANSFORM_GRAY_TO_RGB | // convert grayscale samples to RGB
                        PNG_TRANSFORM_BGR;          // Flip RGB to BGR, RGBA to BGRA
 
 
@@ -3243,7 +3263,19 @@ long LoadPngMemory (unsigned char * Buffer, const size_t Length, HBITMAP & hbmp,
   hbmp = CreateDIBSection(NULL, &bmiB, DIB_RGB_COLORS, (void**) &pB, NULL, 0);
 
   if (!hbmp)
+    {
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
     return eUnableToLoadImage;
+    }
+
+  png_size_t rowBytes = png_get_rowbytes (png_ptr, info_ptr);
+  if (rowBytes > (png_size_t) bpl)
+    {
+    DeleteObject (hbmp);
+    hbmp = NULL;
+    png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
+    return eUnableToLoadImage;
+    }
 
   long row;
   unsigned char * p = pB;
@@ -3251,7 +3283,10 @@ long LoadPngMemory (unsigned char * Buffer, const size_t Length, HBITMAP & hbmp,
   // have to reverse row order
   png_uint_32 iHeight = png_get_image_height (png_ptr, info_ptr);
   for (row = 0; row < iHeight; row++, p += bpl)
-     memcpy (p, row_pointers [iHeight - row - 1], bpl);
+    {
+    memset (p, 0, bpl);
+    memcpy (p, row_pointers [iHeight - row - 1], rowBytes);
+    }
 
   // done with data
   png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);


### PR DESCRIPTION
Convert grayscale and palette PNG data to RGB before copying rows. Copy only the decoded row width, clear bitmap padding, reject rows that exceed the destination width, and release decoder resources when bitmap creation fails.

Related change set: #6.
