### PR TITLE
Check output selection bounds before reading lines

### DIFF
--- a/mushview.cpp
+++ b/mushview.cpp
@@ -2036,11 +2036,15 @@ ASSERT_VALID(pDoc);
   // find word under mouse for GetInfo (86)
 
   CLine * pLine = pDoc->m_LineList.GetAt (pos);
-  while (start_col >= 0 &&
-        !isspace ((unsigned char) pLine->text [start_col]) &&
-        strchr (App.m_strWordDelimitersDblClick, pLine->text [start_col]) == NULL)
-    start_col--;
-  start_col++;   // now onto the start of that word
+  start_col = MIN (start_col, pLine->len);
+  if (start_col < pLine->len)
+    {
+    while (start_col >= 0 &&
+          !isspace ((unsigned char) pLine->text [start_col]) &&
+          strchr (App.m_strWordDelimitersDblClick, pLine->text [start_col]) == NULL)
+      start_col--;
+    start_col++;   // now onto the start of that word
+    }
 
   // a word will end on a space, or whatever
   while (end_col < pLine->len &&
@@ -4915,11 +4919,15 @@ int line,
   else
     {
     CLine * pLine = pDoc->m_LineList.GetAt (pos);
-    while (m_selstart_col >= 0 && 
-          !isspace ((unsigned char) pLine->text [m_selstart_col]) &&
-          strchr (App.m_strWordDelimitersDblClick, pLine->text [m_selstart_col]) == NULL)
-      m_selstart_col--;
-    m_selstart_col++;   // now onto the start of that word
+    m_selstart_col = MIN (m_selstart_col, pLine->len);
+    if (m_selstart_col < pLine->len)
+      {
+      while (m_selstart_col >= 0 &&
+            !isspace ((unsigned char) pLine->text [m_selstart_col]) &&
+            strchr (App.m_strWordDelimitersDblClick, pLine->text [m_selstart_col]) == NULL)
+        m_selstart_col--;
+      m_selstart_col++;   // now onto the start of that word
+      }
 
     m_pin_col = m_selstart_col;
 
@@ -5372,6 +5380,18 @@ long startcol,
   if (!(m_selend_line > m_selstart_line || 
               (m_selend_line == m_selstart_line && 
                endcol > startcol)))
+    return;
+
+  long iSelectedLine = m_selstart_line;
+  while (startcol >= pStartLine->len && iSelectedLine < m_selend_line)
+    {
+    iSelectedLine++;
+    pStartLine = pDoc->m_LineList.GetAt (pDoc->GetLinePosition (iSelectedLine));
+    startcol = 0;
+    }
+
+  if (startcol >= pStartLine->len ||
+      (iSelectedLine == m_selend_line && startcol >= endcol))
     return;
 
 unsigned int iStyle;

--- a/mushview.cpp
+++ b/mushview.cpp
@@ -5424,7 +5424,7 @@ char * sColours [8] =
 CTextAttributesDlg dlg;
 
   dlg.m_pDoc = pDoc;
-  dlg.m_iLine = m_selstart_line + 1;    // make 1-relative
+  dlg.m_iLine = iSelectedLine + 1;    // make 1-relative
   dlg.m_pLine = pStartLine; 
 
   dlg.m_strLetter = c;


### PR DESCRIPTION
Validate output selection positions and line pointers before using selected text or constructing popup actions.

Related change set: #6.
