### PR TITLE
Check XML Unicode conversion before publishing text

### DIFF
--- a/tests/check_xml_unicode.py
+++ b/tests/check_xml_unicode.py
@@ -26,7 +26,7 @@ def run(args, output):
     cpp.write_text(template.replace('// PRODUCTION_PROBE', probe).replace('// PRODUCTION_BUILD', build))
     binary = output / 'xml_unicode.exe'
     subprocess.run([args.compiler, '-std=c++17', '-Wall', '-Wextra', '-Werror',
-                    '-O1', '-static', str(cpp), '-o', str(binary)], check=True)
+                    '-O1', '-static', '-D_WIN32_WINNT=0x0501', '-DWINVER=0x0501', str(cpp), '-o', str(binary)], check=True)
     command = ([args.runner] if args.runner else []) + [str(binary), args.case]
     subprocess.run(command, check=True)
 

--- a/tests/check_xml_unicode.py
+++ b/tests/check_xml_unicode.py
@@ -1,0 +1,47 @@
+"""Run extracted XML conversion code with the Windows API.
+
+Use a MinGW C++ compiler. On a non-Windows host, pass --runner with a Wine
+executable path and set WINEPREFIX to a test prefix. MFC storage, file access,
+exceptions, and ProcessNode use substitutes; text conversion calls WideCharToMultiByte.
+"""
+import argparse
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def run(args, output):
+    root = Path(__file__).resolve().parents[1]
+    def read(path):
+        if args.source_ref:
+            return subprocess.check_output(['git', 'show', args.source_ref + ':' + path], cwd=root, text=True)
+        return (root / path).read_text()
+    serializer = read('xml/xml_serialize.cpp')
+    parser = read('xml/xmlparse.cpp')
+    probe = serializer[serializer.index('#define COMPARE_MEMORY'):serializer.index('void SeeIfBase64')]
+    start = parser.index('void CXMLparser::BuildStructure (')
+    build = parser[start:parser.index('// end of CXMLparser::BuildStructure', start)]
+    template = (root / 'tests/xml_unicode.cpp.in').read_text()
+    cpp = output / 'xml_unicode.cpp'
+    cpp.write_text(template.replace('// PRODUCTION_PROBE', probe).replace('// PRODUCTION_BUILD', build))
+    binary = output / 'xml_unicode.exe'
+    subprocess.run([args.compiler, '-std=c++17', '-Wall', '-Wextra', '-Werror',
+                    '-O1', '-static', str(cpp), '-o', str(binary)], check=True)
+    command = ([args.runner] if args.runner else []) + [str(binary), args.case]
+    subprocess.run(command, check=True)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--compiler', default='x86_64-w64-mingw32-g++')
+    parser.add_argument('--runner')
+    parser.add_argument('--source-ref')
+    parser.add_argument('--case', choices=['all', 'odd', 'surrogates', 'preservation'], default='all')
+    parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=True)
+        run(args, args.output)
+    else:
+        with tempfile.TemporaryDirectory(prefix='xml-unicode-') as path:
+            run(args, Path(path))

