### PR TITLE
Preserve world socket state during receive callbacks

### DIFF
--- a/doc.cpp
+++ b/doc.cpp
@@ -1059,13 +1059,11 @@ CString str;
               (const char *) m_mush_name, m_port);
   Frame.SetStatusMessageNow (str);
 
-// get rid of any earlier socket
+// create the replacement before releasing the current socket
 
+  CWorldSocket * pNewSocket = new CWorldSocket(this);
   delete m_pSocket;
-
-// now create a new one 
-
-	m_pSocket = new CWorldSocket(this);
+  m_pSocket = pNewSocket;
 
 	if (!m_pSocket->Create(0,
                          SOCK_STREAM,
@@ -1534,11 +1532,12 @@ int count;
        // See: http://www.gammon.com.au/forum/?id=11160 
        if (iCompressResult == Z_BUF_ERROR)
          {
-         m_nCompressionOutputBufferSize += COMPRESS_BUFFER_LENGTH;
-         m_zCompress.avail_out += COMPRESS_BUFFER_LENGTH;
-         m_CompressOutput = (Bytef *) realloc (m_CompressOutput, m_nCompressionOutputBufferSize);
+         const int nNewBufferSize =
+           m_nCompressionOutputBufferSize + COMPRESS_BUFFER_LENGTH;
+         Bytef * pNewCompressOutput =
+           (Bytef *) realloc (m_CompressOutput, nNewBufferSize);
 
-         if (m_CompressOutput == NULL)
+         if (pNewCompressOutput == NULL)
            {
             OnConnectionDisconnect ();    // close the world
             free (m_CompressInput);       // may as well get rid of compression input as well
@@ -1546,6 +1545,13 @@ int count;
             TMessageBox ("Insufficient memory to decompress MCCP text.", MB_ICONEXCLAMATION);
             return;
            }  // end of cannot get more memory
+
+         const uInt nBytesWritten =
+           m_nCompressionOutputBufferSize - m_zCompress.avail_out;
+         m_CompressOutput = pNewCompressOutput;
+         m_nCompressionOutputBufferSize = nNewBufferSize;
+         m_zCompress.next_out = m_CompressOutput + nBytesWritten;
+         m_zCompress.avail_out += COMPRESS_BUFFER_LENGTH;
          }  // end of Z_BUF_ERROR
 
       } while (iCompressResult == Z_BUF_ERROR);

--- a/mainfrm.cpp
+++ b/mainfrm.cpp
@@ -821,6 +821,7 @@ void CMainFrame::OnTimer(UINT nIDEvent)
 
   CheckTimerFallback ();
 	CMDIFrameWnd::OnTimer(nIDEvent);
+  CWorldSocket::CheckBufferedReads ();
   }  // end of CMainFrame::OnTimer
 
 void CMainFrame::OnUpdateStatuslineFreeze(CCmdUI* pCmdUI) 

--- a/tests/check_worldsock_receive.py
+++ b/tests/check_worldsock_receive.py
@@ -15,12 +15,18 @@ def main():
     repo = pathlib.Path(__file__).resolve().parents[1]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source", type=pathlib.Path, default=repo / "worldsock.cpp")
+    parser.add_argument("--output", type=pathlib.Path)
     args = parser.parse_args()
     source = args.source.read_text()
