### PR TITLE
Update LuaCOM component unregistration

### DIFF
--- a/luacom/luacom.cpp
+++ b/luacom/luacom.cpp
@@ -1023,6 +1023,47 @@ static void luacom_DelRegKey(const char * key)
   CHK_LCOM_ERR(tCOMUtil::DelRegKey(key, NULL), message.c_str());
 }
 
+// Several coclasses can share one type library registration.
+static HRESULT luacom_UnRegisterTypeLib(const TLIBATTR& attributes)
+{
+  const wchar_t* platform = NULL;
+  switch(attributes.syskind)
+  {
+    case SYS_WIN16: platform = L"win16"; break;
+    case SYS_WIN32: platform = L"win32"; break;
+    case SYS_WIN64: platform = L"win64"; break;
+    default: return E_INVALIDARG;
+  }
+
+  wchar_t guid[40];
+  if(!StringFromGUID2(attributes.guid, guid, sizeof(guid) / sizeof(guid[0])))
+    return E_INVALIDARG;
+
+  wchar_t key[100];
+  _snwprintf(key, sizeof(key) / sizeof(key[0]),
+             L"TypeLib\\%ls\\%x.%x\\%lx\\%ls", guid,
+             static_cast<unsigned>(attributes.wMajorVerNum),
+             static_cast<unsigned>(attributes.wMinorVerNum),
+             static_cast<unsigned long>(attributes.lcid), platform);
+
+  // Check the exact version, locale and platform, without COM lookup fallbacks.
+  HKEY registration = NULL;
+  LONG status = RegOpenKeyExW(HKEY_CLASSES_ROOT, key, 0, KEY_QUERY_VALUE,
+                              &registration);
+  if(status == ERROR_FILE_NOT_FOUND || status == ERROR_PATH_NOT_FOUND)
+    return S_OK;
+  if(status != ERROR_SUCCESS)
+    return HRESULT_FROM_WIN32(status);
+
+  status = RegCloseKey(registration);
+  if(status != ERROR_SUCCESS)
+    return HRESULT_FROM_WIN32(status);
+
+  return UnRegisterTypeLib(attributes.guid, attributes.wMajorVerNum,
+                            attributes.wMinorVerNum, attributes.lcid,
+                            attributes.syskind);
+}
+
 static int luacom_RegisterObject(lua_State *L)
 {
   if(lua_type(L, 1) != LUA_TTABLE && lua_type(L,1) != LUA_TUSERDATA)
@@ -1324,9 +1365,7 @@ static int luacom_UnRegisterObject(lua_State *L)
       CHK_COM_CODE(typelib->GetLibAttr(&plibattr));
       CHK_LCOM_ERR(plibattr, "Type library attributes are unavailable.");
 
-      hr = UnRegisterTypeLib(plibattr->guid, plibattr->wMajorVerNum,
-                             plibattr->wMinorVerNum, plibattr->lcid,
-                             plibattr->syskind);
+      hr = luacom_UnRegisterTypeLib(*plibattr);
 
       typelib->ReleaseTLibAttr(plibattr);
       CHK_COM_CODE(hr);

--- a/luacom/readme.txt
+++ b/luacom/readme.txt
@@ -1,5 +1,5 @@
 LuaCOM source: https://github.com/fiendish/luacom
-Revision: 96f9e5bfacd8aec6c5e98d85e55854188eba7412
+Revision: af855b4f03f45185e44629c28fee34edf536c08e
 
 Copy the files from src/library and include/luacom.h into this directory.
 Copy COPYRIGHT to ../licences/LuaCOM licence.txt.
@@ -15,3 +15,5 @@ Local changes in luacom.cpp:
 
 3. In luacom_StartMessageLoop, reject the call when the mushclient_embedded
    registry flag is set. MUSHclient uses its own message loop.
+
+Whitespace-only cleanup is also retained in LuaCompat.cpp and luacom5.lua.

--- a/luacom/readme.txt
+++ b/luacom/readme.txt
@@ -15,5 +15,3 @@ Local changes in luacom.cpp:
 
 3. In luacom_StartMessageLoop, reject the call when the mushclient_embedded
    registry flag is set. MUSHclient uses its own message loop.
-
-Whitespace-only cleanup is also retained in LuaCompat.cpp and luacom5.lua.


### PR DESCRIPTION
Update vendored LuaCOM so removing one component does not prevent cleanup of another component that shares its type library. Retain the existing embedding adjustments and whitespace cleanup. The source revision is from https://github.com/fiendish/luacom/pull/3; merge that upstream PR first.