--- a/tests/xml_unicode.cpp.in
+++ b/tests/xml_unicode.cpp.in
@@ -1,0 +1,135 @@
+// Calls WideCharToMultiByte. MFC storage and parser publication are substitutes.
+#define NOMINMAX
+#include <windows.h>
+#include <algorithm>
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <cctype>
+
+class CString {
+  std::string value;
+public:
+  CString() = default;
+  CString(const char* p) : value(p) {}
+  CString(const std::string& p) : value(p) {}
+  char* GetBuffer(size_t count) { value.resize(count + 1, '\0'); return value.data(); }
+  void ReleaseBuffer(size_t count) { assert(count < value.size()); value.resize(count); }
+  operator const char*() const { return value.c_str(); }
+  char operator[](size_t i) const { assert(i <= value.size()); return value[i]; }
+  CString Mid(size_t i) const { return value.substr(i); }
+  void Replace(char old, char next) { std::replace(value.begin(), value.end(), old, next); }
+};
+class CFile {
+  std::string bytes;
+public:
+  size_t pos = 0;
+  explicit CFile(const std::string& data) : bytes(data) {}
+  UINT GetLength() const { return static_cast<UINT>(bytes.size()); }
+  const char* GetFilePath() const { return "test.xml"; }
+  UINT Read(char* dest, UINT count) {
+    count = std::min(count, static_cast<UINT>(bytes.size() - pos));
+    std::memcpy(dest, bytes.data() + pos, count); pos += count; return count;
+  }
+  void SeekToBegin() { pos = 0; }
+};
+struct CArchive { CFile* file; CFile* GetFile() { return file; } };
+[[noreturn]] void ThrowErrorException(const char* message, ...) {
+  char buffer[256]; va_list args; va_start(args, message);
+  std::vsnprintf(buffer, sizeof buffer, message, args); va_end(args);
+  throw std::runtime_error(buffer);
+}
+static unsigned conversionCalls = 0;
+int CountedConversion(UINT cp, DWORD flags, LPCWSTR text, int units,
+                      LPSTR out, int size, LPCSTR fallback, LPBOOL used) {
+  ++conversionCalls;
+  return ::WideCharToMultiByte(cp, flags, text, units, out, size, fallback, used);
+}
+#define WideCharToMultiByte CountedConversion
+#define NUMITEMS(a) (static_cast<int>(sizeof(a) / sizeof((a)[0])))
+#define MAX_XML_DOCUMENT_SIZE 20000000
+UINT iLineLastItemFound = 0;
+struct CXMLparser {
+  UINT m_xmlLength = 0;
+  CString m_strxmlBuffer;
+  const char* m_xmlBuff = nullptr;
+  int m_xmlRoot = 0;
+  unsigned published = 0;
+  std::string text;
+  void BuildStructure(CFile* file);
+  void ProcessNode(int&) { ++published; text = m_xmlBuff; }
+};
+void SeeIfBase64(CString& text) { assert(std::strchr(text, '<')); }
+// PRODUCTION_PROBE
+// PRODUCTION_BUILD
+
+static unsigned cases = 0;
+void require(bool value, const char* message) {
+  if (!value) throw std::runtime_error(message);
+}
+std::string utf16(const std::u16string& value) {
+  std::string result("\xff\xfe", 2);
+  for (char16_t c : value) { result += static_cast<char>(c & 255); result += static_cast<char>(c >> 8); }
+  return result;
+}
+void accepted(const std::string& bytes, const std::string& expected) {
+  CFile file(bytes); CXMLparser parser; parser.BuildStructure(&file);
+  require(parser.published == 1 && parser.text == expected, "Valid input changed"); ++cases;
+}
+void rejected(const std::string& bytes, unsigned expectedCalls) {
+  CFile file(bytes); CXMLparser parser; conversionCalls = 0; bool failed = false;
+  try { parser.BuildStructure(&file); }
+  catch (const std::runtime_error&) { failed = true; }
+  require(failed, "Malformed UTF-16 reached parsing");
+  require(parser.published == 0, "Malformed input was published");
+  require(conversionCalls == expectedCalls, "Unexpected conversion work before rejection"); ++cases;
+}
+int main(int argc, char** argv) {
+  try {
+    const std::string selection = argc > 1 ? argv[1] : "all";
+    if (selection == "all" || selection == "odd") {
+      // Every possible trailing byte must be rejected, including zero.
+      for (int c = 0; c != 256; ++c)
+        rejected(utf16(u"<variables></variables>") + static_cast<char>(c), 0);
+      rejected(std::string("\xff\xfe<", 3), 0);
+    }
+    if (selection == "all" || selection == "surrogates") {
+      for (char16_t c : {char16_t(0xd800), char16_t(0xdbff), char16_t(0xdc00), char16_t(0xdfff)}) {
+        rejected(utf16(u"<variables>" + std::u16string(1, c) + u"</variables>"), 1);
+        rejected(utf16(u"<variables></variables>" + std::u16string(1, c)), 1);
+      }
+      rejected(utf16(u"<variables>" + std::u16string({0xdc00, 0xd800}) + u"</variables>"), 1);
+    }
+    if (selection == "all" || selection == "preservation") {
+      accepted("<variables></variables>", "<variables></variables>");
+      accepted(std::string("\xef\xbb\xbf") + "<variables></variables>", "<variables></variables>");
+      accepted(utf16(u"<variables>\u754c\U0001f600</variables>"), "<variables>\xe7\x95\x8c\xf0\x9f\x98\x80</variables>");
+      accepted(utf16(u"<variables>\ufffd</variables>"), "<variables>\xef\xbf\xbd</variables>");
+      accepted(utf16(u"<variables>\t</variables>"), "<variables> </variables>");
+      rejected("", 0);
+      rejected(std::string("\xff\xfe", 2), 1);
+      // A valid pair starts at byte 496, across the 498-byte probe boundary.
+      const auto input = utf16(u"<!--" + std::u16string(243, u'a') + u"\U0001f600--><variables></variables>");
+      require(static_cast<unsigned char>(input[496]) == 0x3d && static_cast<unsigned char>(input[498]) == 0x00, "Boundary fixture changed");
+      CFile file(input); CArchive archive{&file};
+      require(IsArchiveXML(archive), "A split surrogate pair hid valid XML");
+      require(file.pos == 0, "XML probe did not restore the archive");
+      accepted(input, "<!--" + std::string(243, 'a') + "\xf0\x9f\x98\x80--><variables></variables>");
+      std::vector<wchar_t> prefix(248);
+      std::memcpy(prefix.data(), input.data() + 2, 496);
+      SetLastError(0);
+      require(::WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, prefix.data(), 248, nullptr, 0, nullptr, nullptr) == 0,
+              "Strict probe control did not reject the split pair");
+      require(GetLastError() == ERROR_NO_UNICODE_TRANSLATION, "Unexpected strict probe error");
+      ++cases;
+    }
+    std::printf("PASS %s: %u cases\n", selection.c_str(), cases);
+    return 0;
+  } catch (const std::exception& error) {
+    std::fprintf(stderr, "FAIL: %s\n", error.what()); return 1;
+  }
+}

