### PR TITLE
Release GDI resources after glyph lookup

### DIFF
--- a/scripting/lua_utils.cpp
+++ b/scripting/lua_utils.cpp
@@ -1942,64 +1942,83 @@ typedef struct tagGLYPHSET
 static int glyph_available (lua_State *L) 
   {
   // which glyph?
-  const char * fontName   = luaL_checkstring (L, 1);
+  const char * fontName = luaL_checkstring (L, 1);
+  WORD glyph = (WORD) luaL_checknumber (L, 2);  // which Unicode character
 
   // this DLL might not be available
-	HMODULE hDLL = LoadLibrary ("gdi32");
+  HMODULE hDLL = LoadLibrary ("gdi32");
   if (!hDLL)
     {
-    lua_pushnil (L); 
+    lua_pushnil (L);
     return 1;
     }
 
+  class CModuleGuard
+    {
+    public:
+    explicit CModuleGuard (HMODULE hModule) : m_hModule (hModule) {}
+    ~CModuleGuard () { FreeLibrary (m_hModule); }
+    private:
+    HMODULE m_hModule;
+    } moduleGuard (hDLL);
+
   // make a device contect
   CDC dc;
-  dc.CreateCompatibleDC (NULL);
+  if (!dc.CreateCompatibleDC (NULL))
+    {
+    lua_pushnil (L);
+    return 1;
+    }
 
-  int lfHeight = -MulDiv(5, dc.GetDeviceCaps(LOGPIXELSY), 72);
+  int lfHeight = -MulDiv (5, dc.GetDeviceCaps (LOGPIXELSY), 72);
   CFont font;
 
   // select requested font into it
-  font.CreateFont(lfHeight, // int nHeight, 
-        0,                  // int nWidth, 
-        0,                  // int nEscapement, 
-        0,                  // int nOrientation, 
-        FW_DONTCARE,        // int nWeight, 
-        0,                  // BYTE bItalic, 
-        0,                  // BYTE bUnderline, 
-        0,                  // BYTE cStrikeOut, 
-        DEFAULT_CHARSET,    // BYTE nCharSet, 
-        OUT_DEVICE_PRECIS,  // BYTE nOutPrecision, 
-        CLIP_DEFAULT_PRECIS,// BYTE nClipPrecision, 
-        DEFAULT_QUALITY,    // BYTE nQuality, 
-        FF_DONTCARE,        // BYTE nPitchAndFamily,  
-        fontName);          // LPCTSTR lpszFacename
+  if (!font.CreateFont (lfHeight, // int nHeight,
+        0,                        // int nWidth,
+        0,                        // int nEscapement,
+        0,                        // int nOrientation,
+        FW_DONTCARE,              // int nWeight,
+        0,                        // BYTE bItalic,
+        0,                        // BYTE bUnderline,
+        0,                        // BYTE cStrikeOut,
+        DEFAULT_CHARSET,          // BYTE nCharSet,
+        OUT_DEVICE_PRECIS,        // BYTE nOutPrecision,
+        CLIP_DEFAULT_PRECIS,      // BYTE nClipPrecision,
+        DEFAULT_QUALITY,          // BYTE nQuality,
+        FF_DONTCARE,              // BYTE nPitchAndFamily,
+        fontName))                // LPCTSTR lpszFacename
+    {
+    lua_pushnil (L);
+    return 1;
+    }
 
-  dc.SelectObject(font);
-
-  // test a single character
-  WORD glyph = luaL_checknumber(L, 2);    // which Unicode character
+  CFont * pOldFont = dc.SelectObject (&font);
+  if (!pOldFont)
+    {
+    lua_pushnil (L);
+    return 1;
+    }
 
   typedef DWORD (CALLBACK* GetGlyphIndicesW_PROC)(HDC, LPCWSTR, int, LPWORD, DWORD);
   GetGlyphIndicesW_PROC pGetGlyphIndicesW = NULL;
 
   // get function address
-  pGetGlyphIndicesW = (GetGlyphIndicesW_PROC) GetProcAddress(hDLL, "GetGlyphIndicesW");
+  pGetGlyphIndicesW = (GetGlyphIndicesW_PROC) GetProcAddress (hDLL, "GetGlyphIndicesW");
+
+  WORD indice = 0;
 
   // if it exists, call it
-  if (pGetGlyphIndicesW)
-    {
-	  WORD indice;
+  if (pGetGlyphIndicesW &&
+      (*pGetGlyphIndicesW)((HDC) dc.m_hDC, (LPCWSTR) &glyph, 1,
+                           &indice, GGI_MARK_NONEXISTING_GLYPHS) == GDI_ERROR)
+    indice = 0;
 
-	  if ((*pGetGlyphIndicesW)((HDC) dc.m_hDC, (LPCWSTR) &glyph, 1,
-	                            &indice, GGI_MARK_NONEXISTING_GLYPHS ) != GDI_ERROR &&
-	          indice != 0xffff)
-      lua_pushnumber (L, indice);  
-    else
-      lua_pushnumber (L, 0); 
-    }
-  else
-    lua_pushnumber (L, 0); 
+  if (indice == 0xffff)
+    indice = 0;
+
+  dc.SelectObject (pOldFont);
+  lua_pushnumber (L, indice);
   
   return 1;   // one result
 

--- a/scripting/lua_utils.cpp
+++ b/scripting/lua_utils.cpp
@@ -1942,14 +1942,15 @@ typedef struct tagGLYPHSET
 static int glyph_available (lua_State *L) 
   {
   // which glyph?
-  const char * fontName = luaL_checkstring (L, 1);
+  const char * fontName   = luaL_checkstring (L, 1);
+  // test a single character
   WORD glyph = (WORD) luaL_checknumber (L, 2);  // which Unicode character
 
   // this DLL might not be available
-  HMODULE hDLL = LoadLibrary ("gdi32");
+	HMODULE hDLL = LoadLibrary ("gdi32");
   if (!hDLL)
     {
-    lua_pushnil (L);
+    lua_pushnil (L); 
     return 1;
     }
 
@@ -1970,23 +1971,23 @@ static int glyph_available (lua_State *L)
     return 1;
     }
 
-  int lfHeight = -MulDiv (5, dc.GetDeviceCaps (LOGPIXELSY), 72);
+  int lfHeight = -MulDiv(5, dc.GetDeviceCaps(LOGPIXELSY), 72);
   CFont font;
 
   // select requested font into it
   if (!font.CreateFont (lfHeight, // int nHeight,
-        0,                        // int nWidth,
-        0,                        // int nEscapement,
-        0,                        // int nOrientation,
-        FW_DONTCARE,              // int nWeight,
-        0,                        // BYTE bItalic,
-        0,                        // BYTE bUnderline,
-        0,                        // BYTE cStrikeOut,
-        DEFAULT_CHARSET,          // BYTE nCharSet,
-        OUT_DEVICE_PRECIS,        // BYTE nOutPrecision,
-        CLIP_DEFAULT_PRECIS,      // BYTE nClipPrecision,
-        DEFAULT_QUALITY,          // BYTE nQuality,
-        FF_DONTCARE,              // BYTE nPitchAndFamily,
+        0,                  // int nWidth, 
+        0,                  // int nEscapement, 
+        0,                  // int nOrientation, 
+        FW_DONTCARE,        // int nWeight, 
+        0,                  // BYTE bItalic, 
+        0,                  // BYTE bUnderline, 
+        0,                  // BYTE cStrikeOut, 
+        DEFAULT_CHARSET,    // BYTE nCharSet, 
+        OUT_DEVICE_PRECIS,  // BYTE nOutPrecision, 
+        CLIP_DEFAULT_PRECIS,// BYTE nClipPrecision, 
+        DEFAULT_QUALITY,    // BYTE nQuality, 
+        FF_DONTCARE,        // BYTE nPitchAndFamily,  
         fontName))                // LPCTSTR lpszFacename
     {
     lua_pushnil (L);
@@ -2004,7 +2005,7 @@ static int glyph_available (lua_State *L)
   GetGlyphIndicesW_PROC pGetGlyphIndicesW = NULL;
 
   // get function address
-  pGetGlyphIndicesW = (GetGlyphIndicesW_PROC) GetProcAddress (hDLL, "GetGlyphIndicesW");
+  pGetGlyphIndicesW = (GetGlyphIndicesW_PROC) GetProcAddress(hDLL, "GetGlyphIndicesW");
 
   WORD indice = 0;
 


### PR DESCRIPTION
Validate Lua glyph arguments before acquiring GDI resources. Check device context and font creation, restore the selected font, and release the loaded module when glyph lookup returns.

Related change set: #6.
