### PR TITLE
Use the minute field when converting timer values

### DIFF
--- a/scripting/methods/methods_timers.cpp
+++ b/scripting/methods/methods_timers.cpp
@@ -862,13 +862,13 @@ bool bChanged;
       if (Timer_item->iType == CTimer::eInterval)
         {
         Timer_item->iEveryHour    = Timer_item->iAtHour;
-        Timer_item->iEveryMinute  = Timer_item->iAtHour;
+        Timer_item->iEveryMinute  = Timer_item->iAtMinute;
         Timer_item->fEverySecond  = Timer_item->fAtSecond;
         }
       else
         {
         Timer_item->iAtHour    = Timer_item->iEveryHour;
-        Timer_item->iAtMinute  = Timer_item->iEveryHour;
+        Timer_item->iAtMinute  = Timer_item->iEveryMinute;
         Timer_item->fAtSecond  = Timer_item->fEverySecond;
         }
        ResetOneTimer (Timer_item);


### PR DESCRIPTION
Convert the timer minute value from the minute field instead of repeating the hour field.

Related change set: #6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected timer scheduling when changing the `at_time` option for interval and at-time timers.
  - Timer minute values are now preserved and applied correctly, preventing incorrect schedule updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->