--- a/tests/xml_unicode.cpp.in
+++ b/tests/xml_unicode.cpp.in
@@ -1,6 +1,10 @@
 // Calls WideCharToMultiByte. MFC storage and parser publication are substitutes.
 #define NOMINMAX
 #include <windows.h>
+// Match the Windows SDK flag exposure for the project's XP target.
+#ifdef WC_ERR_INVALID_CHARS
+#undef WC_ERR_INVALID_CHARS
+#endif
 #include <algorithm>
 #include <cassert>
 #include <cstdarg>
@@ -99,16 +103,18 @@ int main(int argc, char** argv) {
     }
     if (selection == "all" || selection == "surrogates") {
       for (char16_t c : {char16_t(0xd800), char16_t(0xdbff), char16_t(0xdc00), char16_t(0xdfff)}) {
-        rejected(utf16(u"<variables>" + std::u16string(1, c) + u"</variables>"), 1);
-        rejected(utf16(u"<variables></variables>" + std::u16string(1, c)), 1);
+        rejected(utf16(u"<variables>" + std::u16string(1, c) + u"</variables>"), 0);
+        rejected(utf16(u"<variables></variables>" + std::u16string(1, c)), 0);
       }
-      rejected(utf16(u"<variables>" + std::u16string({0xdc00, 0xd800}) + u"</variables>"), 1);
+      rejected(utf16(u"<variables>" + std::u16string({0xdc00, 0xd800}) + u"</variables>"), 0);
     }
     if (selection == "all" || selection == "preservation") {
       accepted("<variables></variables>", "<variables></variables>");
       accepted(std::string("\xef\xbb\xbf") + "<variables></variables>", "<variables></variables>");
       accepted(utf16(u"<variables>\u754c\U0001f600</variables>"), "<variables>\xe7\x95\x8c\xf0\x9f\x98\x80</variables>");
       accepted(utf16(u"<variables>\ufffd</variables>"), "<variables>\xef\xbf\xbd</variables>");
+      accepted(utf16(u"<variables>\U00010000</variables>"), "<variables>\xf0\x90\x80\x80</variables>");
+      accepted(utf16(u"<variables>\U0010ffff</variables>"), "<variables>\xf4\x8f\xbf\xbf</variables>");
       accepted(utf16(u"<variables>\t</variables>"), "<variables> </variables>");
       rejected("", 0);
       rejected(std::string("\xff\xfe", 2), 1);
@@ -121,8 +127,10 @@ int main(int argc, char** argv) {
       accepted(input, "<!--" + std::string(243, 'a') + "\xf0\x9f\x98\x80--><variables></variables>");
       std::vector<wchar_t> prefix(248);
       std::memcpy(prefix.data(), input.data() + 2, 496);
+      // WC_ERR_INVALID_CHARS is hidden by the XP target headers.
+      const DWORD strictConversion = 0x00000080;
       SetLastError(0);
-      require(::WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, prefix.data(), 248, nullptr, 0, nullptr, nullptr) == 0,
+      require(::WideCharToMultiByte(CP_UTF8, strictConversion, prefix.data(), 248, nullptr, 0, nullptr, nullptr) == 0,
               "Strict probe control did not reject the split pair");
       require(GetLastError() == ERROR_NO_UNICODE_TRANSLATION, "Unexpected strict probe error");
       ++cases;

--- a/xml/xml_serialize.cpp
+++ b/xml/xml_serialize.cpp
@@ -103,8 +103,8 @@ bool IsArchiveXML (CArchive& ar)
 
   // auto-detect XML files
 
-  char buf [500],     // should be even number of bytes in case Unicode
-       buf2 [500];
+  char buf [500];     // should be even number of bytes in case Unicode
+  CString strProbe;
 
   memset (buf, 0, sizeof (buf));
   ar.GetFile ()->Read (buf, sizeof (buf) - 2);   // allow for Unicode 00 00
@@ -113,20 +113,35 @@ bool IsArchiveXML (CArchive& ar)
   // look for Unicode (FF FE)
   if ((unsigned char) buf [0] == 0xFF &&
       (unsigned char) buf [1] == 0xFE)
-    WideCharToMultiByte (CP_UTF8, 0, (LPCWSTR) &buf [2], -1, buf2, sizeof buf2, NULL, NULL);
+    {
+    int iLength = WideCharToMultiByte (CP_UTF8, 0, (LPCWSTR) &buf [2], -1,
+                                       NULL, 0, NULL, NULL);
+    if (iLength <= 0)
+      return false;
+
+    char * pBuffer = strProbe.GetBuffer (iLength);
+    int iConverted = WideCharToMultiByte (CP_UTF8, 0, (LPCWSTR) &buf [2], -1,
+                                          pBuffer, iLength, NULL, NULL);
+    if (iConverted != iLength)
+      {
+      strProbe.ReleaseBuffer (0);
+      return false;
+      }
+    strProbe.ReleaseBuffer (iLength - 1);
+    }
   else
     // look for UTF-8 indicator bytes (EF BB BF)
     if ((unsigned char) buf [0] == 0xEF &&
         (unsigned char) buf [1] == 0xBB &&
         (unsigned char) buf [2] == 0xBF)
-      strcpy (buf2, &buf [3]);   // skip them
+      strProbe = &buf [3];   // skip them
   else 
-    strcpy (buf2, buf);
+    strProbe = buf;
 
-  char * p = buf2;
+  const char * p = strProbe;
 
   // skip leading whitespace
-  while (isspace (*p))
+  while (isspace ((unsigned char) *p))
     p++;
 
   // can't see them squeezing much into less than 15 chars

--- a/xml/xmlparse.cpp
+++ b/xml/xmlparse.cpp
@@ -195,11 +195,20 @@ void CXMLparser::BuildStructure (CFile * file)
     // find required buffer length
     int length = WideCharToMultiByte (CP_UTF8, 0, (LPCWSTR) q, (m_xmlLength - 2) / 2, 
                     NULL, 0, NULL, NULL);
+    if (length <= 0)
+      ThrowErrorException ("Could not convert Unicode XML file");
+
     // make a new string with enough length to hold it
     char * p = buf2.GetBuffer (length);
     // convert it
-    WideCharToMultiByte (CP_UTF8, 0, (LPCWSTR) q, (m_xmlLength - 2) / 2, 
-              p, length, NULL, NULL);
+    int iConverted = WideCharToMultiByte (CP_UTF8, 0, (LPCWSTR) q,
+                                          (m_xmlLength - 2) / 2,
+                                          p, length, NULL, NULL);
+    if (iConverted != length)
+      {
+      buf2.ReleaseBuffer (0);
+      ThrowErrorException ("Could not convert Unicode XML file");
+      }
     buf2.ReleaseBuffer (length);
     // copy to our buffer
     m_strxmlBuffer = buf2;

--- a/xml/xmlparse.cpp
+++ b/xml/xmlparse.cpp
@@ -189,19 +189,22 @@ void CXMLparser::BuildStructure (CFile * file)
   if ((unsigned char) m_strxmlBuffer [0] == 0xFF &&
       (unsigned char) m_strxmlBuffer [1] == 0xFE)
     {
+    if ((m_xmlLength - 2) % 2 != 0)
+      ThrowErrorException ("Unicode XML file ends with an incomplete character");
+
     CString buf2;
     const char * q =  m_strxmlBuffer;
     q += 2; // skip indicator bytes
     // find required buffer length
-    int length = WideCharToMultiByte (CP_UTF8, 0, (LPCWSTR) q, (m_xmlLength - 2) / 2, 
-                    NULL, 0, NULL, NULL);
+    int length = WideCharToMultiByte (CP_UTF8, WC_ERR_INVALID_CHARS, (LPCWSTR) q,
+                                       (m_xmlLength - 2) / 2, NULL, 0, NULL, NULL);
     if (length <= 0)
       ThrowErrorException ("Could not convert Unicode XML file");
 
     // make a new string with enough length to hold it
     char * p = buf2.GetBuffer (length);
     // convert it
-    int iConverted = WideCharToMultiByte (CP_UTF8, 0, (LPCWSTR) q,
+    int iConverted = WideCharToMultiByte (CP_UTF8, WC_ERR_INVALID_CHARS, (LPCWSTR) q,
                                           (m_xmlLength - 2) / 2,
                                           p, length, NULL, NULL);
     if (iConverted != length)

--- a/xml/xmlparse.cpp
+++ b/xml/xmlparse.cpp
@@ -195,17 +195,34 @@ void CXMLparser::BuildStructure (CFile * file)
     CString buf2;
     const char * q =  m_strxmlBuffer;
     q += 2; // skip indicator bytes
+    const WCHAR * pWide = (LPCWSTR) q;
+    const int iCharacters = (m_xmlLength - 2) / 2;
+
+    // Validate surrogate pairs without newer Windows conversion flags.
+    for (int i = 0; i < iCharacters; i++)
+      {
+      if (pWide [i] >= 0xD800 && pWide [i] <= 0xDBFF)
+        {
+        if (i + 1 == iCharacters ||
+            pWide [i + 1] < 0xDC00 || pWide [i + 1] > 0xDFFF)
+          ThrowErrorException ("Could not convert Unicode XML file");
+        i++; // skip the low surrogate of this valid pair
+        }
+      else if (pWide [i] >= 0xDC00 && pWide [i] <= 0xDFFF)
+        ThrowErrorException ("Could not convert Unicode XML file");
+      }
+
     // find required buffer length
-    int length = WideCharToMultiByte (CP_UTF8, WC_ERR_INVALID_CHARS, (LPCWSTR) q,
-                                       (m_xmlLength - 2) / 2, NULL, 0, NULL, NULL);
+    int length = WideCharToMultiByte (CP_UTF8, 0, pWide,
+                                       iCharacters, NULL, 0, NULL, NULL);
     if (length <= 0)
       ThrowErrorException ("Could not convert Unicode XML file");
 
     // make a new string with enough length to hold it
     char * p = buf2.GetBuffer (length);
     // convert it
-    int iConverted = WideCharToMultiByte (CP_UTF8, WC_ERR_INVALID_CHARS, (LPCWSTR) q,
-                                          (m_xmlLength - 2) / 2,
+    int iConverted = WideCharToMultiByte (CP_UTF8, 0, pWide,
+                                          iCharacters,
                                           p, length, NULL, NULL);
     if (iConverted != length)
       {


### PR DESCRIPTION
Check Unicode conversion sizes and results and keep conversion buffers under ownership until the converted XML text is complete.

Related change set: #6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Unicode XML content, including UTF-16 and UTF-8 encoded documents.
  * Added validation for failed or incomplete text conversions to prevent processing invalid XML.
  * Improved whitespace handling for text containing non-ASCII characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->