-    callback = source[source.index("CWorldSocket::CWorldSocket"):
+    callback = source[source.index("static bool IsLiveWorldSocket") if "static bool IsLiveWorldSocket" in source else source.index("CWorldSocket::CWorldSocket"):
                       source.index("void CWorldSocket::OnSend")]
     with tempfile.TemporaryDirectory(prefix="worldsock-receive-") as work:
-        work = pathlib.Path(work)
+        work = args.output or pathlib.Path(work)
+        work.mkdir(parents=True, exist_ok=True)
+        frame = (repo / "mainfrm.cpp").read_text()
+        first = frame.index("void CMainFrame::OnTimer(")
+        last = frame.index("void CMainFrame::OnUpdateStatuslineFreeze", first)
+        (work / "worldsock_timer.inc").write_text(frame[first:last])
         (work / "worldsock_receive.inc").write_text(callback)
         binary = work / "worldsock_receive"
         subprocess.run([

--- a/tests/check_worldsock_receive.py
+++ b/tests/check_worldsock_receive.py
@@ -1,0 +1,36 @@
+"""Compile the actual receive callback with an MFC/Winsock contract model.
+
+Run with Python 3 and clang++. This checks callback control flow and buffer
+ownership. It does not replace a native Windows MFC message-loop test.
+Pass --source to check another revision of worldsock.cpp.
+"""
+
+import argparse
+import pathlib
+import subprocess
+import tempfile
+
+
+def main():
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=pathlib.Path, default=repo / "worldsock.cpp")
+    args = parser.parse_args()
+    source = args.source.read_text()
+    callback = source[source.index("CWorldSocket::CWorldSocket"):
+                      source.index("void CWorldSocket::OnSend")]
+    with tempfile.TemporaryDirectory(prefix="worldsock-receive-") as work:
+        work = pathlib.Path(work)
+        (work / "worldsock_receive.inc").write_text(callback)
+        binary = work / "worldsock_receive"
+        subprocess.run([
+            "clang++", "-std=c++17", "-Wall", "-Wextra", "-Werror",
+            "-fsanitize=address,undefined", "-fno-omit-frame-pointer",
+            "-I", str(repo), "-I", str(work),
+            str(repo / "tests/worldsock_receive.cpp"), "-o", str(binary),
+        ], check=True)
+        subprocess.run([str(binary)], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/check_worldsock_tls.py
+++ b/tests/check_worldsock_tls.py
@@ -1,0 +1,72 @@
+"""Check buffered TLS recovery with real OpenSSL memory BIOs.
+
+Requires Python 3, clang++, and OpenSSL development libraries. No network socket
+is opened. MFC and Winsock event delivery are substitutes. The constructor,
+receive recovery, timer dispatch and socket declaration come from production.
+Use --openssl-prefix for a library installation without pkg-config.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+
+
+def run(source, output, flags):
+    tests = Path(__file__).resolve().parent
+    socket = (source / 'worldsock.cpp').read_text()
+    first = socket.index('static bool IsLiveWorldSocket') if 'static bool IsLiveWorldSocket' in socket else socket.index('CWorldSocket::CWorldSocket')
+    wrapper = socket[first:socket.index('void CWorldSocket::OnSend', first)]
+    frame = (source / 'mainfrm.cpp').read_text()
+    first = frame.index('void CMainFrame::OnTimer(')
+    timer = frame[first:frame.index('void CMainFrame::OnUpdateStatuslineFreeze', first)]
+    (output / 'worldsock_receive.inc').write_text(wrapper)
+    (output / 'worldsock_timer.inc').write_text(timer)
+    cpp = output / 'worldsock_tls.cpp'
+    cpp.write_text((tests / 'worldsock_tls_prefix.cpp').read_text() +
+                   (tests / 'worldsock_tls_main.cpp').read_text())
+    results = []
+    for throws in [1, 0]:
+        for nested in [1, 0]:
+            binary = output / ('worldsock_tls_' + str(throws) + '_' + str(nested))
+            command = ['clang++', '-std=c++17', '-Wall', '-Wextra', '-Werror',
+                       '-O1', '-g', '-fsanitize=address,undefined',
+                       '-fno-omit-frame-pointer', '-I', str(source), '-I', str(output),
+                       '-DTHROW_AFTER_CALLBACK=' + str(throws),
+                       '-DNESTED_READ=' + str(nested), str(cpp), '-o', str(binary)] + flags
+            subprocess.run(command, check=True)
+            result = subprocess.run([str(binary)], text=True, capture_output=True)
+            binary.with_suffix('.log').write_text(result.stdout + result.stderr)
+            print(result.stdout + result.stderr, end='')
+            result.check_returncode()
+            results.append({'throws': throws, 'nested_read': nested,
+                            'output': result.stdout, 'status': 'pass'})
+    (output / 'result.json').write_text(json.dumps({
+        'source': str(source),
+        'wrapper_sha256': hashlib.sha256(wrapper.encode()).hexdigest(),
+        'timer_sha256': hashlib.sha256(timer.encode()).hexdigest(),
+        'checks': results,
+        'limitations': 'OpenSSL buffering is real. MFC and Windows event delivery are substitutes.'
+    }, indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source', type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--output', type=Path)
+    parser.add_argument('--openssl-prefix', type=Path)
+    args = parser.parse_args()
+    if args.openssl_prefix:
+        flags = ['-I' + str(args.openssl_prefix / 'include'),
+                 '-L' + str(args.openssl_prefix / 'lib'), '-lssl', '-lcrypto']
+    else:
+        flags = shlex.split(subprocess.check_output(
+            ['pkg-config', '--cflags', '--libs', 'openssl'], text=True))
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=True)
+        run(args.source, args.output, flags)
+    else:
+        with tempfile.TemporaryDirectory(prefix='worldsock-tls-') as temp:
+            run(args.source, Path(temp), flags)

--- a/tests/worldsock_receive.cpp
+++ b/tests/worldsock_receive.cpp
@@ -1,0 +1,257 @@
+// Model only the facilities used by the actual constructor and OnReceive.
+// Winsock rearms FD_READ after recv, including MSG_PEEK and failed calls:
+// https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsaasyncselect
+#include <cassert>
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using std::string;
+using POSITION = unsigned;
+using SOCKET = int;
+const SOCKET INVALID_SOCKET = -1;
+const int SOCKET_ERROR = -1, WSAEWOULDBLOCK = 10035, WSAECONNRESET = 10054;
+const int MSG_PEEK = 2, MB_OK = 0, MB_ICONERROR = 16, MB_TASKMODAL = 8192;
+const int FD_READ = 1, FD_WRITE = 2, FD_OOB = 4;
+const int FD_ACCEPT = 8, FD_CONNECT = 16, FD_CLOSE = 32;
+const int allEvents = FD_READ | FD_WRITE | FD_OOB | FD_ACCEPT | FD_CONNECT | FD_CLOSE;
+int lastError = 0;
+string report;
+std::function<void()> onReport;
+int MessageBoxA(void *, const char *text, const char *, int flags) {
+  assert(flags == (MB_OK | MB_ICONERROR | MB_TASKMODAL));
+  report = text;
+  if (onReport) onReport();
+  return 1;
+}
+
+struct CAsyncSocket {
+  virtual ~CAsyncSocket() = default;
+  SOCKET m_hSocket = 42;
+  int eventMask = allEvents, peekCalls = 0, error = 0;
+  int closeEvents = 0, baseCalls = 0, baseError = 0;
+  bool enabled = false, queued = false, eof = false;
+  string unread;
+  void notify() {
+    if (enabled && !unread.empty() && (eventMask & FD_READ)) {
+      queued = true;
+      enabled = false;
+    }
+  }
+  void arrive(const string &data) { unread += data; notify(); }
+  string read() {
+    string data = unread;
+    unread.clear();
+    enabled = true;
+    if (eof && (eventMask & FD_CLOSE)) ++closeEvents;
+    return data;
+  }
+  int Receive(void *buffer, int length, int flags) {
+    assert(m_hSocket != INVALID_SOCKET && length == 1 && flags == MSG_PEEK);
+    ++peekCalls;
+    enabled = true;
+    notify();
+    if (error) { lastError = error; return SOCKET_ERROR; }
+    if (!unread.empty()) { *static_cast<char *>(buffer) = unread[0]; return 1; }
+    if (eof) return 0;
+    lastError = WSAEWOULDBLOCK;
+    return SOCKET_ERROR;
+  }
+  static int GetLastError() { return lastError; }
+  void OnReceive(int errorCode) { ++baseCalls; baseError = errorCode; }
+};
+#define DECLARE_DYNAMIC(type)
+#include "worldsock.h"
+
+struct SSL { int pending = 0; };
+int SSL_pending(SSL *ssl) { return ssl->pending; }
+class CMUSHclientDoc {
+public:
+  CWorldSocket *m_pSocket = nullptr;
+  SSL *m_pSSL = nullptr;
+  bool m_bSSL_Connected = false;
+  std::function<void()> receive;
+  void ReceiveMsg() { receive(); }
+};
+struct DocTemplate {
+  std::vector<CMUSHclientDoc *> docs;
+  POSITION GetFirstDocPosition() { return docs.empty() ? 0 : 1; }
+  CMUSHclientDoc *GetNextDoc(POSITION &pos) {
+    auto *doc = docs.at(pos - 1);
+    pos = pos < docs.size() ? pos + 1 : 0;
+    return doc;
+  }
+} docTemplate;
+struct { DocTemplate *m_pWorldDocTemplate = &docTemplate; } App;
+#include "worldsock_receive.inc"
+// Supply the other vtable entries; these callbacks are not under test.
+void CWorldSocket::OnSend(int) {}
+void CWorldSocket::OnClose(int) {}
+void CWorldSocket::OnConnect(int) {}
+
+struct ReceiveFailure {};
+struct Fixture {
+  CMUSHclientDoc doc;
+  CWorldSocket socket{&doc};
+  ReceiveFailure failure;
+  Fixture() {
+    doc.m_pSocket = &socket;
+    docTemplate.docs = {&doc};
+    report.clear();
+    onReport = nullptr;
+  }
+  void fail() {
+    bool caught = false;
+    try { socket.OnReceive(0); }
+    catch (ReceiveFailure *value) { assert(value == &failure); caught = true; }
+    assert(caught); // Preserve the exact pointer, as for an MFC exception.
+  }
+  void dispatch() {
+    assert(socket.queued);
+    socket.queued = false;
+    socket.OnReceive(0);
+  }
+};
+
+int main() {
+  {
+    Fixture f;
+    int calls = 0, depth = 0;
+    f.doc.receive = [&] {
+      assert(++depth == 1);
+      if (++calls == 1) for (int i = 0; i < 3; ++i) f.socket.OnReceive(0);
+      --depth;
+    };
+    f.socket.OnReceive(7);
+    assert(calls == 2 && f.socket.peekCalls == 0);
+    assert(f.socket.baseCalls == 1 && f.socket.baseError == 7);
+    assert(!f.socket.m_bInReceive && !f.socket.m_bReceivePending);
+    SSL ssl{3};
+    f.doc.m_pSSL = &ssl; f.doc.m_bSSL_Connected = true;
+    calls = 0;
+    f.doc.receive = [&] { ++calls; --ssl.pending; };
+    f.socket.OnReceive(0);
+    assert(calls == 3 && ssl.pending == 0 && f.socket.peekCalls == 0);
+  }
+  std::cout << "PASS: nested callbacks stay serial; TLS data drains\n";
+
+  for (int mask : {allEvents, FD_READ | FD_WRITE | FD_CONNECT | FD_CLOSE}) {
+    Fixture f;
+    f.socket.eventMask = mask;
+    f.socket.unread = "first";
+    string output;
+    int calls = 0;
+    f.doc.receive = [&] {
+      ++calls;
+      output += f.socket.read();
+      if (calls == 1) {
+        f.socket.arrive("second");
+        f.dispatch(); // A modal loop consumes FD_READ without a recv.
+        throw &f.failure;
+      }
+    };
+    f.fail();
+    assert(calls == 1 && output == "first"); // No synchronous retry.
+    assert(f.socket.unread == "second" && f.socket.queued);
+    assert(f.socket.peekCalls == 1 && f.socket.eventMask == mask);
+    assert(!f.socket.m_bInReceive && !f.socket.m_bReceivePending && report.empty());
+    f.dispatch();
+    assert(calls == 2 && output == "firstsecond");
+    f.socket.arrive("third");
+    f.dispatch();
+    assert(output == "firstsecondthird" && f.socket.enabled);
+    assert(f.socket.closeEvents == 0 && f.socket.baseCalls == 2);
+  }
+  std::cout << "PASS: exception preserves queued bytes and later packets for both masks\n";
+
+  {
+    Fixture f;
+    SSL ssl{0};
+    f.doc.m_pSSL = &ssl; f.doc.m_bSSL_Connected = true;
+    f.socket.unread = "first";
+    int calls = 0;
+    string output;
+    f.doc.receive = [&] {
+      ++calls;
+      if (ssl.pending) { --ssl.pending; output += "decrypted"; return; }
+      output += f.socket.read();
+      if (calls == 1) {
+        f.socket.arrive("second");
+        f.dispatch();
+        throw &f.failure;
+      }
+      ssl.pending = 2;
+    };
+    f.fail();
+    assert(calls == 1 && f.socket.queued);
+    f.dispatch();
+    assert(calls == 4 && ssl.pending == 0);
+    assert(output == "firstseconddecrypteddecrypted");
+  }
+  std::cout << "PASS: deferred TLS callback resumes normal decrypted-data draining\n";
+
+  for (int mode = 0; mode < 5; ++mode) {
+    Fixture f;
+    // No deferred event; stale event; EOF; socket error; disabled events.
+    if (mode == 2) { f.socket.eof = true; f.socket.closeEvents = 1; }
+    if (mode == 3) f.socket.error = WSAECONNRESET;
+    if (mode == 4) { f.socket.eventMask = 0; f.socket.unread = "retained"; }
+    f.doc.receive = [&] {
+      if (mode) f.socket.OnReceive(0);
+      throw &f.failure;
+    };
+    f.fail();
+    assert(f.socket.peekCalls == (mode ? 1 : 0) && !f.socket.queued);
+    assert(f.socket.closeEvents == (mode == 2 ? 1 : 0));
+    assert(!f.socket.m_bInReceive && !f.socket.m_bReceivePending);
+    if (mode == 3) assert(report.find("10054") != string::npos);
+    else assert(report.empty());
+    if (mode == 1) {
+      f.socket.arrive("later");
+      f.doc.receive = [&] { assert(f.socket.read() == "later"); };
+      f.dispatch();
+    }
+    if (mode == 4) assert(f.socket.eventMask == 0 && f.socket.unread == "retained");
+  }
+  std::cout << "PASS: no pending event, would-block, EOF, visible error, disabled mask\n";
+
+  for (int mode = 0; mode < 4; ++mode) {
+    Fixture f;
+    CWorldSocket replacement{&f.doc};
+    f.doc.receive = [&] {
+      f.socket.OnReceive(0);
+      if (mode == 0) f.doc.m_pSocket = &replacement;
+      if (mode == 1) docTemplate.docs.clear();
+      if (mode == 2) f.socket.m_hSocket = INVALID_SOCKET;
+      if (mode == 3) f.socket.m_hSocket = 99;
+      throw &f.failure;
+    };
+    f.fail();
+    assert(f.socket.peekCalls == 0 && replacement.peekCalls == 0);
+    assert(!replacement.m_bInReceive && !replacement.m_bReceivePending);
+  }
+  std::cout << "PASS: replaced socket, removed document, closed or changed handle\n";
+
+  for (bool deleteDuringReport : {false, true}) {
+    Fixture f;
+    auto socket = std::make_unique<CWorldSocket>(&f.doc);
+    f.doc.m_pSocket = socket.get();
+    socket->error = WSAECONNRESET;
+    auto removeSocket = [&] { f.doc.m_pSocket = nullptr; socket.reset(); };
+    if (deleteDuringReport) onReport = removeSocket;
+    f.doc.receive = [&] {
+      socket->OnReceive(0);
+      if (!deleteDuringReport) removeSocket();
+      throw &f.failure;
+    };
+    bool caught = false;
+    try { socket->OnReceive(0); }
+    catch (ReceiveFailure *value) { assert(value == &f.failure); caught = true; }
+    assert(caught && !socket);
+    onReport = nullptr;
+  }
+  std::cout << "PASS: socket deletion before catch and during error report\n";
+}

--- a/tests/worldsock_receive.cpp
+++ b/tests/worldsock_receive.cpp
@@ -10,6 +10,8 @@
 #include <vector>
 
 using std::string;
+using __int64 = long long;
+using UINT = unsigned;
 using POSITION = unsigned;
 using SOCKET = int;
 const SOCKET INVALID_SOCKET = -1;
@@ -66,15 +68,17 @@ struct CAsyncSocket {
 #define DECLARE_DYNAMIC(type)
 #include "worldsock.h"
 
-struct SSL { int pending = 0; };
+struct ssl_st { int pending = 0; };
+using SSL = ssl_st;
 int SSL_pending(SSL *ssl) { return ssl->pending; }
 class CMUSHclientDoc {
 public:
+  __int64 m_iUniqueDocumentNumber = 101;
   CWorldSocket *m_pSocket = nullptr;
   SSL *m_pSSL = nullptr;
   bool m_bSSL_Connected = false;
   std::function<void()> receive;
-  void ReceiveMsg() { receive(); }
+  void ReceiveMsg() { auto callback = receive; callback(); }
 };
 struct DocTemplate {
   std::vector<CMUSHclientDoc *> docs;
@@ -85,8 +89,20 @@ struct DocTemplate {
     return doc;
   }
 } docTemplate;
-struct { DocTemplate *m_pWorldDocTemplate = &docTemplate; } App;
+struct {
+  DocTemplate *m_pWorldDocTemplate = &docTemplate;
+  __int64 nextNumber = 1;
+  __int64 GetUniqueNumber() { return nextNumber++; }
+} App;
 #include "worldsock_receive.inc"
+struct CMDIFrameWnd { int baseTimers = 0; void OnTimer(UINT) { ++baseTimers; } };
+struct CMainFrame : CMDIFrameWnd {
+  int fallbacks = 0;
+  std::function<void()> fallback;
+  void CheckTimerFallback() { ++fallbacks; if (fallback) fallback(); }
+  void OnTimer(UINT);
+};
+#include "worldsock_timer.inc"
 // Supply the other vtable entries; these callbacks are not under test.
 void CWorldSocket::OnSend(int) {}
 void CWorldSocket::OnClose(int) {}
@@ -115,6 +131,8 @@ struct Fixture {
     socket.OnReceive(0);
   }
 };
+
+static void bufferedReadCases();
 
 int main() {
   {
@@ -254,4 +272,211 @@ int main() {
     onReport = nullptr;
   }
   std::cout << "PASS: socket deletion before catch and during error report\n";
+  bufferedReadCases();
+}
+
+static void bufferedReadCases() {
+  for (bool nested : {false, true}) {
+    Fixture f; CMainFrame frame; SSL ssl{7};
+    f.doc.m_pSSL = &ssl; f.doc.m_bSSL_Connected = true;
+    int calls = 0, depth = 0;
+    f.doc.receive = [&] {
+      assert(++depth == 1); ++calls;
+      if (calls == 1) {
+        if (nested) f.socket.OnReceive(0);
+        --depth; throw &f.failure;
+      }
+      frame.OnTimer(1); // A modal turn inside the retry must not recurse.
+      assert(f.socket.m_bInReceive);
+      ssl.pending = 0; --depth;
+    };
+    f.fail();
+    assert(calls == 1 && f.socket.m_bBufferedReadPending);
+    assert(!f.socket.queued && f.socket.peekCalls == int(nested));
+    f.socket.m_bInReceive = true;
+    frame.OnTimer(1);
+    assert(calls == 1 && f.socket.m_bBufferedReadPending);
+    f.socket.m_bInReceive = false;
+    frame.OnTimer(1);
+    assert(calls == 2 && ssl.pending == 0 && !f.socket.m_bBufferedReadPending);
+    assert(frame.fallbacks == 3 && frame.baseTimers == 3);
+    frame.OnTimer(1); assert(calls == 2);
+  }
+  std::cout << "PASS: buffered TLS retries after unwind, including no nested event; timer receive stays serial\n";
+
+  {
+    Fixture f; CMainFrame frame; SSL ssl{2}; int calls = 0;
+    f.doc.m_pSSL = &ssl; f.doc.m_bSSL_Connected = true;
+    f.doc.receive = [&] { ++calls; throw &f.failure; };
+    f.fail();
+    bool caught = false;
+    try { frame.OnTimer(1); } catch (ReceiveFailure *e) { assert(e == &f.failure); caught = true; }
+    assert(caught && calls == 2 && f.socket.m_bBufferedReadPending);
+    assert(frame.fallbacks == 1 && frame.baseTimers == 1);
+    f.doc.receive = [&] { ++calls; ssl.pending = 0; };
+    // A transport event can consume the retry first. The timer must not repeat it.
+    f.socket.OnReceive(0); frame.OnTimer(1);
+    assert(calls == 3 && !f.socket.m_bBufferedReadPending);
+  }
+  std::cout << "PASS: retry exceptions propagate unchanged and later FD_READ consumes the pending retry\n";
+
+
+  {
+    CMUSHclientDoc first, next;
+    next.m_iUniqueDocumentNumber = 202;
+    CWorldSocket a(&first), b(&next);
+    CMainFrame frame;
+    SSL sa{1}, sb{1};
+    ReceiveFailure failure;
+    first.m_pSocket = &a; next.m_pSocket = &b;
+    first.m_pSSL = &sa; next.m_pSSL = &sb;
+    first.m_bSSL_Connected = next.m_bSSL_Connected = true;
+    docTemplate.docs = {&first, &next};
+    first.receive = next.receive = [&] { throw &failure; };
+    for (auto *socket : {&a, &b}) {
+      bool caught = false;
+      try { socket->OnReceive(0); }
+      catch (ReceiveFailure *e) { assert(e == &failure); caught = true; }
+      assert(caught);
+    }
+    int firstCalls = 0, nextCalls = 0;
+    first.receive = [&] { ++firstCalls; sa.pending = 0; };
+    next.receive = [&] { ++nextCalls; sb.pending = 0; };
+    frame.OnTimer(1);
+    assert(firstCalls == 1 && nextCalls == 0 && b.m_bBufferedReadPending);
+    frame.OnTimer(1);
+    assert(firstCalls == 1 && nextCalls == 1 && !b.m_bBufferedReadPending);
+  }
+  std::cout << "PASS: separate timer entries resume separate pending worlds\n";
+
+  for (bool replace : {false, true}) {
+    Fixture f;
+    SSL ssl{2}, replacement{2};
+    int calls = 0;
+    if (replace) { f.doc.m_pSSL = &ssl; f.doc.m_bSSL_Connected = true; }
+    f.doc.receive = [&] {
+      ++calls;
+      if (calls == 1) {
+        // A proxy response can create TLS; an established session can be replaced.
+        f.doc.m_pSSL = replace ? &replacement : &ssl;
+        f.doc.m_bSSL_Connected = true;
+      } else {
+        --ssl.pending;
+      }
+    };
+    f.socket.OnReceive(0);
+    assert(calls == (replace ? 1 : 3));
+    assert(replacement.pending == 2 && !f.socket.m_bInReceive);
+  }
+  std::cout << "PASS: proxy TLS creation drains normally; replaced sessions stop the old receive\n";
+
+  for (int mode = 0; mode < 9; ++mode) {
+    Fixture f; CMainFrame frame; SSL ssl{2}, replacementSSL{2};
+    CWorldSocket replacement{&f.doc};
+    f.doc.m_pSSL = &ssl; f.doc.m_bSSL_Connected = true;
+    int calls = 0;
+    f.doc.receive = [&] { ++calls; throw &f.failure; };
+    f.fail(); assert(f.socket.m_bBufferedReadPending);
+    if (mode == 0) f.doc.m_pSSL = &replacementSSL;
+    if (mode == 1) f.doc.m_bSSL_Connected = false;
+    if (mode == 2) f.doc.m_pSSL = nullptr;
+    if (mode == 3) f.socket.m_hSocket = 99;
+    if (mode == 4) f.socket.m_hSocket = INVALID_SOCKET;
+    if (mode == 5) ++f.doc.m_iUniqueDocumentNumber;
+    if (mode == 6) f.doc.m_pSocket = &replacement;
+    if (mode == 7) docTemplate.docs.clear();
+    if (mode == 8) ssl.pending = 0;
+    frame.OnTimer(1);
+    assert(calls == 1 && !replacement.m_bBufferedReadPending);
+    if (mode != 6 && mode != 7) assert(!f.socket.m_bBufferedReadPending);
+  }
+  std::cout << "PASS: timer rejects changed TLS session, state, handle, document, socket and drained input\n";
+
+  for (int mode = 0; mode < 5; ++mode) {
+    Fixture f; CMainFrame frame; SSL ssl{2}, replacementSSL{2};
+    auto socket = std::make_unique<CWorldSocket>(&f.doc);
+    f.doc.m_pSocket = socket.get(); f.doc.m_pSSL = &ssl; f.doc.m_bSSL_Connected = true;
+    socket->error = WSAECONNRESET;
+    int calls = 0;
+    f.doc.receive = [&] { ++calls; socket->OnReceive(0); throw &f.failure; };
+    onReport = [&] {
+      assert(!socket->m_bBufferedReadPending);
+      frame.OnTimer(1); assert(calls == 1); // Original exception is still in catch.
+      if (mode == 1) f.doc.m_pSSL = &replacementSSL;
+      if (mode == 2) { f.doc.m_pSocket = nullptr; socket.reset(); }
+      if (mode == 3) ++f.doc.m_iUniqueDocumentNumber;
+      if (mode == 4) socket->m_hSocket = 99;
+    };
+    bool caught = false;
+    try { socket->OnReceive(0); } catch (ReceiveFailure *e) { assert(e == &f.failure); caught = true; }
+    assert(caught && calls == 1 && report.find("10054") != string::npos);
+    onReport = nullptr;
+    if (socket) assert(socket->m_bBufferedReadPending == (mode == 0));
+    f.doc.receive = [&] { ++calls; ssl.pending = 0; };
+    frame.OnTimer(1); assert(calls == (mode == 0 ? 2 : 1));
+    f.doc.m_pSocket = nullptr;
+  }
+  std::cout << "PASS: error dialog cannot run the retry before unwind; catch rechecks all live identities\n";
+
+  for (bool fail : {false, true}) {
+    CMainFrame frame; auto doc = std::make_unique<CMUSHclientDoc>();
+    auto socket = std::make_unique<CWorldSocket>(doc.get());
+    SSL ssl{2}; ReceiveFailure failure;
+    doc->m_pSSL = &ssl; doc->m_bSSL_Connected = true; doc->m_pSocket = socket.get();
+    docTemplate.docs = {doc.get()};
+    doc->receive = [&] { docTemplate.docs.clear(); socket.reset(); doc.reset(); if (fail) throw &failure; };
+    bool caught = false;
+    try { socket->OnReceive(0); } catch (ReceiveFailure *e) { assert(e == &failure); caught = true; }
+    assert(caught == fail && !doc && !socket);
+    frame.OnTimer(1);
+  }
+  std::cout << "PASS: successful and throwing callbacks can delete the receiving document and socket\n";
+
+  for (bool fail : {false, true}) {
+    CMainFrame frame; auto first = std::make_unique<CMUSHclientDoc>();
+    auto next = std::make_unique<CMUSHclientDoc>();
+    next->m_iUniqueDocumentNumber = 202;
+    auto a = std::make_unique<CWorldSocket>(first.get());
+    auto b = std::make_unique<CWorldSocket>(next.get());
+    SSL sa{2}, sb{2}; ReceiveFailure failure;
+    first->m_pSocket=a.get(); next->m_pSocket=b.get();
+    first->m_pSSL=&sa; next->m_pSSL=&sb;
+    first->m_bSSL_Connected=next->m_bSSL_Connected=true;
+    docTemplate.docs={first.get(),next.get()};
+    first->receive=next->receive=[&] { throw &failure; };
+    for (auto *s : {a.get(),b.get()}) {
+      bool caught=false;try{s->OnReceive(0);}catch(ReceiveFailure *e){assert(e==&failure);caught=true;}assert(caught);
+    }
+    int calls=0;
+    next->receive=[&]{assert(false);};
+    first->receive=[&]{++calls;docTemplate.docs.clear();a.reset();b.reset();first.reset();next.reset();if(fail)throw &failure;};
+    bool caught=false;try{frame.OnTimer(1);}catch(ReceiveFailure *e){assert(e==&failure);caught=true;}
+    assert(caught==fail && calls==1 && !a && !b && !first && !next);
+  }
+  std::cout << "PASS: one timer receive can delete both current and next worlds without using a stale position\n";
+
+  {
+    Fixture f; CMainFrame frame; SSL ssl{2};
+    f.doc.m_pSSL=&ssl; f.doc.m_bSSL_Connected=true;
+    f.doc.receive=[&]{throw &f.failure;}; f.fail();
+    frame.fallback=[&]{docTemplate.docs.clear();};
+    frame.OnTimer(1);assert(f.socket.m_bBufferedReadPending);
+    assert(frame.fallbacks==1 && frame.baseTimers==1);
+  }
+  {
+    Fixture f; CMainFrame frame; SSL ssl{2};
+    auto socket=std::make_unique<CWorldSocket>(&f.doc);f.doc.m_pSocket=socket.get();
+    f.doc.m_pSSL=&ssl;f.doc.m_bSSL_Connected=true;
+    auto oldId=socket->m_iSocketNumber;
+    f.doc.receive=[&]{
+      // Model allocator address reuse. The replacement has a distinct identity.
+      auto *where=socket.get();where->~CWorldSocket();new(where) CWorldSocket(&f.doc);
+      throw &f.failure;
+    };
+    bool caught=false;try{socket->OnReceive(0);}catch(ReceiveFailure *e){assert(e==&f.failure);caught=true;}
+    assert(caught && socket->m_iSocketNumber!=oldId && !socket->m_bBufferedReadPending && !socket->m_bInReceive);
+    frame.OnTimer(1);f.doc.m_pSocket=nullptr;
+  }
+  std::cout << "PASS: fallback deletion and same-address socket replacement do not reuse pending state\n";
+  docTemplate.docs.clear();
 }

--- a/tests/worldsock_tls_main.cpp
+++ b/tests/worldsock_tls_main.cpp
@@ -1,0 +1,99 @@
+int main() {
+  CMainFrame frame;
+  SSL_CTX *clientCtx = SSL_CTX_new(TLS_client_method());
+  SSL_CTX *serverCtx = SSL_CTX_new(TLS_server_method());
+  assert(clientCtx && serverCtx);
+  for(auto ctx : {clientCtx, serverCtx}) {
+    assert(SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION));
+    assert(SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION));
+    assert(SSL_CTX_set_cipher_list(ctx, "PSK-AES128-GCM-SHA256"));
+  }
+  SSL_CTX_set_psk_client_callback(clientCtx, clientPsk);
+  SSL_CTX_set_psk_server_callback(serverCtx, serverPsk);
+  SSL *client = SSL_new(clientCtx), *server = SSL_new(serverCtx);
+  assert(client && server);
+  BIO *clientIn = BIO_new(BIO_s_mem()), *clientOut = BIO_new(BIO_s_mem());
+  BIO *serverIn = BIO_new(BIO_s_mem()), *serverOut = BIO_new(BIO_s_mem());
+  BIO_METHOD *method = BIO_meth_new(BIO_TYPE_FILTER, "count transport reads");
+  assert(method);
+  BIO_meth_set_read(method, traceRead); BIO_meth_set_write(method, traceWrite);
+  BIO_meth_set_ctrl(method, traceCtrl);
+  BIO *filter = BIO_new(method); assert(filter);
+  BIO_set_init(filter, 1); BIO_push(filter, clientIn);
+  encryptedInput = clientIn;
+  SSL_set_bio(client, filter, clientOut); SSL_set_bio(server, serverIn, serverOut);
+  SSL_set_connect_state(client); SSL_set_accept_state(server);
+  for(int i = 0; i < 20 && (!SSL_is_init_finished(client) || !SSL_is_init_finished(server)); ++i) {
+    int a = SSL_do_handshake(client);
+    assert(a == 1 || SSL_get_error(client, a) == SSL_ERROR_WANT_READ);
+    moveBytes(clientOut, serverIn);
+    int b = SSL_do_handshake(server);
+    assert(b == 1 || SSL_get_error(server, b) == SSL_ERROR_WANT_READ);
+    moveBytes(serverOut, clientIn);
+  }
+  assert(SSL_is_init_finished(client) && SSL_is_init_finished(server));
+  assert(BIO_ctrl_pending(clientIn) == 0);
+  string message(16000, 'X');
+  assert(SSL_write(server, message.data(), message.size()) == 16000);
+  moveBytes(serverOut, clientIn);
+  recordReadsEnabled = true;
+  CMUSHclientDoc doc; CWorldSocket socket(&doc);
+  doc.m_pSocket = &socket; doc.m_pSSL = client; docTemplate.docs = {&doc};
+  int calls = 0, delivered = 0, pendingBeforeModal = 0;
+  struct ReceiveFailure {} failure;
+  doc.receive = [&] {
+    ++calls;
+    char buff[9000]; // Exact ReceiveMsg capacity and SSL_read call size.
+    int count = SSL_read(doc.m_pSSL, buff, sizeof(buff) - 1);
+    if(count <= 0) {
+      assert(SSL_get_error(doc.m_pSSL, count) == SSL_ERROR_WANT_READ);
+      return; // ReceiveMsg returns on SSL_ERROR_WANT_READ.
+    }
+    delivered += count;
+    if(calls == 1) {
+      pendingBeforeModal = SSL_pending(client);
+      assert(count == 8999 && pendingBeforeModal == 7001);
+      assert(BIO_ctrl_pending(clientIn) == 0 && staleReadQueued);
+      staleReadQueued = false;
+      #if NESTED_READ
+      socket.OnReceive(0); // A modal callback dispatches the queued stale FD_READ.
+      #endif
+      frame.OnTimer(1); // No retry while ReceiveMsg is still active.
+      assert(delivered == 8999);
+      #if THROW_AFTER_CALLBACK
+      throw &failure; // Native failure after the callback returns.
+#endif
+    }
+  };
+  bool caught = false;
+  try { socket.OnReceive(0); }
+  catch(ReceiveFailure *value) { assert(value == &failure); caught = true; }
+  assert(caught == bool(THROW_AFTER_CALLBACK));
+  if (THROW_AFTER_CALLBACK) {
+    assert(delivered == 8999 && SSL_pending(client) == 7001);
+    assert(!socket.nextReadQueued && socket.peekCalls == NESTED_READ);
+  }
+  frame.OnTimer(1);
+  assert(delivered == 16000 && SSL_pending(client) == 0);
+  assert(frame.fallbacks == 2 && frame.baseTimers == 2);
+  int afterDrainCalls = calls;
+  frame.OnTimer(1); // Completed retries do not read again.
+  assert(calls == afterDrainCalls);
+  string later = "later packet";
+  assert(SSL_write(server, later.data(), later.size()) == int(later.size()));
+  moveBytes(serverOut, clientIn);
+  socket.OnReceive(0);
+  assert(delivered == 16000 + int(later.size()) && SSL_pending(client) == 0);
+  std::cout << OpenSSL_version(OPENSSL_VERSION) << '\n';
+  std::cout << "transport_reads=";
+  for(int n : transportReads) std::cout << n << ',';
+  std::cout << " pending_before_modal=" << pendingBeforeModal
+            << " transport_bytes=" << BIO_ctrl_pending(clientIn)
+            << " decrypted_bytes=" << SSL_pending(client)
+            << " delivered=" << delivered << " receive_calls=" << calls
+            << " peek_calls=" << socket.peekCalls
+            << " queued=" << socket.nextReadQueued << '\n';
+  assert(!socket.m_bInReceive && !socket.m_bReceivePending);
+  SSL_free(client); SSL_free(server); SSL_CTX_free(clientCtx); SSL_CTX_free(serverCtx);
+  BIO_meth_free(method);
+}

--- a/tests/worldsock_tls_prefix.cpp
+++ b/tests/worldsock_tls_prefix.cpp
@@ -1,0 +1,110 @@
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+using std::string;
+using __int64 = long long;
+using UINT = unsigned;
+using POSITION = unsigned;
+using SOCKET = int;
+inline constexpr int INVALID_SOCKET = -1, SOCKET_ERROR = -1, WSAEWOULDBLOCK = 10035;
+inline constexpr int MSG_PEEK = 2, MB_OK = 0, MB_ICONERROR = 16, MB_TASKMODAL = 8192;
+static bool staleReadQueued = false;
+static bool recordReadsEnabled = false;
+static int lastError = 0;
+static BIO *encryptedInput;
+static std::vector<int> transportReads;
+int MessageBoxA(void *, const char *, const char *, int) { assert(false); return 0; }
+static int traceRead(BIO *bio, char *data, int size) {
+  BIO_clear_retry_flags(bio);
+  int got = BIO_read(BIO_next(bio), data, size);
+  BIO_copy_next_retry(bio);
+  if(recordReadsEnabled && got > 0) {
+    transportReads.push_back(got);
+    // Model a possible Winsock event posted after recv reenables FD_READ
+    // while payload remains. A later recv does not remove that queued event.
+    if(BIO_ctrl_pending(BIO_next(bio)) > 0) staleReadQueued = true;
+  }
+  return got;
+}
+static int traceWrite(BIO *bio, const char *data, int size) {
+  BIO_clear_retry_flags(bio);
+  int got = BIO_write(BIO_next(bio), data, size);
+  BIO_copy_next_retry(bio);
+  return got;
+}
+static long traceCtrl(BIO *bio, int cmd, long value, void *ptr) {
+  return BIO_ctrl(BIO_next(bio), cmd, value, ptr);
+}
+static unsigned int clientPsk(SSL *, const char *, char *identity, unsigned int maxId,
+                             unsigned char *psk, unsigned int maxPsk) {
+  assert(maxId > 8 && maxPsk >= 16);
+  std::strcpy(identity, "fixture"); std::memset(psk, 0x42, 16); return 16;
+}
+static unsigned int serverPsk(SSL *, const char *identity, unsigned char *psk, unsigned int maxPsk) {
+  assert(std::strcmp(identity, "fixture") == 0 && maxPsk >= 16);
+  std::memset(psk, 0x42, 16); return 16;
+}
+static void moveBytes(BIO *from, BIO *to) {
+  char data[32768];
+  while(BIO_ctrl_pending(from)) {
+    int n = BIO_read(from, data, sizeof(data)); assert(n > 0);
+    assert(BIO_write(to, data, n) == n);
+  }
+}
+struct CAsyncSocket {
+  virtual ~CAsyncSocket() = default;
+  SOCKET m_hSocket = 42;
+  int peekCalls = 0;
+  bool nextReadQueued = false;
+  int Receive(void *, int count, int flags) {
+    assert(count == 1 && flags == MSG_PEEK);
+    ++peekCalls;
+    nextReadQueued = BIO_ctrl_pending(encryptedInput) > 0;
+    if(nextReadQueued) return 1;
+    lastError = WSAEWOULDBLOCK; return SOCKET_ERROR;
+  }
+  static int GetLastError() { return lastError; }
+  void OnReceive(int) {}
+};
+#define DECLARE_DYNAMIC(type)
+#include "worldsock.h"
+class CMUSHclientDoc {
+public:
+  __int64 m_iUniqueDocumentNumber = 101;
+  CWorldSocket *m_pSocket = nullptr;
+  SSL *m_pSSL = nullptr;
+  bool m_bSSL_Connected = true;
+  std::function<void()> receive;
+  void ReceiveMsg() { receive(); }
+};
+struct DocTemplate {
+  std::vector<CMUSHclientDoc *> docs;
+  POSITION GetFirstDocPosition() { return docs.empty() ? 0 : 1; }
+  CMUSHclientDoc *GetNextDoc(POSITION &p) {
+    auto result = docs.at(p - 1); p = p < docs.size() ? p + 1 : 0; return result;
+  }
+} docTemplate;
+struct TestApp {
+  DocTemplate *m_pWorldDocTemplate = &docTemplate;
+  __int64 nextNumber = 1;
+  __int64 GetUniqueNumber() { return nextNumber++; }
+};
+inline TestApp App;
+
+struct CMDIFrameWnd { int baseTimers = 0; void OnTimer(UINT) { ++baseTimers; } };
+struct CMainFrame : CMDIFrameWnd {
+  int fallbacks = 0;
+  void CheckTimerFallback() { ++fallbacks; }
+  void OnTimer(UINT);
+};
+#include "worldsock_receive.inc"
+#include "worldsock_timer.inc"
+void CWorldSocket::OnSend(int) {}
+void CWorldSocket::OnClose(int) {}
+void CWorldSocket::OnConnect(int) {}

--- a/worldsock.cpp
+++ b/worldsock.cpp
@@ -28,32 +28,72 @@ IMPLEMENT_DYNAMIC(CWorldSocket, CAsyncSocket)
 CWorldSocket::CWorldSocket(CMUSHclientDoc* pDoc)
 {
 	m_pDoc = pDoc;
+  m_bInReceive = false;
+  m_bReceivePending = false;
 }
 
 void CWorldSocket::OnReceive(int nErrorCode)
 {
+  if (m_bInReceive)
+    {
+    m_bReceivePending = true;
+    return;
+    }
+
+  m_bInReceive = true;
+
   // save m_pDoc locally — if the handshake fails, 'this' (the socket) gets
   // deleted inside ReceiveMsg, so we must not touch 'this' afterwards
   CMUSHclientDoc * pDoc = m_pDoc;
 
-  pDoc->ReceiveMsg();
-
-  // if the socket was destroyed (e.g. SSL handshake failure), don't touch anything
-  if (pDoc->m_pSocket == NULL)
-    return;
-
-  // SSL may have buffered more decrypted data than one SSL_read consumed.
-  // Since we won't get another FD_READ for already-buffered data, drain it now.
-  if (pDoc->m_pSSL && pDoc->m_bSSL_Connected)
+  try
     {
-    while (SSL_pending (pDoc->m_pSSL) > 0)
+    do
       {
+      m_bReceivePending = false;
       pDoc->ReceiveMsg();
-      if (pDoc->m_pSocket == NULL)
+
+      // if the socket was destroyed or replaced, don't touch the old object
+      if (pDoc->m_pSocket != this)
         return;
+
+      // SSL may have buffered more decrypted data than one SSL_read consumed.
+      // Since we won't get another FD_READ for already-buffered data, drain it now.
+      if (pDoc->m_pSSL && pDoc->m_bSSL_Connected)
+        {
+        while (SSL_pending (pDoc->m_pSSL) > 0)
+          {
+          pDoc->ReceiveMsg();
+          if (pDoc->m_pSocket != this)
+            return;
+          }
+        }
+      } while (m_bReceivePending);
+    }
+  catch (...)
+    {
+    bool bSocketLive = false;
+    for (POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition(); pos; )
+      {
+      CMUSHclientDoc * pLiveDoc =
+        (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (pos);
+      if (pLiveDoc == pDoc)
+        {
+        bSocketLive = pLiveDoc->m_pSocket == this;
+        break;
+        }
       }
+
+    if (bSocketLive)
+      {
+      m_bInReceive = false;
+      m_bReceivePending = false;
+      }
+    throw;
     }
 
+  m_bInReceive = false;
+  m_bReceivePending = false;
   CAsyncSocket::OnReceive(nErrorCode);
 }
 

--- a/worldsock.cpp
+++ b/worldsock.cpp
@@ -26,12 +26,64 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 
 IMPLEMENT_DYNAMIC(CWorldSocket, CAsyncSocket)
 
+// Compare identities before accessing an object saved across a callback.
+static bool IsLiveWorldSocket (const CMUSHclientDoc * pDoc,
+                                const __int64 iDocumentNumber,
+                                const CWorldSocket * pSocket,
+                                const __int64 iSocketNumber)
+  {
+  for (POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition (); pos; )
+    {
+    CMUSHclientDoc * pLiveDoc =
+      (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (pos);
+    if (pLiveDoc == pDoc &&
+        pLiveDoc->m_iUniqueDocumentNumber == iDocumentNumber)
+      return pLiveDoc->m_pSocket == pSocket &&
+             pSocket->m_iSocketNumber == iSocketNumber;
+    }
+  return false;
+  }
+
 CWorldSocket::CWorldSocket(CMUSHclientDoc* pDoc)
+  : m_iSocketNumber (App.GetUniqueNumber ())
 {
-	m_pDoc = pDoc;
+  m_pDoc = pDoc;
   m_bInReceive = false;
   m_bReceivePending = false;
+  m_bBufferedReadPending = false;
+  m_iBufferedReadDocumentNumber = 0;
+  m_hBufferedReadSocket = INVALID_SOCKET;
+  m_pBufferedReadSSL = NULL;
 }
+
+// A transport FD_READ cannot report plaintext already buffered by OpenSSL.
+// Use a later timer entry, after the original receive exception has unwound.
+void CWorldSocket::CheckBufferedReads (void)
+  {
+  for (POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition (); pos; )
+    {
+    CMUSHclientDoc * pDoc =
+      (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (pos);
+    CWorldSocket * pSocket = pDoc->m_pSocket;
+    if (!pSocket || !pSocket->m_bBufferedReadPending || pSocket->m_bInReceive)
+      continue;
+
+    pSocket->m_bBufferedReadPending = false;
+    if (pSocket->m_pDoc != pDoc ||
+        pDoc->m_iUniqueDocumentNumber != pSocket->m_iBufferedReadDocumentNumber ||
+        pSocket->m_hSocket == INVALID_SOCKET ||
+        pSocket->m_hSocket != pSocket->m_hBufferedReadSocket ||
+        !pDoc->m_bSSL_Connected || !pDoc->m_pSSL ||
+        pDoc->m_pSSL != pSocket->m_pBufferedReadSSL ||
+        SSL_pending (pDoc->m_pSSL) <= 0)
+      continue;
+
+    pSocket->OnReceive (0);
+    // Receive callbacks can delete any world, including the next list entry.
+    // Do not use the saved position, document or socket after this call.
+    return;
+    }
+  }
 
 void CWorldSocket::OnReceive(int nErrorCode)
 {
@@ -42,11 +94,13 @@ void CWorldSocket::OnReceive(int nErrorCode)
     }
 
   m_bInReceive = true;
+  m_bBufferedReadPending = false;
 
-  // save m_pDoc locally — if the handshake fails, 'this' (the socket) gets
-  // deleted inside ReceiveMsg, so we must not touch 'this' afterwards
   CMUSHclientDoc * pDoc = m_pDoc;
+  const __int64 iDocumentNumber = pDoc->m_iUniqueDocumentNumber;
+  const __int64 iSocketNumber = m_iSocketNumber;
   const SOCKET hSocket = m_hSocket;
+  struct ssl_st * pSSL = pDoc->m_pSSL;
 
   try
     {
@@ -55,62 +109,77 @@ void CWorldSocket::OnReceive(int nErrorCode)
       m_bReceivePending = false;
       pDoc->ReceiveMsg();
 
-      // if the socket was destroyed or replaced, don't touch the old object
-      if (pDoc->m_pSocket != this)
+      if (!IsLiveWorldSocket (pDoc, iDocumentNumber, this, iSocketNumber))
         return;
+      if (m_hSocket != hSocket || (pSSL && pDoc->m_pSSL != pSSL))
+        {
+        m_bInReceive = false;
+        m_bReceivePending = false;
+        return;
+        }
+
+      // A proxy response can start TLS on this socket during ReceiveMsg.
+      if (!pSSL)
+        pSSL = pDoc->m_pSSL;
 
       // SSL may have buffered more decrypted data than one SSL_read consumed.
-      // Since we won't get another FD_READ for already-buffered data, drain it now.
+      // Since we will not get FD_READ for buffered data, drain it now.
       if (pDoc->m_pSSL && pDoc->m_bSSL_Connected)
         {
         while (SSL_pending (pDoc->m_pSSL) > 0)
           {
           pDoc->ReceiveMsg();
-          if (pDoc->m_pSocket != this)
+          if (!IsLiveWorldSocket (pDoc, iDocumentNumber, this, iSocketNumber))
             return;
+          if (m_hSocket != hSocket || (pSSL && pDoc->m_pSSL != pSSL))
+            {
+            m_bInReceive = false;
+            m_bReceivePending = false;
+            return;
+            }
+          if (!pDoc->m_pSSL || !pDoc->m_bSSL_Connected)
+            break;
           }
         }
       } while (m_bReceivePending);
     }
   catch (...)
     {
-    bool bSocketLive = false;
-    for (POSITION pos = App.m_pWorldDocTemplate->GetFirstDocPosition(); pos; )
-      {
-      CMUSHclientDoc * pLiveDoc =
-        (CMUSHclientDoc *) App.m_pWorldDocTemplate->GetNextDoc (pos);
-      if (pLiveDoc == pDoc)
-        {
-        bSocketLive = pLiveDoc->m_pSocket == this;
-        break;
-        }
-      }
-
-    if (bSocketLive)
+    if (IsLiveWorldSocket (pDoc, iDocumentNumber, this, iSocketNumber))
       {
       m_bInReceive = false;
       if (m_bReceivePending && hSocket != INVALID_SOCKET &&
           m_hSocket == hSocket)
         {
-        // A nested FD_READ returned without calling recv. MSG_PEEK rearms
-        // FD_READ without consuming data or changing the event mask. Let the
-        // later notification call ReceiveMsg after this exception unwinds.
+        // Keep plain FD_READ recovery. This consumes no bytes and changes no
+        // event mask. A later notification can read remaining transport data.
         char c;
         const int nResult = CAsyncSocket::Receive (&c, 1, MSG_PEEK);
         const int nError = nResult == SOCKET_ERROR ? GetLastError () : 0;
         m_bReceivePending = false;
         if (nError != 0 && nError != WSAEWOULDBLOCK)
           {
-          // Do not allocate a CString or replace the exception being handled.
-          // Winsock rearms FD_READ even when recv fails. Report that failure.
           char szMessage [160];
           snprintf (szMessage, sizeof szMessage, "Unable to rearm socket read notification (Winsock error %d).",
-                   nError);
+                    nError);
           ::MessageBoxA (NULL, szMessage, "MUSHclient", MB_OK | MB_ICONERROR | MB_TASKMODAL);
           }
         }
       else
         m_bReceivePending = false;
+      }
+
+    // Error reporting can run callbacks, destroy worlds or reconnect. Check
+    // again and publish the retry only immediately before rethrowing.
+    if (IsLiveWorldSocket (pDoc, iDocumentNumber, this, iSocketNumber) &&
+        m_hSocket == hSocket && hSocket != INVALID_SOCKET &&
+        pSSL && pDoc->m_pSSL == pSSL && pDoc->m_bSSL_Connected &&
+        SSL_pending (pSSL) > 0)
+      {
+      m_iBufferedReadDocumentNumber = iDocumentNumber;
+      m_hBufferedReadSocket = hSocket;
+      m_pBufferedReadSSL = pSSL;
+      m_bBufferedReadPending = true;
       }
     throw;
     }

--- a/worldsock.cpp
+++ b/worldsock.cpp
@@ -13,6 +13,7 @@
 #include "doc.h"
 
 #include <stddef.h>
+#include <stdio.h>
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -45,6 +46,7 @@ void CWorldSocket::OnReceive(int nErrorCode)
   // save m_pDoc locally — if the handshake fails, 'this' (the socket) gets
   // deleted inside ReceiveMsg, so we must not touch 'this' afterwards
   CMUSHclientDoc * pDoc = m_pDoc;
+  const SOCKET hSocket = m_hSocket;
 
   try
     {
@@ -87,7 +89,28 @@ void CWorldSocket::OnReceive(int nErrorCode)
     if (bSocketLive)
       {
       m_bInReceive = false;
-      m_bReceivePending = false;
+      if (m_bReceivePending && hSocket != INVALID_SOCKET &&
+          m_hSocket == hSocket)
+        {
+        // A nested FD_READ returned without calling recv. MSG_PEEK rearms
+        // FD_READ without consuming data or changing the event mask. Let the
+        // later notification call ReceiveMsg after this exception unwinds.
+        char c;
+        const int nResult = CAsyncSocket::Receive (&c, 1, MSG_PEEK);
+        const int nError = nResult == SOCKET_ERROR ? GetLastError () : 0;
+        m_bReceivePending = false;
+        if (nError != 0 && nError != WSAEWOULDBLOCK)
+          {
+          // Do not allocate a CString or replace the exception being handled.
+          // Winsock rearms FD_READ even when recv fails. Report that failure.
+          char szMessage [160];
+          snprintf (szMessage, sizeof szMessage, "Unable to rearm socket read notification (Winsock error %d).",
+                   nError);
+          ::MessageBoxA (NULL, szMessage, "MUSHclient", MB_OK | MB_ICONERROR | MB_TASKMODAL);
+          }
+        }
+      else
+        m_bReceivePending = false;
       }
     throw;
     }

--- a/worldsock.h
+++ b/worldsock.h
@@ -27,6 +27,8 @@ public:
 public:
 	CMUSHclientDoc* m_pDoc;
   string m_outstanding_data;
+  bool m_bInReceive;
+  bool m_bReceivePending;
 
 // Implementation
 

--- a/worldsock.h
+++ b/worldsock.h
@@ -29,6 +29,13 @@ public:
   string m_outstanding_data;
   bool m_bInReceive;
   bool m_bReceivePending;
+  const __int64 m_iSocketNumber;
+  bool m_bBufferedReadPending;
+  __int64 m_iBufferedReadDocumentNumber;
+  SOCKET m_hBufferedReadSocket;
+  struct ssl_st * m_pBufferedReadSSL;
+
+  static void CheckBufferedReads (void);
 
 // Implementation
 


### PR DESCRIPTION
Drain pending world receive notifications after the active callback returns. Publish replacement socket and decompression buffers only after allocation succeeds.

Related change set: #6.
