### PR TITLE
Retain new script arrays until map insertion succeeds

### DIFF
--- a/scripting/methods/methods_arrays.cpp
+++ b/scripting/methods/methods_arrays.cpp
@@ -138,9 +138,13 @@ long CMUSHclientDoc::ArrayCreate(LPCTSTR Name)
   if (it != GetArrayMap ().end ())
     return eArrayAlreadyExists;
 
-  tStringToStringMap * m = new tStringToStringMap;
+  std::unique_ptr<tStringToStringMap> m (new tStringToStringMap);
 
-  GetArrayMap ().insert (make_pair (Name, m));
+  pair<tStringMapOfMaps::iterator, bool> result =
+    GetArrayMap ().insert (make_pair (Name, m.get ()));
+  if (!result.second)
+    return eArrayAlreadyExists;
+  m.release ();
 
   return eOK;
 


### PR DESCRIPTION
Keep a new script array under local ownership until it is inserted into the array map, so insertion failure does not leak the array.

Related change set: #6.
