### PR TITLE
Resume command history searches after reopening

### DIFF
--- a/Finding.cpp
+++ b/Finding.cpp
@@ -63,8 +63,11 @@ bool NotFound (CFindInfo & FindInfo)
 bool FindRoutine (const CObject * pObject,       // passed back to callback routines
                   CFindInfo & FindInfo,          // details about find
                   const InitiateSearch pInitiateSearch, // how to re-initiate a find
-                  const GetNextLine pGetNextLine)
+                  const GetNextLine pGetNextLine,
+                  bool * pCancelled)
   {
+if (pCancelled)
+  *pCancelled = false;
 CFindDlg dlg (FindInfo.m_strFindStringList);
 
 
@@ -83,7 +86,11 @@ CFindDlg dlg (FindInfo.m_strFindStringList);
     dlg.m_bRegexp     = FindInfo.m_bRegexp;
 
     if (dlg.DoModal () != IDOK)
+      {
+      if (pCancelled)
+        *pCancelled = true;
       return false;
+      }
 
     FindInfo.m_bMatchCase    = dlg.m_bMatchCase;
     FindInfo.m_bForwards     = dlg.m_bForwards;

--- a/dialogs/cmdhist.cpp
+++ b/dialogs/cmdhist.cpp
@@ -27,6 +27,8 @@ CCmdHistory::CCmdHistory(CWnd* pParent /*=NULL*/)
   m_pDoc = NULL;
   m_iDocumentNumber = 0;
   m_hSendView = NULL;
+  m_iHistoryDiscarded = 0;
+  m_nSnapshotLines = 0;
 }
 
 
@@ -68,9 +70,13 @@ int count = 0;
    pList->SetRedraw (FALSE);
    pList->ResetContent ();
    m_msgListSnapshot.RemoveAll ();
+   m_HistoryLineNumbers.clear ();
+   m_iHistoryDiscarded = m_sendview->m_iHistoryDiscarded;
+   m_nSnapshotLines = m_msgList->GetCount ();
 
   CString str;
   POSITION pos = m_msgList->GetHeadPosition ();
+  long iLine = 0;
 
   while (pos)
     {
@@ -89,11 +95,24 @@ int count = 0;
     nItem = pList->AddString(strDisplay);  // add to list (truncate to 500 chars)
     if (nItem != LB_ERR  && nItem != LB_ERRSPACE)
       {
+      m_HistoryLineNumbers.push_back (iLine);
       POSITION itemPos = m_msgListSnapshot.AddTail (str);
       pList->SetItemData (nItem, (DWORD) itemPos);
       count++;
       }
+    ++iLine;
     }
+
+   // Resume from the saved line, including when a list-box row was not added.
+   vector<long>::const_iterator resume = std::lower_bound (
+       m_HistoryLineNumbers.begin (), m_HistoryLineNumbers.end (),
+       m_pHistoryFindInfo->m_nCurrentLine);
+   m_HistoryFindInfo.m_nCurrentLine =
+       static_cast<long> (resume - m_HistoryLineNumbers.begin ());
+   if (m_HistoryFindInfo.m_bForwards &&
+       (resume == m_HistoryLineNumbers.end () ||
+        *resume != m_pHistoryFindInfo->m_nCurrentLine))
+     --m_HistoryFindInfo.m_nCurrentLine;
 
    pList->SetCurSel(count - 1);
    pList->SetRedraw (TRUE);
@@ -213,9 +232,6 @@ if (!IsContextLive ())
 m_HistoryFindInfo.m_bAgain = bAgain &&
     !m_HistoryFindInfo.m_strFindStringList.IsEmpty ();
 m_HistoryFindInfo.m_nTotalLines = m_msgListSnapshot.GetCount ();
-int selection = pList->GetCurSel ();
-if (selection != LB_ERR)
-  m_HistoryFindInfo.m_nCurrentLine = selection;
 
 // Find Next can use saved settings before this dialog has compiled the pattern.
 if (bAgain && m_HistoryFindInfo.m_bRegexp &&
@@ -224,10 +240,12 @@ if (bAgain && m_HistoryFindInfo.m_bRegexp &&
       (m_HistoryFindInfo.m_bMatchCase ? 0 : PCRE_CASELESS) |
       (m_HistoryFindInfo.m_bUTF8 ? PCRE_UTF8 : 0));
 
+bool bCancelled = false;
 bool found = FindRoutine (&m_msgListSnapshot,    // passed back to callback routines
                           m_HistoryFindInfo,     // finding structure
                           InitiateSearch,        // how to re-initiate a find
-                          GetNextLine);          // get the next line
+                          GetNextLine,           // get the next line
+                          &bCancelled);
 
 // FindRoutine can process messages that close the world or destroy the send view.
 if (!IsContextLive ())
@@ -238,6 +256,22 @@ if (!IsContextLive ())
 
 m_HistoryFindInfo.m_pFindPosition = NULL;
 CopyFindSettings (*m_pHistoryFindInfo, m_HistoryFindInfo);
