### PR TITLE
Release XML import exceptions after reporting failure

### DIFF
--- a/scripting/methods/methods_xml.cpp
+++ b/scripting/methods/methods_xml.cpp
@@ -82,8 +82,9 @@ long iCount = 0;
       iCount = -1;    // not in XML
 
      } // end of try block
-  catch (CArchiveException* ) 
+  catch (CArchiveException* e)
     {
+    e->Delete ();
     iCount = -1;    // error parsing XML
     }
 


### PR DESCRIPTION
Delete caught archive exceptions after converting XML import errors into the existing failure result.

Related change set: #6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during XML imports by properly releasing exception resources when an import fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->