### PR TITLE
Restore command input state after nested execution

### DIFF
--- a/dialogs/ImmediateDlg.cpp
+++ b/dialogs/ImmediateDlg.cpp
@@ -63,6 +63,7 @@ CString strText;
 
   Frame.SetStatusMessageNow (Translate ("Executing immediate script"));
 
+  CWorldDocumentOperationGuard operationGuard (m_pDoc);
   CBoolStateGuard sendToScriptGuard (m_pDoc->m_bInSendToScript, false);
 
   m_pDoc->m_ScriptEngine->Parse (strText, "Immediate");

--- a/doc.cpp
+++ b/doc.cpp
@@ -1259,6 +1259,7 @@ void CMUSHclientDoc::DoSendMsg(const CString & strText,
                                const bool bEchoIt,
                                const bool bLogIt)
 {
+CWorldDocumentOperationGuard operationGuard (this);
 CString str = strText;
 
   // cannot change what we are sending in OnPluginSent
@@ -9084,6 +9085,7 @@ void CMUSHclientDoc::Screendraw  (const long iType,
   if (m_bInScreendraw)
     return;
 
+  CWorldDocumentOperationGuard operationGuard (this);
   CBoolStateGuard screendrawGuard (m_bInScreendraw, true);
   SendToAllPluginCallbacks (ON_PLUGIN_SCREENDRAW,
                             iType,
@@ -9100,6 +9102,7 @@ bool CMUSHclientDoc::PlaySoundFile (CString strSound)
   // stop infinite loops
   if (!m_bInPlaySoundFilePlugin)
     {
+    CWorldDocumentOperationGuard operationGuard (this);
     CBoolStateGuard playSoundGuard (m_bInPlaySoundFilePlugin, true);
     
     if (SendToFirstPluginCallbacks (ON_PLUGIN_PLAYSOUND, strSound))
@@ -9117,6 +9120,7 @@ void CMUSHclientDoc::CancelSound (void)
   // stop infinite loops
   if (!m_bInCancelSoundFilePlugin)
     {
+    CWorldDocumentOperationGuard operationGuard (this);
     CBoolStateGuard cancelSoundGuard (m_bInCancelSoundFilePlugin, true);
 
     CString strSound;   // deliberately the empty string

--- a/doc.cpp
+++ b/doc.cpp
@@ -7653,6 +7653,8 @@ void CMUSHclientDoc::SendTo (
     if (strSendText.IsEmpty ())
       return;
 
+  CWorldDocumentOperationGuard operationGuard (this);
+
   switch (iWhere)
     {
     case eSendToCommand:

--- a/mushview.cpp
+++ b/mushview.cpp
@@ -3631,6 +3631,8 @@ void CMUSHView::OnContextMenu(CWnd*, CPoint point)
 CMUSHclientDoc* pDoc = GetDocument();
 ASSERT_VALID(pDoc);
 
+  CWorldDocumentOperationGuard operationGuard (pDoc);
+
     if (point.x == -1 && point.y == -1)
       {
       //keystroke invocation
@@ -3759,7 +3761,7 @@ ASSERT_VALID(pDoc);
                                 menupoint.x, 
                                 menupoint.y,
                                 pWndPopupOwner);
-          if (nCommand)
+          if (nCommand && !pDoc->m_bWorldClosePending)
             OnMXPMenu (nCommand);
 
           return;
@@ -3799,7 +3801,7 @@ ASSERT_VALID(pDoc);
                                 menupoint.x, 
                                 menupoint.y,
                                 pWndPopupOwner);
-          if (nCommand)
+          if (nCommand && !pDoc->m_bWorldClosePending)
             OnMXPMenu (nCommand);
 
           return;

--- a/mushview.cpp
+++ b/mushview.cpp
@@ -2008,6 +2008,7 @@ ASSERT_VALID(pDoc);
   if (!pDoc->m_FontHeight)
     return;
 
+  CWorldDocumentOperationGuard operationGuard (pDoc);
   CPluginContextGuard pluginContextGuard (pDoc, NULL);
 
   CPoint wordPoint (point);
@@ -2156,7 +2157,7 @@ CPoint menupoint = point;
                         point.x,
                         point.y,
                         pWndPopupOwner);
-  if (nCommand)
+  if (nCommand && !pDoc->m_bWorldClosePending)
     OnMXPMenu (nCommand);
 
   } // end of CMUSHView::AliasMenu
@@ -6600,14 +6601,15 @@ void CMUSHView::Send_Mouse_Event_To_Plugin (DISPID iDispatchID,
                                             long Flags,
                                             bool dont_modify_flags)
   {
+CMUSHclientDoc* pDoc = GetDocument();
+ASSERT_VALID(pDoc);
+
+  CWorldDocumentOperationGuard operationGuard (pDoc);
   CBoolStateGuard executingGuard (miniwindow.m_bExecutingScript, true);
 
   // only if they have a routine
   if (sRoutineName.empty ())
     return;
-
-CMUSHclientDoc* pDoc = GetDocument();
-ASSERT_VALID(pDoc);
 
 // also Flags might be (from caller):
 
@@ -7690,10 +7692,11 @@ void CMUSHView::NotifySelectionChanged(void)
   m_old_selend_line   = m_selend_line;
   m_old_selend_col    = m_selend_col;
 
-  CBoolStateGuard selectionGuard (m_bInSelectionChanged, true);
-
   CMUSHclientDoc* pDoc = GetDocument();
   ASSERT_VALID(pDoc);
+
+  CWorldDocumentOperationGuard operationGuard (pDoc);
+  CBoolStateGuard selectionGuard (m_bInSelectionChanged, true);
 
   if (pDoc->m_ScriptEngine)
     pDoc->SendToAllPluginCallbacks(ON_PLUGIN_SELECTION_CHANGED);

--- a/mxp/mxpEntities.cpp
+++ b/mxp/mxpEntities.cpp
@@ -49,6 +49,7 @@ CString strEntityContents = MXP_GetEntity (m_strMXPstring);
   if (!strEntityContents.IsEmpty ())
     {
 //  if the entity happens to be < & > etc. don't reprocess it
+    CWorldDocumentOperationGuard operationGuard (this);
     CValueStateGuard<bool> mxpGuard (m_bMXP, false);
     DisplayMsg (strEntityContents, strEntityContents.GetLength (), 0, true);  // fake packet
     }

--- a/scripting/lua_scripting.cpp
+++ b/scripting/lua_scripting.cpp
@@ -265,6 +265,7 @@ void CScriptEngine::CloseLua ()
 // send some code to Lua to be parsed
 bool CScriptEngine::ParseLua (const CString & strCode, const CString & strWhat)
   {
+  CWorldDocumentOperationGuard operationGuard (m_pDoc);
   CPluginCallGuard callGuard (m_pDoc->m_CurrentPlugin, true);
 
   // safety check ;)
@@ -475,6 +476,7 @@ bool CScriptEngine::ExecuteLua (DISPID & dispid,  // dispatch ID, will be set to
 
 
   {
+  CWorldDocumentOperationGuard operationGuard (m_pDoc);
   CPluginCallGuard callGuard (m_pDoc->m_CurrentPlugin, true);
 
   // safety check ;)
@@ -698,6 +700,7 @@ bool CScriptEngine::ExecuteLua (DISPID & dispid,          // dispatch ID, will b
                                long & nInvocationCount,  // count of invocations
                                CString & result)         // where to put result
   {
+  CWorldDocumentOperationGuard operationGuard (m_pDoc);
   CPluginCallGuard callGuard (m_pDoc->m_CurrentPlugin, true);
 
   // safety check ;)

--- a/scripting/methods/methods_commands.cpp
+++ b/scripting/methods/methods_commands.cpp
@@ -249,6 +249,8 @@ void CMUSHclientDoc::DeleteCommandHistory()
 long CMUSHclientDoc::Execute(LPCTSTR Command) 
 {
 
+CWorldDocumentOperationGuard executeOperationGuard (this);
+
 // remember current plugin
 CValueStateGuard<CPlugin *> pluginGuard (m_CurrentPlugin, m_CurrentPlugin);
 

--- a/scripting/methods/methods_miniwindows.cpp
+++ b/scripting/methods/methods_miniwindows.cpp
@@ -1359,6 +1359,7 @@ long CMUSHclientDoc::WindowDelete(LPCTSTR Name)
 
 BSTR CMUSHclientDoc::WindowMenu(LPCTSTR Name, long Left, long Top, LPCTSTR Items) 
 {
+  CWorldDocumentOperationGuard operationGuard (this);
 
   CString strResult;
 

--- a/scripting/methods/methods_tracing.cpp
+++ b/scripting/methods/methods_tracing.cpp
@@ -23,6 +23,8 @@ void CMUSHclientDoc::Trace (LPCTSTR lpszFormat, ...)
   if (!m_bTrace)
     return;
 
+  CWorldDocumentOperationGuard operationGuard (this);
+
 	ASSERT(AfxIsValidString(lpszFormat, FALSE));
 
 CString strMsg;

--- a/scripting/methods/methods_utilities.cpp
+++ b/scripting/methods/methods_utilities.cpp
@@ -430,6 +430,7 @@ SetModifiedFlag (ChangedFlag);
 
 void CMUSHclientDoc::Simulate(LPCTSTR Text) 
 {
+  CWorldDocumentOperationGuard operationGuard (this);
   CBoolStateGuard doingSimulateGuard (m_bDoingSimulate, true);
   DisplayMsg(Text, strlen (Text), 0);
 }   // end of CMUSHclientDoc::Simulate

--- a/scripting/scriptengine.cpp
+++ b/scripting/scriptengine.cpp
@@ -20,6 +20,7 @@ bool CScriptEngine::Execute (DISPID & dispid,  // dispatch ID, will be set to DI
                               COleVariant * result    // result of call
                               )
   {
+  CWorldDocumentOperationGuard operationGuard (m_pDoc);
   CPluginCallGuard callGuard (m_pDoc->m_CurrentPlugin, true);
 
   // If Lua, we may have been called with no arguments, so just do that
@@ -394,6 +395,7 @@ WCHAR charWorld[]=L"world";
 
 bool CScriptEngine::Parse (const CString & strCode, const CString & strWhat)
   {
+  CWorldDocumentOperationGuard operationGuard (m_pDoc);
   CPluginCallGuard callGuard (m_pDoc->m_CurrentPlugin, true);
 
   CValueStateGuard<CString> procedureGuard (strProcedure, CString ());

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -333,8 +333,8 @@ ASSERT_VALID(pDoc);
 
 	if (nChar == VK_RETURN)
   	{
-
-    pDoc->m_iCurrentActionSource = eUserTyping;
+    CValueStateGuard<unsigned short> actionSourceGuard
+      (pDoc->m_iCurrentActionSource, eUserTyping);
 
 		CString strText;
 		GetEditCtrl().GetWindowText(strText);
@@ -382,7 +382,6 @@ ASSERT_VALID(pDoc);
 // cancel any previous message on the status line
     pDoc->ShowStatusLine ();
 
-    pDoc->m_iCurrentActionSource = eUnknownActionSource;
     return;
 
   	} // end of return key
@@ -670,11 +669,10 @@ void CSendView::SendCommand (const CString strOriginalCommand,
     // break up auto-say string into a list, terminated by newlines
     CStringList strList;
     StringToList (strFullCommand, ENDLINE, strList);
-    pDoc->m_bEnableAutoSay = false; // disable to prevent loop
-
-    // disable command stacking
-    unsigned short bSaveCommandStack = pDoc->m_enable_command_stack;
-    pDoc->m_enable_command_stack = false;
+    CValueStateGuard<unsigned short> autoSayGuard
+      (pDoc->m_bEnableAutoSay, false); // disable to prevent loop
+    CValueStateGuard<unsigned short> commandStackGuard
+      (pDoc->m_enable_command_stack, false);
 
     for (POSITION command_pos = strList.GetHeadPosition (); command_pos; )
       {
@@ -684,7 +682,8 @@ void CSendView::SendCommand (const CString strOriginalCommand,
         {
         // evaluate aliases, speed walking, command stacking etc.
 
-        pDoc->m_iExecutionDepth = 0;    // hand-typed command, assume depth zero
+        CValueStateGuard<int> executionDepthGuard
+          (pDoc->m_iExecutionDepth, 0); // hand-typed command
 
         // execution is now done separately :)
 
@@ -706,16 +705,14 @@ void CSendView::SendCommand (const CString strOriginalCommand,
         }
       }
 
-    pDoc->m_bEnableAutoSay = true; // re-enable it
-    pDoc->m_enable_command_stack = bSaveCommandStack; // re-enable it
-
     } // end of auto say
   else
     {  // not auto-say
 
     // evaluate aliases, speed walking, command stacking etc.
 
-    pDoc->m_iExecutionDepth = 0;    // hand-typed command, assume depth zero
+    CValueStateGuard<int> executionDepthGuard
+      (pDoc->m_iExecutionDepth, 0); // hand-typed command
 
     // execution is now done separately :)
 
@@ -773,6 +770,8 @@ void CSendView::SendMacro (int whichone)
 
 // send the command in the appropriate way
 
+  try
+    {
   switch (pDoc->m_macro_type [whichone])
   {
   case REPLACE_COMMAND: 
@@ -789,9 +788,11 @@ void CSendView::SendMacro (int whichone)
 
   case SEND_NOW:        
 
-        pDoc->m_iCurrentActionSource = eUserMacro;
+        {
+        CValueStateGuard<unsigned short> actionSourceGuard
+          (pDoc->m_iCurrentActionSource, eUserMacro);
         SendCommand (pDoc->m_macros [whichone], TRUE, ! pDoc->m_bDoNotAddMacrosToCommandHistory);
-        pDoc->m_iCurrentActionSource = eUnknownActionSource;
+        }
         break;
 
   case ADD_TO_COMMAND:  
@@ -802,6 +803,13 @@ void CSendView::SendMacro (int whichone)
   default:              
         break;  // do nothing
   } // end of switch
+    }
+  catch (...)
+    {
+    if (IsWorldDocumentLive (pDoc, iDocumentNumber))
+      pDoc->m_bEnableAutoSay = bSavedAutoSay;
+    throw;
+    }
 
 // restore auto-say
 
@@ -1056,8 +1064,8 @@ ASSERT_VALID(pDoc);
 
 // turn auto-say off, they obviously don't want to say west, examine, etc.
 
-  BOOL bSavedAutoSay = pDoc->m_bEnableAutoSay;
-  pDoc->m_bEnableAutoSay = FALSE;
+  CValueStateGuard<unsigned short> autoSayGuard
+    (pDoc->m_bEnableAutoSay, FALSE);
 
 const char * sValues [eKeypad_Max_Items] =
   {
@@ -1112,17 +1120,13 @@ int iIndex = -1;
     {
     if (pDoc->m_keypad_enable)
       {
-      pDoc->m_iCurrentActionSource = eUserKeypad;
+      CValueStateGuard<unsigned short> actionSourceGuard
+        (pDoc->m_iCurrentActionSource, eUserKeypad);
       SendCommand (pDoc->m_keypad [iIndex], TRUE, FALSE);    // do not keep in history window
-      pDoc->m_iCurrentActionSource = eUnknownActionSource;
       }
     else
       GetEditCtrl().ReplaceSel (sValues [iIndex], TRUE);
     }
-
-// restore auto-say
-
-  pDoc->m_bEnableAutoSay = bSavedAutoSay;
 
   return TRUE;
 
@@ -2055,6 +2059,8 @@ CString strCurrent;
 
 //save old config
 bool old_bTabCompletionSpace = pDoc->m_bTabCompletionSpace;
+CValueStateGuard<unsigned short> tabCompletionSpaceGuard
+  (pDoc->m_bTabCompletionSpace, pDoc->m_bTabCompletionSpace);
 
   // find where cursor is
   

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -2761,6 +2761,8 @@ void CSendView::OnAcceleratorCommand (UINT nID)
   if (sCommand.empty ())
     return;
 
+  CWorldDocumentOperationGuard operationGuard (pDoc);
+
 // turn auto-say off, they obviously don't want to say west, QUIT, etc.
 
   CValueStateGuard<unsigned short> autoSayGuard

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -1226,6 +1226,7 @@ ASSERT_VALID(pDoc);
 
   if (!m_bNotifyingPluginCommandChanged)      // don't recurse
     {
+    CWorldDocumentOperationGuard operationGuard (pDoc);
     CBoolStateGuard notifyGuard (m_bNotifyingPluginCommandChanged, true);
     pDoc->SendToAllPluginCallbacks (ON_PLUGIN_COMMAND_CHANGED);
     }

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -336,6 +336,7 @@ ASSERT_VALID(pDoc);
 	if (nChar == VK_RETURN)
   	{
 
+    CWorldDocumentOperationGuard operationGuard (pDoc);
     CValueStateGuard<unsigned short> actionSourceGuard
       (pDoc->m_iCurrentActionSource, eUserTyping);
 
@@ -618,6 +619,7 @@ void CSendView::SendCommand (const CString strOriginalCommand,
 	CMUSHclientDoc* pDoc = GetDocument();
 	ASSERT_VALID(pDoc);
 
+  CWorldDocumentOperationGuard operationGuard (pDoc);
   pDoc->m_bOmitFromCommandHistory = false;    // don't omit it yet
 
   // auto-say only applies when you actually type something, so I removed it 
@@ -765,6 +767,8 @@ void CSendView::SendMacro (int whichone)
   // ignore empty macros
   if (pDoc->m_macros [whichone].IsEmpty ())
     return;
+
+  CWorldDocumentOperationGuard operationGuard (pDoc);
 
 // turn auto-say off, they obviously don't want to say west, QUIT, etc.
 
@@ -1068,6 +1072,7 @@ ASSERT_VALID(pDoc);
 
 // turn auto-say off, they obviously don't want to say west, examine, etc.
 
+  CWorldDocumentOperationGuard operationGuard (pDoc);
   CValueStateGuard<unsigned short> autoSayGuard
     (pDoc->m_bEnableAutoSay, FALSE);
 
@@ -2224,6 +2229,7 @@ int nEndChar;
 CString strCurrent;
 
 //save old config
+CWorldDocumentOperationGuard operationGuard (pDoc);
 bool old_bTabCompletionSpace = pDoc->m_bTabCompletionSpace;
 CValueStateGuard<unsigned short> tabCompletionSpaceGuard
   (pDoc->m_bTabCompletionSpace, pDoc->m_bTabCompletionSpace);

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -333,6 +333,7 @@ ASSERT_VALID(pDoc);
 
 	if (nChar == VK_RETURN)
   	{
+
     CValueStateGuard<unsigned short> actionSourceGuard
       (pDoc->m_iCurrentActionSource, eUserTyping);
 
@@ -671,6 +672,7 @@ void CSendView::SendCommand (const CString strOriginalCommand,
     StringToList (strFullCommand, ENDLINE, strList);
     CValueStateGuard<unsigned short> autoSayGuard
       (pDoc->m_bEnableAutoSay, false); // disable to prevent loop
+    // disable command stacking
     CValueStateGuard<unsigned short> commandStackGuard
       (pDoc->m_enable_command_stack, false);
 
@@ -683,7 +685,7 @@ void CSendView::SendCommand (const CString strOriginalCommand,
         // evaluate aliases, speed walking, command stacking etc.
 
         CValueStateGuard<int> executionDepthGuard
-          (pDoc->m_iExecutionDepth, 0); // hand-typed command
+          (pDoc->m_iExecutionDepth, 0); // hand-typed command, assume depth zero
 
         // execution is now done separately :)
 
@@ -712,7 +714,7 @@ void CSendView::SendCommand (const CString strOriginalCommand,
     // evaluate aliases, speed walking, command stacking etc.
 
     CValueStateGuard<int> executionDepthGuard
-      (pDoc->m_iExecutionDepth, 0); // hand-typed command
+      (pDoc->m_iExecutionDepth, 0); // hand-typed command, assume depth zero
 
     // execution is now done separately :)
 

--- a/tests/check_world_callback_lifetime.py
+++ b/tests/check_world_callback_lifetime.py
@@ -1,4 +1,4 @@
-"""Test world retention in extracted chat and script-reload callbacks.
+"""Test world retention in callback and script execution paths.
 
 Requires Python 3 and clang++. Uses ASan/UBSan and MFC/socket stubs.
 The fixture delivers close requests during callbacks and drains deferred closes
@@ -37,6 +37,42 @@ def main():
             return subprocess.check_output(
                 ['git', '-C', str(ROOT), 'show', f'{args.revision}:{path}'], text=True)
         return (ROOT / path).read_text()
+
+    def require_before(body, first, second, label):
+        first_position = body.find(first)
+        second_position = body.find(second)
+        if first_position < 0 or second_position < 0 or first_position > second_position:
+            raise ValueError(f'{label}: required guard order is missing')
+
+    mushview = read('mushview.cpp')
+    context_menu = block(mushview, 'void CMUSHView::OnContextMenu(')
+    require_before(context_menu, 'CWorldDocumentOperationGuard operationGuard (pDoc);',
+                   'CValueStateGuard<int> actionGuard', 'OnContextMenu')
+    if context_menu.count('if (nCommand && !pDoc->m_bWorldClosePending)') != 2:
+        raise ValueError('OnContextMenu: close-pending checks are missing')
+
+    scriptengine = read('scripting/scriptengine.cpp')
+    for signature in ('bool CScriptEngine::Execute (', 'bool CScriptEngine::Parse ('):
+        require_before(block(scriptengine, signature),
+                       'CWorldDocumentOperationGuard operationGuard (m_pDoc);',
+                       'CPluginCallGuard callGuard', signature)
+
+    lua = read('scripting/lua_scripting.cpp')
+    require_before(block(lua, 'bool CScriptEngine::ParseLua ('),
+                   'CWorldDocumentOperationGuard operationGuard (m_pDoc);',
+                   'CPluginCallGuard callGuard', 'ParseLua')
+    execute_lua_blocks = []
+    offset = 0
+    signature = 'bool CScriptEngine::ExecuteLua ('
+    while (start := lua.find(signature, offset)) >= 0:
+        function = block(lua[start:], signature)
+        execute_lua_blocks.append(function)
+        offset = start + len(function)
+    if len(execute_lua_blocks) != 2:
+        raise ValueError(f'Expected two ExecuteLua overloads, found {len(execute_lua_blocks)}')
+    for index, function in enumerate(execute_lua_blocks, 1):
+        require_before(function, 'CWorldDocumentOperationGuard operationGuard (m_pDoc);',
+                       'CPluginCallGuard callGuard', f'ExecuteLua overload {index}')
 
     chat = read('chatsock.cpp')
     doc = read('doc.cpp')

--- a/tests/check_world_callback_lifetime.py
+++ b/tests/check_world_callback_lifetime.py
@@ -76,6 +76,15 @@ def main():
 
     chat = read('chatsock.cpp')
     doc = read('doc.cpp')
+    require_before(block(doc, 'void CMUSHclientDoc::SendTo ('),
+                   'CWorldDocumentOperationGuard operationGuard (this);',
+                   'switch (iWhere)', 'SendTo')
+
+    miniwindows = read('scripting/methods/methods_miniwindows.cpp')
+    require_before(block(miniwindows, 'BSTR CMUSHclientDoc::WindowMenu('),
+                   'CWorldDocumentOperationGuard operationGuard (this);',
+                   'it->second->Menu', 'WindowMenu')
+
     stdafx = read('stdafx.h')
     functions = '\n\n'.join([
         *(block(doc, signature) for signature in [

--- a/tests/check_world_callback_lifetime.py
+++ b/tests/check_world_callback_lifetime.py
@@ -90,11 +90,14 @@ def main():
 
     if not args.skip_mutations:
         chat_guard = '  CWorldDocumentOperationGuard operationGuard (m_pDoc);'
+        execute_guard = 'CWorldDocumentOperationGuard executeOperationGuard (this);'
         script_guard = '  CWorldDocumentOperationGuard operationGuard (this);'
         inner_guard = '    CValueStateGuard<int> executionDepthGuard (m_pDoc->m_iExecutionDepth, 0);'
         no_chat_guard = replace_once(source, chat_guard, '')
         mutants = [
-            ('remove_chat_guard', no_chat_guard, 'chat', 'world retained during command'),
+            ('remove_execute_guard', replace_once(source, execute_guard, ''),
+                'execute', 'world retained during command'),
+            ('remove_chat_guard', no_chat_guard, 'chat', 'world retained after command'),
             ('move_chat_guard_to_command', replace_once(no_chat_guard, inner_guard,
                 chat_guard + '\n' + inner_guard), 'chat', 'world retained after command'),
             ('remove_script_guard', replace_once(source, script_guard, ''),

--- a/tests/world_callback_lifetime.cpp.in
+++ b/tests/world_callback_lifetime.cpp.in
@@ -106,7 +106,7 @@ struct State {
     bool worldDestroyed=false,chatDestroyed=false,throwCommand=false,throwReload=false;
     bool throwPrompt=false,closeDuringCommand=true,closeDuringPrompt=true;
     int commands=0,afterCommands=0,disabled=0,created=0,prompts=0,answer=IDYES;
-    int commandNotes=0,closeRequests=0,completedCommands=0;
+    int commandNotes=0,closeRequests=0,completedCommands=0,expectedExecutionDepth=1;
 };
 State* state=nullptr;
 struct CDocument {
@@ -256,7 +256,7 @@ void CMUSHclientDoc::CleanupTick() {
 }
 void ScriptEngine::Parse(const CString&,const char*) {
     ++state->commands;
-    CHECK(doc->m_iExecutionDepth==1,"remote execution depth reset");
+    CHECK(doc->m_iExecutionDepth==state->expectedExecutionDepth,"execution depth set for command source");
     CHECK(doc->m_CurrentPlugin==nullptr,"Execute clears current plugin");
     if(state->closeDuringCommand)ExpectRetained(doc,"world retained during command");
     if(commandHook)commandHook(doc);
@@ -288,6 +288,21 @@ void Finish() {
     if(App.documentClose || App.frameClose)App.Drain();
     else App.doc->OnCloseDocument();
     CHECK(state->worldDestroyed,"world closes after callback returns");
+}
+void ExecuteCases() {
+    for(bool throughFrame:{false,true})for(bool throws:{false,true}) {
+        State s;Reset(s);closeThroughFrame=throughFrame;s.throwCommand=throws;
+        s.expectedExecutionDepth=8;
+        bool caught=false;
+        try { CHECK(App.doc->Execute("/test")==eOK,"direct command returns success"); }
+        catch(const std::runtime_error& error) {
+            caught=true;CHECK(string(error.what())=="command callback failure","direct command preserves original exception");
+        }
+        CHECK(caught==throws,"direct command exception propagates");
+        CHECK(s.commands==1 && s.completedCommands==(throws?0:1),"direct command runs once");
+        Finish();
+    }
+    std::puts("PASS: direct Execute retains state through close requests and exceptions");
 }
 string Packet(int protocol,int command,const string& payload) {
     if(protocol==eChatMudMaster)return string(1,static_cast<char>(command))+payload+static_cast<char>(CHAT_END_OF_COMMAND);
@@ -369,7 +384,7 @@ void TimerCases() {
         if(outerOperation)outer=std::make_unique<CWorldDocumentOperationGuard>(doc);
         commandHook=[&](CMUSHclientDoc* current) {
             CHECK(current==doc,"command uses its owning world");
-            CHECK(doc->m_iActiveProgressOperations==1+outerOperation,"receive guard nests in prior operation");
+            CHECK(doc->m_iActiveProgressOperations==2+outerOperation,"execute guard nests in receive and prior operations");
             CHECK(doc->ChatDisconnect(11)==eOK,"command disconnects its own chat");
             CHECK(active->m_bDeleteMe && active->m_iChatStatus==eChatClosed,"real OnClose marks the active chat");
             CHECK(doc->GetChatSocket(11)==nullptr && doc->ChatDisconnect(11)==eChatIDNotFound,
@@ -380,7 +395,7 @@ void TimerCases() {
             // Model a modal script callback that dispatches a timer while Parse is active.
             {
                 CWorldDocumentOperationGuard nested(doc);
-                CHECK(doc->m_iActiveProgressOperations==2+outerOperation,"nested operation depth retained");
+                CHECK(doc->m_iActiveProgressOperations==3+outerOperation,"nested operation depth retained");
                 const int before=doc->timerContinuations;
                 doc->CleanupTick();
                 CHECK(!activeDeleted,"marked chat survives modal timer cleanup");
@@ -393,7 +408,7 @@ void TimerCases() {
                 CHECK(otherSecondDeleted && !otherLiveDeleted,"other world next tick cleans remaining marked chat");
                 CHECK(other->timerContinuations==2,"other world timer work continues on each tick");
             }
-            CHECK(doc->m_iActiveProgressOperations==1+outerOperation,"inner guard restores prior operation depth");
+            CHECK(doc->m_iActiveProgressOperations==2+outerOperation,"inner guard restores execute operation depth");
             doc->CleanupTick();
             CHECK(!activeDeleted && !markedDeleted,"receive guard retains marked chats after inner scope");
             CHECK(doc->timerContinuations==2,"timer work continues after inner scope");
@@ -435,6 +450,7 @@ void TimerCases() {
     std::puts("PASS: timer cleanup retains active chat, preserves other worlds and timer work, and deletes on later ticks after return or throw");
 }
 int main(int argc,char** argv) {
+    if(argc==1 || string(argv[1])=="execute")ExecuteCases();
     if(argc==1 || string(argv[1])=="chat")ChatCases();
     if(argc==1 || string(argv[1])=="script")ScriptCases();
     if(argc==1 || string(argv[1])=="timer")TimerCases();


### PR DESCRIPTION
Restore auto-say, command stacking, action source, and execution depth after typed commands, macros, keypad commands, and tab completion. Preserve the existing macro history behavior.

Related change set: #6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing commands, macros, keypad actions, keyboard shortcuts, scripts, and plugins, including when operations are interrupted.
  * Application state is now restored correctly after these actions, including when an error occurs.
  * Improved handling of automatic speech, command execution, tab completion, and tracing after interrupted or failed actions.
  * Improved document and world handling during commands, callbacks, sound playback, simulations, and close requests.
  * Prevented interrupted or failed actions from leaving subsequent input behavior in an inconsistent state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->