### PR TITLE
Restore command window Automation IDs

### DIFF
--- a/doc.cpp
+++ b/doc.cpp
@@ -628,8 +628,8 @@ BEGIN_DISPATCH_MAP(CMUSHclientDoc, CDocument)
 	DISP_PROPERTY_PARAM(CMUSHclientDoc, "CustomColourBackground", GetCustomColourBackground, SetCustomColourBackground, VT_I4, VTS_I2)
 	DISP_FUNCTION(CMUSHclientDoc, "GetCommandCursorPosition", GetCommandCursorPosition, VT_I4, VTS_NONE)
 	DISP_FUNCTION(CMUSHclientDoc, "GetCommandLineCount", GetCommandLineCount, VT_I4, VTS_NONE)
-	DISP_FUNCTION(CMUSHclientDoc, "GetCommandWindowDesiredHeight", GetCommandWindowDesiredHeight, VT_I4, VTS_I4)
 	DISP_FUNCTION(CMUSHclientDoc, "SetCommandWindowAutoResizeSuppressed", SetCommandWindowAutoResizeSuppressed, VT_I4, VTS_BOOL)
+	DISP_FUNCTION(CMUSHclientDoc, "GetCommandWindowDesiredHeight", GetCommandWindowDesiredHeight, VT_I4, VTS_I4)
 	//}}AFX_DISPATCH_MAP
 END_DISPATCH_MAP()
 


### PR DESCRIPTION
Keep SetCommandWindowAutoResizeSuppressed at dispatch ID 421 and append GetCommandWindowDesiredHeight as ID 422. This makes runtime dispatch match the type library and preserves existing Automation callers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered internal automation dispatch entries without changing functionality, behavior, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->