### PR TITLE
Keep the SSL preference checkbox wrapper alive

### DIFF
--- a/dialogs/world_prefs/prefspropertypages.cpp
+++ b/dialogs/world_prefs/prefspropertypages.cpp
@@ -215,13 +215,13 @@ BOOL CPrefsP1::OnInitDialog()
     rcSSL.right = rcSSL.left + 200;
     rcSSL.bottom = rcSSL.top + (rcSave.bottom - rcSave.top);
 
-    CButton * pCheck = new CButton;
-    pCheck->Create ("Use SSL/TLS for this connection",
-                    WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
-                    rcSSL, this, IDC_USE_SSL);
-    pCheck->SetFont (GetFont ());
+    if (!m_ctlUseSSL.Create ("Use SSL/TLS for this connection",
+                             WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
+                             rcSSL, this, IDC_USE_SSL))
+      AfxThrowResourceException ();
+    m_ctlUseSSL.SetFont (GetFont ());
     if (m_bUseSSL)
-      pCheck->SetCheck (BST_CHECKED);
+      m_ctlUseSSL.SetCheck (BST_CHECKED);
     }
 
   return CPropertyPage::OnInitDialog();

--- a/dialogs/world_prefs/prefspropertypages.h
+++ b/dialogs/world_prefs/prefspropertypages.h
@@ -25,6 +25,7 @@ public:
 
 	CStaticLink	m_MudListLink;
 	CStaticLink	m_BugReportLink;
+  CButton m_ctlUseSSL;
 
   CString m_strProxyUserName;
   CString m_strProxyPassword;


### PR DESCRIPTION
Store the SSL checkbox wrapper on the preferences page so its lifetime matches the control instead of ending during page initialization.

Related change set: #6.
