### PR TITLE
Roll back failed help database updates

### DIFF
--- a/plugins/MUSHclient_Help.xml
+++ b/plugins/MUSHclient_Help.xml
@@ -145,6 +145,17 @@ local function fixsql (s)
   return "NULL"
 end -- fixsql
 
+local function db_success (code)
+  return code == sqlite3.OK or code == sqlite3.ROW or code == sqlite3.DONE
+end -- db_success
+
+local function dbcheck (code)
+  if not db_success (code) then
+    error (db:errmsg (), 2)
+  end -- database error
+  return code
+end -- dbcheck
+
 -- for fixing up entities
 local entities = {
   ["&lt;"]    = "<";
@@ -473,8 +484,10 @@ function OnPluginInstall ()
     ColourNote ("cyan", "", "Creating help database full-text lookup tables ...")
 
     -- START
-    assert (db:execute [[
-      BEGIN TRANSACTION;
+    dbcheck (db:execute "BEGIN TRANSACTION")
+
+    local ok, result = pcall (function ()
+    dbcheck (db:execute [[
       DROP TABLE IF EXISTS commands_lookup;
       DROP TABLE IF EXISTS dialogs_lookup;
       DROP TABLE IF EXISTS functions_lookup;
@@ -484,11 +497,11 @@ function OnPluginInstall ()
     ]])
 
     -- COMMANDS
-    assert (db:execute "CREATE VIRTUAL TABLE commands_lookup USING FTS4(name, summary, description)")
+    dbcheck (db:execute "CREATE VIRTUAL TABLE commands_lookup USING FTS4(name, summary, description)")
 
     -- fix up HTML stuff
     for row in db:nrows("SELECT command_name, short_description, description FROM commands") do
-      assert (db:execute (string.format ([[
+      dbcheck (db:execute (string.format ([[
       INSERT INTO commands_lookup (name, summary, description)
              VALUES (%s, %s, %s)]],
              fixsql (row.command_name),
@@ -497,11 +510,11 @@ function OnPluginInstall ()
     end -- for
 
     -- DIALOGS
-    assert (db:execute "CREATE VIRTUAL TABLE dialogs_lookup USING FTS4(name, summary, description)")
+    dbcheck (db:execute "CREATE VIRTUAL TABLE dialogs_lookup USING FTS4(name, summary, description)")
 
     -- fix up HTML stuff
     for row in db:nrows("SELECT dialog_name, title, description FROM dialogs") do
-      assert (db:execute (string.format ([[
+      dbcheck (db:execute (string.format ([[
       INSERT INTO dialogs_lookup (name, summary, description)
              VALUES (%s, %s, %s)]],
              fixsql (row.dialog_name),
@@ -510,16 +523,16 @@ function OnPluginInstall ()
     end -- for
 
     -- WORLD FUNCTIONS
-    assert (db:execute "CREATE VIRTUAL TABLE functions_lookup USING FTS4(name, summary, description, lua_example, lua_notes)")
-    assert (db:execute [[INSERT INTO functions_lookup (name, summary, description, lua_example, lua_notes)
+    dbcheck (db:execute "CREATE VIRTUAL TABLE functions_lookup USING FTS4(name, summary, description, lua_example, lua_notes)")
+    dbcheck (db:execute [[INSERT INTO functions_lookup (name, summary, description, lua_example, lua_notes)
                          SELECT name, summary, description, lua_example, lua_notes FROM functions]])
 
     -- GENERAL TOPICS
-    assert (db:execute "CREATE VIRTUAL TABLE general_doc_lookup USING FTS4(name, summary, description)")
+    dbcheck (db:execute "CREATE VIRTUAL TABLE general_doc_lookup USING FTS4(name, summary, description)")
 
     -- fix up HTML stuff
     for row in db:nrows("SELECT doc_name, title, description FROM general_doc") do
-      assert (db:execute (string.format ([[
+      dbcheck (db:execute (string.format ([[
       INSERT INTO general_doc_lookup (name, summary, description)
              VALUES (%s, %s, %s)]],
              fixsql (row.doc_name),
@@ -528,16 +541,16 @@ function OnPluginInstall ()
     end -- for
 
     -- ERRORS
-    assert (db:execute "CREATE VIRTUAL TABLE errors_lookup USING FTS4(name, error_code, description)")
-    assert (db:execute [[INSERT INTO errors_lookup (name, error_code, description)
+    dbcheck (db:execute "CREATE VIRTUAL TABLE errors_lookup USING FTS4(name, error_code, description)")
+    dbcheck (db:execute [[INSERT INTO errors_lookup (name, error_code, description)
                          SELECT error_name, error_code, meaning FROM errors ]])
 
     -- LUA FUNCTIONS
-    assert (db:execute "CREATE VIRTUAL TABLE lua_functions_lookup USING FTS4(name, summary, description)")
+    dbcheck (db:execute "CREATE VIRTUAL TABLE lua_functions_lookup USING FTS4(name, summary, description)")
 
     -- fix up HTML stuff
     for row in db:nrows("SELECT name, summary, description FROM lua_functions") do
-      assert (db:execute (string.format ([[
+      dbcheck (db:execute (string.format ([[
       INSERT INTO lua_functions_lookup (name, summary, description)
              VALUES (%s, %s, %s)]],
              fixsql (row.name),
@@ -546,7 +559,17 @@ function OnPluginInstall ()
     end -- for
 
     -- DONE
-    assert (db:execute "COMMIT;")
+    dbcheck (db:execute "COMMIT;")
+    end)
+
+    if not ok then
+      local rollback = db:execute "ROLLBACK"
+      if not db_success (rollback) then
+        result = tostring (result) .. "\nRollback failed: " .. db:errmsg ()
+      end -- rollback failed
+      error (result, 0)
+    end -- transaction failed
+
     ColourNote ("cyan", "", string.format ("Done. Took %0.3f seconds.", utils.timer () - start))
 
   end -- if


### PR DESCRIPTION
Check help database transaction and write results. Roll back failed updates and report the database error instead of leaving a partial update.

Related change set: #6.
