### PR TITLE
Keep hotspot recursion state alive through callbacks

### DIFF
--- a/miniwindow.cpp
+++ b/miniwindow.cpp
@@ -29,7 +29,7 @@ CMiniWindow::CMiniWindow ()  :
           m_FlagsOnMouseDown (0),
           m_ZOrder (0),
           m_bExecutingScript (false),
-          m_bAddingHotspot (false)
+          m_pAddingHotspot (new bool (false))
   {
   pdc = new CDC;
   pdc->CreateCompatibleDC(NULL);

--- a/miniwindow.h
+++ b/miniwindow.h
@@ -114,7 +114,7 @@ class CMiniWindow
   long    m_FlagsOnMouseDown;     // which mouse-down we got
   long    m_ZOrder;               // Z-order. If zero, use name order. Lower is drawn earlier.
   bool    m_bExecutingScript;      // so windows don't delete themselves
-  bool    m_bAddingHotspot;        // prevent recursive hotspot creation in this window
+  std::shared_ptr<bool> m_pAddingHotspot;        // prevent recursive hotspot creation in this window
 
   string  m_sCallbackPlugin;      // plugin we are using
   string  m_sCreatingPlugin;      // plugin that created the miniwindow

--- a/scripting/methods/methods_miniwindows.cpp
+++ b/scripting/methods/methods_miniwindows.cpp
@@ -570,11 +570,14 @@ long CMUSHclientDoc::WindowAddHotspot(LPCTSTR Name,
 
   CMiniWindow * mw = it->second;
 
+  // Callbacks can delete this window before the recursion guard returns.
+  std::shared_ptr<bool> addingHotspot = mw->m_pAddingHotspot;
+
   // don't recurse into infinite loops
-  if (mw->m_bAddingHotspot)
+  if (*addingHotspot)
     return eItemInUse;
 
-  CBoolStateGuard addingHotspotGuard (mw->m_bAddingHotspot, true);
+  CBoolStateGuard addingHotspotGuard (*addingHotspot, true);
 
   string sPluginID;
 


### PR DESCRIPTION
Keep each miniwindow's hotspot recursion state alive until WindowAddHotspot returns. Mouse callbacks can then delete or replace the window without leaving the state guard with a reference to freed memory, while same-window recursion and existing deletion rules remain unchanged.
