### PR TITLE
Retain XML nodes until insertion succeeds

### DIFF
--- a/xml/xmlparse.cpp
+++ b/xml/xmlparse.cpp
@@ -533,27 +533,24 @@ UINT iFirstLine = m_xmlLine;
       {     // not a declaration, must be an ordinary element
 
       // time to create a new element
-      CXMLelement * pElement = new CXMLelement;
-
-      if (!pElement)
-        ThrowErrorException ("Could not allocate memory for XML parsing of element %s",
-                              (LPCTSTR) strName);
+      std::unique_ptr<CXMLelement> pElement (new CXMLelement);
 
       // remember its name
       pElement->strName = strPrefix + strName;
       pElement->iLine = iLine;
 
-      parent.ChildrenList.AddTail (pElement);    // add to parent's list of children
+      parent.ChildrenList.AddTail (pElement.get ());    // add to parent's list of children
+      CXMLelement * pPublishedElement = pElement.release ();
 
       // OK, we have a new sibling for our parent, let's see if it has any attributes ...
 
-      ProcessAttributes (*pElement);  // process its attributes
+      ProcessAttributes (*pPublishedElement);  // process its attributes
 
       // hmm - we have now got something like <blah> ...
       // drop down to find children for it - unless 'empty' element
 
-      if (!pElement->bEmpty)
-        ProcessNode (*pElement);
+      if (!pPublishedElement->bEmpty)
+        ProcessNode (*pPublishedElement);
 
       }   // end of non-declaration
     } // end of processing buffer
@@ -766,11 +763,8 @@ CString strValue;
 
     strValue = GetValue ("attribute", strName);
 
-    pAttribute = new CAttribute;
-
-    if (!pAttribute)
-      ThrowErrorException ("Could not allocate memory for XML parsing of attribute %s",
-                            (LPCTSTR) strName);
+    std::unique_ptr<CAttribute> newAttribute (new CAttribute);
+    pAttribute = newAttribute.get ();
 
     pAttribute->strName = strName;
     pAttribute->strValue = ReplaceEntities (strValue);
@@ -778,6 +772,7 @@ CString strValue;
 
     // add to map
     node.AttributeMap.SetAt (strName, pAttribute);
+    newAttribute.release ();
 
     } // end of looking for attributes
 


### PR DESCRIPTION
Keep new XML elements and attributes under local ownership until their parent containers accept them.

Related change set: #6.