+
+// Map the snapshot result back to history after any eviction or clear.
+if (!bCancelled)
+  {
+  long iLine = m_HistoryFindInfo.m_nCurrentLine;
+  if (iLine >= static_cast<long> (m_HistoryLineNumbers.size ()))
+    iLine = m_nSnapshotLines;
+  else if (iLine >= 0)
+    iLine = m_HistoryLineNumbers [iLine];
+  const unsigned __int64 iDiscarded =
+      m_sendview->m_iHistoryDiscarded - m_iHistoryDiscarded;
+  if (iDiscarded)
+    iLine = iLine <= 0 || iDiscarded >= static_cast<unsigned __int64> (iLine)
+        ? 0 : iLine - static_cast<long> (iDiscarded);
+  m_pHistoryFindInfo->m_nCurrentLine = iLine;
+  }
 
 // Get the control again after the nested message loops.
 pList = (CListBox*) GetDlgItem (IDC_COMMANDS);

--- a/dialogs/cmdhist.h
+++ b/dialogs/cmdhist.h
@@ -12,6 +12,9 @@ public:
 
   CStringList * m_msgList;
   CStringList m_msgListSnapshot;
+  vector<long> m_HistoryLineNumbers;
+  unsigned __int64 m_iHistoryDiscarded;
+  long m_nSnapshotLines;
   CSendView * m_sendview;
   std::shared_ptr<CFindInfo> m_pHistoryFindInfo;
   CFindInfo m_HistoryFindInfo;

--- a/scripting/methods/methods_commands.cpp
+++ b/scripting/methods/methods_commands.cpp
@@ -228,6 +228,7 @@ void CMUSHclientDoc::DeleteCommandHistory()
 		  CSendView* pmyView = (CSendView*)pView;
 
       // OK, do it ...
+      pmyView->m_iHistoryDiscarded += pmyView->m_msgList.GetCount ();
       pmyView->m_msgList.RemoveAll ();
       pmyView->m_HistoryPosition = NULL;
       pmyView->m_iHistoryStatus = eAtBottom;

--- a/sendvw.cpp
+++ b/sendvw.cpp
@@ -273,6 +273,7 @@ CSendView::CSendView()
 {
   m_HistoryPosition = NULL;
   m_inputcount = 0;
+  m_iHistoryDiscarded = 0;
   m_pHistoryFindInfo->m_strTitle = "Find in command history...";
   m_iHistoryStatus = eAtBottom;
   m_backbr = NULL;
@@ -2160,6 +2161,7 @@ void CSendView::OnDisplayClearCommandHistory()
                     return;
 
   // OK, do it ...
+  m_iHistoryDiscarded += m_msgList.GetCount ();
 	m_msgList.RemoveAll ();
   m_HistoryPosition = NULL;
   m_iHistoryStatus = eAtBottom;
@@ -2439,6 +2441,7 @@ ASSERT_VALID(pDoc);
       if (m_pHistoryFindInfo->m_pFindPosition == oldHead)
         m_pHistoryFindInfo->m_pFindPosition = NULL;
       m_msgList.RemoveHead ();   // keep max of "m_nHistoryLines" previous commands
+      ++m_iHistoryDiscarded;
       m_pHistoryFindInfo->m_nCurrentLine--;     // adjust for a "find again"
       if (m_pHistoryFindInfo->m_nCurrentLine < 0)
         m_pHistoryFindInfo->m_nCurrentLine = 0;

--- a/sendvw.h
+++ b/sendvw.h
@@ -34,6 +34,7 @@ public:
 	CStringList m_msgList;
   CString m_last_command;
   long m_inputcount;
+  unsigned __int64 m_iHistoryDiscarded;
   POSITION m_HistoryPosition;
   int m_iHistoryStatus;   // see enum above
   CMUSHView * m_topview;

--- a/stdafx.h
+++ b/stdafx.h
@@ -316,7 +316,8 @@ typedef void (*InitiateSearch) (const CObject * pObject,
 bool FindRoutine (const CObject * pObject,       // passed back to callback routines
                   CFindInfo & FindInfo,          // details about find
                   const InitiateSearch pInitiateSearch, // how to re-initiate a find
-                  const GetNextLine pGetNextLine);
+                  const GetNextLine pGetNextLine,
+                  bool * pCancelled = NULL);
 
 
 // find-and-replace for strings


### PR DESCRIPTION
Keep the saved search position when command history closes and reopens. Map snapshot results back to live history after eviction or clearing, and preserve the saved position when Find is canceled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Find behavior in the command-history dialog when older entries have been cleared or automatically discarded.
  - Searches now resume from the appropriate command-history position and return to the correct matching entry.
  - Cancelling a search no longer causes the history selection to be remapped unexpectedly.
  - Improved consistency when searching within a command-history snapshot while new entries are added or older entries are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->