### PR TITLE
Preserve output and MXP state across nested callbacks

### DIFF
--- a/Line.cpp
+++ b/Line.cpp
@@ -37,6 +37,7 @@ CLine::CLine (const long nLineNumber,
   m_iPreambleOffset = 0;
   m_theTime = CTime::GetCurrentTime(); 
   QueryPerformanceCounter (&m_lineHighPerformanceTime);
+  nCreationNumber = App.GetUniqueNumber ();
   m_nLineNumber = nLineNumber;
 
   if (bUnicode)
@@ -56,14 +57,27 @@ CLine::CLine (const long nLineNumber,
     AfxThrowMemoryException ();
   flags = 0;      // no special flags yet (ie. normal output line)
 
-  CStyle * pStyle; 
+  try
+    {
+    std::unique_ptr<CStyle> pStyle (NEWSTYLE);
+    pStyle->iFlags = iFlags;
+    pStyle->iForeColour = iForeColour;
+    pStyle->iBackColour = iBackColour;
 
-  // have at least one style item in the list
-  styleList.AddTail (pStyle = NEWSTYLE);
-
-  pStyle->iFlags = iFlags;
-  pStyle->iForeColour = iForeColour;
-  pStyle->iBackColour = iBackColour;
+    // have at least one style item in the list
+    styleList.AddTail (pStyle.get ());
+    pStyle.release ();
+    }
+  catch (...)
+    {
+#ifdef USE_REALLOC
+    free (text);
+#else
+    delete [] text;
+#endif
+    text = NULL;
+    throw;
+    }
 
   }   // end of CLine::CLine
 
@@ -86,11 +100,33 @@ CLine::~CLine ()
 
   }
 
+void CLine::ResizeText (const int iNewSize)
+  {
+  ASSERT (iNewSize >= len);
+
+#ifdef USE_REALLOC
+  char * pNewText = (char *) realloc (text, iNewSize);
+  if (!pNewText)
+    AfxThrowMemoryException ();
+#else
+  char * pNewText = new char [iNewSize];
+  if (!pNewText)
+    AfxThrowMemoryException ();
+  memcpy (pNewText, text, len);
+  delete [] text;
+#endif
+
+  text = pNewText;
+  iMemoryAllocated = iNewSize;
+  } // end of CLine::ResizeText
+
 // for tracking down style allocation errors
 
 CStyle * GetNewStyle (const char * filename, const long linenumber)
   {
   CStyle * pNewStyle = new CStyle;
+  pNewStyle->nCreationNumber = App.GetUniqueNumber ();
+  pNewStyle->nRangeCreationNumber = pNewStyle->nCreationNumber;
   TRACE3 ("new CStyle at %p at file %s line %ld\n",
           pNewStyle,
           filename,

--- a/OtherTypes.h
+++ b/OtherTypes.h
@@ -282,12 +282,18 @@ class CStyle : public CObject
   COLORREF       iBackColour; // RGB background colour, or ANSI/custom colour number
   CAction *      pAction;     // what action, if any this item carries out
                               //  - also stores variables  
+  __int64        nCreationNumber; // immutable identity for this style instance
+  __int64        nRangeCreationNumber; // identity shared by split style fragments
+  __int64        nOutputAppendCreationNumber; // transactional append owner
   CStyle () 
     { 
     iForeColour = WHITE;
     iBackColour = BLACK;
     iLength = iFlags = 0; 
     pAction = NULL;
+    nCreationNumber = 0;
+    nRangeCreationNumber = 0;
+    nOutputAppendCreationNumber = 0;
     };   // constructor
 
   ~CStyle () 
@@ -326,6 +332,7 @@ class CLine : public CObject
   CStyleList styleList; // list of styles applying to text, see above
   CTime m_theTime;      // time this line arrived
   LARGE_INTEGER m_lineHighPerformanceTime;  
+  __int64 nCreationNumber;        // immutable identity for this line instance
   int iMemoryAllocated; // size of buffer allocated for "text"
 
   long m_nLineNumber;
@@ -339,6 +346,7 @@ class CLine : public CObject
          const bool bUnicode 
          );   // constructor
   ~CLine ();    // destructor
+  void ResizeText (const int iNewSize);
 
   };
 
@@ -929,17 +937,105 @@ class CActiveTag :public CObject
   CString strName;    // name of tag we opened
   bool    bSecure;    // was it secure mode at the time?  
   bool    bNoReset;   // protected from reset?
+  __int64 nCreationNumber; // immutable identity for this active tag
+  __int64 nOpeningStyleCreationNumber; // exact opening marker for this tag
+  __int64 nOpeningLineCreationNumber; // line that held the opening marker
+  __int64 nFallbackLineCreationNumber; // line containing a replacement content boundary
+  __int64 nFallbackStyleRangeNumber; // replacement boundary after destructive output changes
+  vector<int> closeActions; // close plan selected when the tag opened
+  unsigned short iOpeningFlags; // style to restore if scrollback prunes the marker
+  COLORREF iOpeningForeColour;
+  COLORREF iOpeningBackColour;
+  CAction * pOpeningAction;
+  CString strVariable;
+  bool bOpeningInParagraph;
+  bool bOpeningPreMode;
+  bool bOpeningMXPScript;
+  int iOpeningListMode;
+  int iOpeningListCount;
+  __int64 iOpeningParagraphOwner;
+  __int64 iOpeningPreOwner;
+  __int64 iOpeningScriptOwner;
+  __int64 iOpeningListOwner;
 
   CActiveTag () 
     { 
     bSecure = false;
     bNoReset = false;
+    nCreationNumber = 0;
+    nOpeningStyleCreationNumber = 0;
+    nOpeningLineCreationNumber = 0;
+    nFallbackLineCreationNumber = 0;
+    nFallbackStyleRangeNumber = 0;
+    iOpeningFlags = 0;
+    iOpeningForeColour = WHITE;
+    iOpeningBackColour = BLACK;
+    pOpeningAction = NULL;
+    bOpeningInParagraph = false;
+    bOpeningPreMode = false;
+    bOpeningMXPScript = false;
+    iOpeningListMode = 0;
+    iOpeningListCount = 0;
+    iOpeningParagraphOwner = 0;
+    iOpeningPreOwner = 0;
+    iOpeningScriptOwner = 0;
+    iOpeningListOwner = 0;
     }; // constructor
 
+  ~CActiveTag ()
+    {
+    if (pOpeningAction)
+      pOpeningAction->Release ();
+    }
 
   };
 
 typedef CTypedPtrList <CPtrList, CActiveTag*> CActiveTagList;
+
+struct CPreparedMXPClose
+  {
+  CPreparedMXPClose () :
+    bHaveVariable (false),
+    iActiveTagCreationNumber (0),
+    iFirstContentLineCreationNumber (0),
+    bOpeningInParagraph (false),
+    bOpeningPreMode (false),
+    bOpeningMXPScript (false),
+    iOpeningListMode (0),
+    iOpeningListCount (0),
+    iOpeningParagraphOwner (0),
+    iOpeningPreOwner (0),
+    iOpeningScriptOwner (0),
+    iOpeningListOwner (0) {}
+  CString strTag;
+  CString strText;
+  CString strVariable;
+  bool bHaveVariable;
+  __int64 iActiveTagCreationNumber;
+  __int64 iFirstContentLineCreationNumber;
+  bool bOpeningInParagraph;
+  bool bOpeningPreMode;
+  bool bOpeningMXPScript;
+  int iOpeningListMode;
+  int iOpeningListCount;
+  __int64 iOpeningParagraphOwner;
+  __int64 iOpeningPreOwner;
+  __int64 iOpeningScriptOwner;
+  __int64 iOpeningListOwner;
+  vector<int> closeActions;
+  set<__int64> contentStyleRangeNumbers;
+  };
+
+struct CDeferredMXPMessage
+  {
+  CDeferredMXPMessage (const int level,
+                       const long number,
+                       const CString & message) :
+    iLevel (level), iMessageNumber (number), strMessage (message) { }
+  int iLevel;
+  long iMessageNumber;
+  CString strMessage;
+  };
 
 // for storing map directions, and inverses of them
 class CMapDirection

--- a/ProcessPreviousLine.cpp
+++ b/ProcessPreviousLine.cpp
@@ -32,22 +32,39 @@ static inline unsigned short get_style (int style)
 
 // shared stuff for logging in colour
 
-void CMUSHclientDoc::LogLineInHTMLcolour (POSITION startpos)
+void CMUSHclientDoc::LogLineInHTMLcolour (POSITION startpos,
+                                        const map<__int64, int> * pLineLengths)
   {
    COLORREF prevcolour = NO_COLOUR;
    bool bInSpan = false;
    COLORREF lastforecolour = 0;
    COLORREF lastbackcolour = 0;
 
+   if (pLineLengths && pLineLengths->empty ())
+     return;
+
    for (POSITION pos = startpos; pos; )
    {
    CLine * pLine = m_LineList.GetNext (pos);
+   // Callback output after the captured paragraph is outside this log entry.
+   if (pLineLengths &&
+       pLine->nCreationNumber > pLineLengths->rbegin ()->first)
+     break;
+   int iLineLength = pLine->len;
+   if (pLineLengths)
+     {
+     map<__int64, int>::const_iterator saved =
+       pLineLengths->find (pLine->nCreationNumber);
+     if (saved == pLineLengths->end ())
+       continue;
+     iLineLength = MIN (iLineLength, saved->second);
+     }
 
    if (!pLine->styleList.IsEmpty ())
      {
 
       int iCol = 0;
-      CString strLine = CString (pLine->text, pLine->len);
+      CString strLine = CString (pLine->text, iLineLength);
 
       for (POSITION style_pos = pLine->styleList.GetHeadPosition(); style_pos; )
         {
@@ -56,7 +73,9 @@ void CMUSHclientDoc::LogLineInHTMLcolour (POSITION startpos)
 
         CStyle * pStyle = pLine->styleList.GetNext (style_pos);
 
-        int iLength = pStyle->iLength;
+        if (iCol >= iLineLength)
+          break;
+        int iLength = MIN (static_cast<int> (pStyle->iLength), iLineLength - iCol);
 
         // ignore zero length styles
         if (iLength <= 0)
@@ -134,6 +153,29 @@ void CMUSHclientDoc::LogLineInHTMLcolour (POSITION startpos)
   } // end of  CMUSHclientDoc::LogLineInHTMLcolour
 
 
+// Resolve the original paragraph without keeping list positions across callbacks.
+static vector<CLine *> ResolveTriggerLines (
+  CMUSHclientDoc * pDoc,
+  const vector<CMUSHclientDoc::CTriggerLineSnapshot> & triggerLines)
+  {
+  vector<CLine *> lines (triggerLines.size (), NULL);
+  map<__int64, size_t> remaining;
+  for (size_t i = 0; i < triggerLines.size (); ++i)
+    remaining [triggerLines [i].iCreationNumber] = i;
+  for (POSITION pos = pDoc->m_LineList.GetTailPosition ();
+       pos && !remaining.empty (); )
+    {
+    CLine * pLine = pDoc->m_LineList.GetPrev (pos);
+    map<__int64, size_t>::iterator it = remaining.find (pLine->nCreationNumber);
+    if (it != remaining.end ())
+      {
+      lines [it->second] = pLine;
+      remaining.erase (it);
+      }
+    }
+  return lines;
+  }
+
 // here when a newline is reached - process triggers etc. for the previous line
 // (ie. the current one, the one just ended)
 // returns true if omitting from output
@@ -147,6 +189,8 @@ int iLineCount = 0;
 
 CString strCurrentLine;   // we will assemble the full line here
 CPaneLine StyledLine;     // and here, with style information
+vector<CTriggerLineSnapshot> triggerLines;
+const __int64 iParagraphGeneration = m_iOutputGeneration;
 /*
 
 New technique - we are going to scan *completed* lines for triggers. We know
@@ -207,6 +251,11 @@ assemble the full text of the original line.
   for (pos = prevpos; pos; )
    {
    CLine * pLine = m_LineList.GetNext (pos);
+   CTriggerLineSnapshot snapshot;
+   snapshot.iCreationNumber = pLine->nCreationNumber;
+   snapshot.iColumn = strCurrentLine.GetLength ();
+   snapshot.iLength = pLine->len;
+   triggerLines.push_back (snapshot);
    CString strLine = CString (pLine->text, pLine->len);
    strCurrentLine += strLine;
 
@@ -543,6 +592,7 @@ assemble the full text of the original line.
 
   m_sRecentLines.push_back ((const char *) strCurrentLine);
   m_newlines_received++;
+  const long iParagraphReceivedNumber = m_newlines_received;
 
   // too many? remove oldest one
   if (m_sRecentLines.size () > MAX_RECENT_LINES)
@@ -612,7 +662,7 @@ assemble the full text of the original line.
         ProcessOneTriggerSequence (strCurrentLine, 
                                    StyledLine, 
                                    strResponse, 
-                                   prevpos, 
+                                   triggerLines,
                                    bNoLog, 
                                    m_bLineOmittedFromOutput,
                                    bChangedColour, 
@@ -631,7 +681,7 @@ assemble the full text of the original line.
       ProcessOneTriggerSequence (strCurrentLine, 
                              StyledLine, 
                              strResponse, 
-                             prevpos, 
+                             triggerLines,
                              bNoLog, 
                              m_bLineOmittedFromOutput,
                              bChangedColour, 
@@ -658,7 +708,7 @@ assemble the full text of the original line.
         ProcessOneTriggerSequence (strCurrentLine, 
                                    StyledLine, 
                                    strResponse, 
-                                   prevpos, 
+                                   triggerLines,
                                    bNoLog, 
                                    m_bLineOmittedFromOutput,
                                    bChangedColour, 
@@ -670,6 +720,29 @@ assemble the full text of the original line.
 
     m_CurrentPlugin = NULL; // not in a plugin any more
     } // if iBad <= 0
+
+  // Keep the original identity boundary for all post-trigger consumers.
+  map<__int64, int> paragraphLengths;
+  for (size_t i = 0; i < triggerLines.size (); ++i)
+    paragraphLengths [triggerLines [i].iCreationNumber] = triggerLines [i].iLength;
+
+  // Find the first surviving paragraph line for logging and omission as well.
+  // Callback-created lines are not a replacement for a deleted paragraph.
+  if (iParagraphGeneration != m_iOutputGeneration)
+    {
+    set<__int64> remaining;
+    for (size_t i = 0; i < triggerLines.size (); ++i)
+      remaining.insert (triggerLines [i].iCreationNumber);
+    prevpos = NULL;
+    for (POSITION scan = m_LineList.GetTailPosition ();
+         scan && !remaining.empty (); )
+      {
+      POSITION current = scan;
+      CLine * pLine = m_LineList.GetPrev (scan);
+      if (remaining.erase (pLine->nCreationNumber))
+        prevpos = current;
+      }
+    }
 
 // if we have changed the colour of this trigger, or omitted it from output,
 //        we must force an update or they won't see it
@@ -697,7 +770,11 @@ assemble the full text of the original line.
     {
     // remember that we want to log it (them), for retrospective logging
     for (pos = prevpos; pos; )
-      (m_LineList.GetNext (pos))->flags |= LOG_LINE;
+      {
+      CLine * pLine = m_LineList.GetNext (pos);
+      if (paragraphLengths.count (pLine->nCreationNumber))
+        pLine->flags |= LOG_LINE;
+      }
 
     // log it now?
     if (m_logfile && !m_bLogRaw) 
@@ -726,7 +803,7 @@ assemble the full text of the original line.
       CString strMessage = strCurrentLine;
       // fix up HTML sequences
       if (m_bLogHTML && m_bLogInColour)
-        LogLineInHTMLcolour (prevpos);
+        LogLineInHTMLcolour (prevpos, &paragraphLengths);
       // not colour - just straight HTML?
       else if (m_bLogHTML)
         WriteToLog (FixHTMLString (strMessage));
@@ -743,96 +820,120 @@ assemble the full text of the original line.
 
 // if omitting from output do that now
 
-  if (m_bLineOmittedFromOutput)
+  if (m_bLineOmittedFromOutput && prevpos)
     {
-
-  // delete all lines in this set
-    for (pos = m_LineList.GetTailPosition (); pos; )
-     {
-     // if this particular line was added to the line positions array, then make it null
-      if (m_LineList.GetCount () % JUMP_SIZE == 1)
-            m_pLinePositions [m_LineList.GetCount () / JUMP_SIZE] = NULL;
-
-      // version 4.54 - keep notes, even if omitted from output ;)
-      // version 4.72 - also player input
-
-      // we have to push_front because we are going through the lines backwards
-      // this means the newline goes first. Also we process the styles in reverse order.
-
-      CLine* pLine = m_LineList.GetTail ();
+    vector<POSITION> linesToDelete;
+    list<CPaneStyle> stagedOutstandingLines;
+    int iRecentLinesToRemove = 0;
+    CLine * pSurvivingCurrentLine = NULL;
+    POSITION scan = m_LineList.GetTailPosition ();
+    while (scan)
+      {
+      POSITION current = scan;
+      CLine * pLine = m_LineList.GetPrev (scan);
+      if (!paragraphLengths.count (pLine->nCreationNumber))
+        {
+        // Later callback output keeps its text, styles, actions, and identity.
+        if (!pSurvivingCurrentLine)
+          pSurvivingCurrentLine = pLine;
+        continue;
+        }
+      linesToDelete.push_back (current);
 
       if (pLine->flags & NOTE_OR_COMMAND)
         {
-       CString strLine = CString (pLine->text, pLine->len);
-       int iCol = 0;
+        CString strLine (pLine->text, pLine->len);
+        int iCol = 0;
+        if (pLine->hard_return)
+          stagedOutstandingLines.push_front (CPaneStyle (ENDLINE, 0, 0, 0));
 
-       // throw in the newline if required
-       if (pLine->hard_return)
-         m_OutstandingLines.push_front (CPaneStyle (ENDLINE, 0, 0, 0));
-
-       for (POSITION stylepos = pLine->styleList.GetTailPosition(); stylepos; )
-         {
-         CStyle * pStyle = pLine->styleList.GetPrev (stylepos);
-
-         COLORREF cText,
-                  cBack;
-
-         // find actual RGB colour of style
-         GetStyleRGB (pStyle, cText, cBack); 
-                          
-         m_OutstandingLines.push_front (CPaneStyle ((const char *)
-                              strLine.Mid (pLine->len -  pStyle->iLength - iCol, pStyle->iLength), 
-                              cText, cBack, pStyle->iFlags & 7));
-         iCol += pStyle->iLength; // new column
-         }     // end of each style
-
-
-        }  // end of coming across a note or command line
-      else
-        {  // must be an output line
-        // consider that this line is no longer a "recent line"
-        // if a trigger stopped all trigger evaluation.
-        // Suggested by Fiendish - version 5.06
-        if (m_iStopTriggerEvaluation == eStopEvaluatingTriggersInAllPlugins)
-          if (!m_sRecentLines.empty ())  // if sane to do so
-            m_sRecentLines.pop_back ();
+        for (POSITION stylepos = pLine->styleList.GetTailPosition ();
+             stylepos; )
+          {
+          CStyle * pStyle = pLine->styleList.GetPrev (stylepos);
+          COLORREF cText,
+                   cBack;
+          GetStyleRGB (pStyle, cText, cBack);
+          stagedOutstandingLines.push_front (
+            CPaneStyle ((const char *)
+              strLine.Mid (pLine->len - pStyle->iLength - iCol,
+                           pStyle->iLength),
+              cText,
+              cBack,
+              pStyle->iFlags & 7));
+          iCol += pStyle->iLength;
+          }
         }
+      else if (m_iStopTriggerEvaluation ==
+               eStopEvaluatingTriggersInAllPlugins)
+        iRecentLinesToRemove++;
 
-      delete pLine; // delete contents of tail iten -- version 3.85
-      m_LineList.RemoveTail ();   // get rid of the line
-      m_total_lines--;            // don't count as received
-
-      // if this was the first line, we have done enough
-      if (pos == prevpos)
-        break;    
-     m_LineList.GetPrev (pos);
-     }
-
-    // try to allow world.tells to span omitted lines
-    if (!m_LineList.IsEmpty ())
-      {
-      m_pCurrentLine = m_LineList.GetTail ();
-      if (((m_pCurrentLine->flags & COMMENT) == 0) ||
-          m_pCurrentLine->hard_return)
-          m_pCurrentLine = NULL;
+      if (current == prevpos)
+        break;
       }
+
+    if (!pSurvivingCurrentLine)
+      {
+      pSurvivingCurrentLine = scan ? m_LineList.GetAt (scan) : NULL;
+      if (pSurvivingCurrentLine &&
+          (((pSurvivingCurrentLine->flags & COMMENT) == 0) ||
+           pSurvivingCurrentLine->hard_return))
+        pSurvivingCurrentLine = NULL;
+      }
+
+    std::unique_ptr<CLine> pNewLine;
+    if (!pSurvivingCurrentLine)
+      {
+      pNewLine.reset (new CLine (m_total_lines -
+                                 static_cast<long> (linesToDelete.size ()) + 1,
+                                 m_nWrapColumn,
+                                 m_iFlags,
+                                 m_iForeColour,
+                                 m_iBackColour,
+                                 m_bUTF_8));
+      m_LineList.AddTail (pNewLine.get ());
+      }
+
+    m_iOutputGeneration++;
+    for (vector<POSITION>::const_iterator it = linesToDelete.begin ();
+         it != linesToDelete.end (); ++it)
+      {
+      CLine * pLine = m_LineList.GetAt (*it);
+      m_LineList.RemoveAt (*it);
+      delete pLine;
+      m_total_lines--;
+      }
+
+    const unsigned long iLaterLines =
+      static_cast<unsigned long> (m_newlines_received) -
+      static_cast<unsigned long> (iParagraphReceivedNumber);
+    while (iRecentLinesToRemove-- > 0 && m_sRecentLines.size () > iLaterLines)
+      m_sRecentLines.erase (m_sRecentLines.end () - iLaterLines - 1);
+
+    if (pSurvivingCurrentLine)
+      m_pCurrentLine = pSurvivingCurrentLine;
     else
-      m_pCurrentLine = NULL;
-
-    if (!m_pCurrentLine)
       {
-      // restart with a blank line at the end of the list
-      m_pCurrentLine = new CLine (++m_total_lines, 
-                                  m_nWrapColumn,
-                                  m_iFlags,
-                                  m_iForeColour,
-                                  m_iBackColour,
-                                  m_bUTF_8);
-      pos = m_LineList.AddTail (m_pCurrentLine);
-
-      if (m_LineList.GetCount () % JUMP_SIZE == 1)
-        m_pLinePositions [m_LineList.GetCount () / JUMP_SIZE] = pos;
+      m_pCurrentLine = pNewLine.release ();
+      m_total_lines++;
       }
+
+    for (int i = 0; i <= m_maxlines / JUMP_SIZE; i++)
+      m_pLinePositions [i] = NULL;
+    int iLine = 0;
+    for (pos = m_LineList.GetHeadPosition (); pos; iLine++)
+      {
+      POSITION current = pos;
+      CLine * pLine = m_LineList.GetNext (pos);
+      pLine->m_nLineNumber = m_total_lines - m_LineList.GetCount () + iLine + 1;
+      if (iLine % JUMP_SIZE == 0)
+        m_pLinePositions [iLine / JUMP_SIZE] = current;
+      }
+
+    m_OutstandingLines.splice (m_OutstandingLines.begin (),
+                               stagedOutstandingLines);
+
+    RefreshMXPMissingTagAnchors ();
 
     }
   else
@@ -1067,7 +1168,7 @@ assemble the full text of the original line.
 void CMUSHclientDoc::ProcessOneTriggerSequence (CString & strCurrentLine,
                                           CPaneLine & StyledLine,
                                           CString & strResponse,
-                                          const POSITION prevpos,
+                                          const vector<CTriggerLineSnapshot> & triggerLines,
                                           bool & bNoLog,
                                           bool & bNoOutput,
                                           bool & bChangedColour,
@@ -1082,7 +1183,8 @@ int iItem;
 CTrigger * trigger_item;
 int iStartCol,
     iEndCol;
-POSITION pos;
+vector<CLine *> outputLines = ResolveTriggerLines (this, triggerLines);
+__int64 iOutputGeneration = m_iOutputGeneration;
 
   for (iItem = 0; iItem < GetTriggerArray ().GetSize (); iItem++)
     {
@@ -1106,27 +1208,33 @@ POSITION pos;
 
     */
 
+      if (iOutputGeneration != m_iOutputGeneration)
+        {
+        outputLines = ResolveTriggerLines (this, triggerLines);
+        iOutputGeneration = m_iOutputGeneration;
+        }
+
       if (trigger_item->iMatch && !trigger_item->bMultiLine)
         {
         int iFlags = 0;
         COLORREF iForeColour = NO_COLOUR; 
         COLORREF iBackColour = NO_COLOUR; 
-        int iCurrentCol = 0;
-        for (pos = prevpos; pos; )  // scan to end of buffer
+        for (size_t line = 0; line < triggerLines.size (); ++line)
          {
-         CLine * pLine = m_LineList.GetNext (pos);
-         int iThisEnd = iCurrentCol + pLine->len;  // column this line ends at
-         if (iStartCol < iThisEnd)  // starting col is in this line
+         CLine * pLine = outputLines [line];
+         const CTriggerLineSnapshot & snapshot = triggerLines [line];
+         if (!pLine)
+           continue;
+         const int i = iStartCol - snapshot.iColumn;
+         if (i >= 0 && i < snapshot.iLength && i < pLine->len &&
+             pLine->text [i] == strCurrentLine [iStartCol])
            {
-           int i = iStartCol - iCurrentCol;
-           if (i < 0)
-             i = 0;
 
            CStyle * pStyle = NULL;
            int iStyleCol = 0;
      
            // find style run
-           for (pos = pLine->styleList.GetHeadPosition(); pos; )
+           for (POSITION pos = pLine->styleList.GetHeadPosition(); pos; )
              {
              pStyle = pLine->styleList.GetNext (pos);
              iStyleCol += pStyle->iLength;
@@ -1142,7 +1250,6 @@ POSITION pos;
              }
            break;                      // done
            }
-         iCurrentCol += pLine->len;   // next line starts where this left off
          }    // end of doing each line
 
 
@@ -1168,7 +1275,6 @@ POSITION pos;
             continue;   // wrong inverse
 
         } // end of some matching wanted
-
 
     // copy the wildcard contents to the clipboard, if required
 
@@ -1258,8 +1364,15 @@ POSITION pos;
           }
         }    // not doing after the omitting
 
-      // if colouring wanted, work our way through all lines to do it
-      if ((trigger_item->colour != SAMECOLOUR || 
+      // Pruning can remove old lines while the matched paragraph survives.
+      if (iOutputGeneration != m_iOutputGeneration)
+        {
+        outputLines = ResolveTriggerLines (this, triggerLines);
+        iOutputGeneration = m_iOutputGeneration;
+        }
+
+      // if colouring wanted, work our way through surviving matched spans
+      if ((trigger_item->colour != SAMECOLOUR ||
           trigger_item->iStyle != NORMAL) &&
           !trigger_item->bMultiLine)  // multi-line won't change colours
         {
@@ -1280,27 +1393,25 @@ POSITION pos;
     */
         while (true)    // repeat until we break (for repeated regexps)
           {
-          int iCurrentCol = 0;   // how far through paragraph
-          int iCount = iEndCol - iStartCol;   // how many columns to colour
-          if (iCount <= 0)
+          if (iEndCol <= iStartCol)
             break;    // can't exactly colour zero columns
 
-          //
-          // Do each line (in the paragraph)
-          //
-          for (pos = prevpos; iCount > 0 && pos; )   // work way to end of buffer
+          for (size_t line = 0; line < triggerLines.size (); ++line)
            {
-           CLine * pLine = m_LineList.GetNext (pos);
-           int iThisEnd = iCurrentCol + pLine->len;   // where this line ends, in para
-           if (iStartCol < iThisEnd)  // does trigger start on this line?
+           CLine * pLine = outputLines [line];
+           const CTriggerLineSnapshot & snapshot = triggerLines [line];
+           if (!pLine)
+             continue;
+           const int ThisCol = MAX (iStartCol - snapshot.iColumn, 0);
+           const int iEnd = MIN (iEndCol - snapshot.iColumn,
+                                MIN (snapshot.iLength, pLine->len));
+           int iCount = iEnd - ThisCol;
+           if (iCount > 0 &&
+               memcmp (pLine->text + ThisCol,
+                       (LPCTSTR) strCurrentLine + snapshot.iColumn + ThisCol,
+                       iCount) == 0)
              {
-             //
-             // Trigger matching part is on *this* line
-             //
-             int ThisCol = iStartCol - iCurrentCol;   // start column on line
-             if (ThisCol < 0)
-               ThisCol = 0;
-
+             // Only the original matched bytes belong to this colour change.
              CStyle * pStyle;
              int iCol;
              POSITION oldpos, pos;
@@ -1323,18 +1434,23 @@ POSITION pos;
                else
                  {
                  int iDiff = iCol - ThisCol;  // amount we overshot
-                 CStyle * pNewStyle = NEWSTYLE;  // make another
+                 std::unique_ptr<CStyle> pNewStyle (NEWSTYLE);  // make another
                  pNewStyle->iLength = iDiff;
                  pNewStyle->iFlags = pStyle->iFlags & STYLE_BITS;
                  pNewStyle->iForeColour = pStyle->iForeColour;
                  pNewStyle->iBackColour = pStyle->iBackColour ;
                  pNewStyle->pAction = pStyle->pAction;
+                 pNewStyle->nRangeCreationNumber =
+                   pStyle->nRangeCreationNumber;
+                 pNewStyle->nOutputAppendCreationNumber =
+                   pStyle->nOutputAppendCreationNumber;
                  if (pNewStyle->pAction)
                    pNewStyle->pAction->AddRef ();
 
-                 pStyle->iLength -= iDiff;  // old one is that much smaller
                  // add to list
-                 pos = pLine->styleList.InsertAfter (oldpos, pNewStyle); // insert
+                 pos = pLine->styleList.InsertAfter (oldpos, pNewStyle.get ()); // insert
+                 pNewStyle.release ();
+                 pStyle->iLength -= iDiff;  // old one is that much smaller
                  }
                } // end of shared style
 
@@ -1349,17 +1465,22 @@ POSITION pos;
                if (pStyle->iLength > iCount)
                  {
                  int iDiff = pStyle->iLength - iCount;  // amount we overshot
-                 CStyle * pNewStyle = NEWSTYLE;  // make another
+                 std::unique_ptr<CStyle> pNewStyle (NEWSTYLE);  // make another
                  pNewStyle->iLength = iDiff;
                  pNewStyle->iFlags = pStyle->iFlags & STYLE_BITS;
                  pNewStyle->iForeColour = pStyle->iForeColour;
                  pNewStyle->iBackColour = pStyle->iBackColour ;
                  pNewStyle->pAction = pStyle->pAction;
+                 pNewStyle->nRangeCreationNumber =
+                   pStyle->nRangeCreationNumber;
+                 pNewStyle->nOutputAppendCreationNumber =
+                   pStyle->nOutputAppendCreationNumber;
                  if (pNewStyle->pAction)
                    pNewStyle->pAction->AddRef ();
-                 pStyle->iLength -= iDiff;  // old one is that much smaller
                  // add to list
-                 pos = pLine->styleList.InsertAfter (oldpos, pNewStyle); // insert
+                 pos = pLine->styleList.InsertAfter (oldpos, pNewStyle.get ()); // insert
+                 pNewStyle.release ();
+                 pStyle->iLength -= iDiff;  // old one is that much smaller
                  }
 
                // colour change wanted? switch to custom colour specified
@@ -1428,7 +1549,6 @@ POSITION pos;
                }
 
              }  // end of being on this line
-           iCurrentCol += pLine->len;   // next line starts where this left off
            }    // end of doing each line
 
 
@@ -1450,21 +1570,27 @@ POSITION pos;
                    // if the change starts past the first column of the style we need to split into before and after
                    if (iStartCol > iStyleCol)
                      {
-                     CPaneStyle * pNewStyle = new CPaneStyle (*pStyle);   // make a new style
-                     pNewStyle->m_sText = sText.substr (0, iStartCol - iStyleCol);    // put front part in new style run
-                     pStyle->m_sText = pStyle->m_sText.substr (iStartCol - iStyleCol);  // trim front of original style run
-                     style_it = StyledLine.m_vStyles.insert (style_it, pNewStyle);   // add new style run before this one
+                     string sBefore = sText.substr (0, iStartCol - iStyleCol);
+                     string sAfter = pStyle->m_sText.substr (iStartCol - iStyleCol);
+                     std::unique_ptr<CPaneStyle> pNewStyle (new CPaneStyle (*pStyle));
+                     pNewStyle->m_sText.swap (sBefore);    // put front part in new style run
+                     style_it = StyledLine.m_vStyles.insert (style_it, pNewStyle.get ());   // add new style run before this one
+                     pNewStyle.release ();
                      style_it++;  // advance past newly inserted item
+                     pStyle->m_sText.swap (sAfter);  // trim front of original style run
                      }  // end if we need to split before the matching text
 
                    // if the change ends before the last column of the style we need to split into before and after
                    if (iEndCol < (iStyleEndCol - 1))
                      {
-                     CPaneStyle * pNewStyle = new CPaneStyle (*pStyle);  // make a new style
-                     pNewStyle->m_sText = sText.substr (iStyleLength - (iStyleEndCol - iEndCol));    // put back part in new style run
-                     pStyle->m_sText = pStyle->m_sText.substr (0, pStyle->m_sText.size () - (iStyleEndCol - iEndCol)); // trim back part
+                     string sAfter = sText.substr (iStyleLength - (iStyleEndCol - iEndCol));
+                     string sBefore = pStyle->m_sText.substr (0, pStyle->m_sText.size () - (iStyleEndCol - iEndCol));
+                     std::unique_ptr<CPaneStyle> pNewStyle (new CPaneStyle (*pStyle));
+                     pNewStyle->m_sText.swap (sAfter);    // put back part in new style run
                      style_it++;  // add new style run after this one
-                     style_it = StyledLine.m_vStyles.insert (style_it, pNewStyle);  // insert it
+                     style_it = StyledLine.m_vStyles.insert (style_it, pNewStyle.get ());  // insert it
+                     pNewStyle.release ();
+                     pStyle->m_sText.swap (sBefore); // trim back part
                      }  // end if we need to split after the matching text
 
                    // Right, we have now split up the style if necessary into another two pieces

--- a/ProcessPreviousLine.cpp
+++ b/ProcessPreviousLine.cpp
@@ -826,11 +826,14 @@ assemble the full text of the original line.
     list<CPaneStyle> stagedOutstandingLines;
     int iRecentLinesToRemove = 0;
     CLine * pSurvivingCurrentLine = NULL;
+    const int iOldLineCount = m_LineList.GetCount ();
+    int iFirstAffectedLine = iOldLineCount;
     POSITION scan = m_LineList.GetTailPosition ();
     while (scan)
       {
       POSITION current = scan;
       CLine * pLine = m_LineList.GetPrev (scan);
+      --iFirstAffectedLine;
       if (!paragraphLengths.count (pLine->nCreationNumber))
         {
         // Later callback output keeps its text, styles, actions, and identity.
@@ -918,10 +921,21 @@ assemble the full text of the original line.
       m_total_lines++;
       }
 
-    for (int i = 0; i <= m_maxlines / JUMP_SIZE; i++)
+    // Earlier lines keep their numbers and jump positions. Clear only entries
+    // whose old line is at or after the first deletion, including removed tails.
+    for (int i = (iFirstAffectedLine + JUMP_SIZE - 1) / JUMP_SIZE;
+         i <= (iOldLineCount - 1) / JUMP_SIZE; i++)
       m_pLinePositions [i] = NULL;
-    int iLine = 0;
-    for (pos = m_LineList.GetHeadPosition (); pos; iLine++)
+
+    // scan is the surviving position immediately before the first deletion.
+    // Do not use the old jump index to locate a line after removing its nodes.
+    pos = scan;
+    if (pos)
+      m_LineList.GetNext (pos);
+    else
+      pos = m_LineList.GetHeadPosition ();
+    int iLine = iFirstAffectedLine;
+    for (; pos; iLine++)
       {
       POSITION current = pos;
       CLine * pLine = m_LineList.GetNext (pos);

--- a/dialogs/world_prefs/configuration.cpp
+++ b/dialogs/world_prefs/configuration.cpp
@@ -1591,29 +1591,13 @@ void CMUSHclientDoc:: SavePrefsP14 (CPrefsP14 &page14)
 
   if (m_pCurrentLine)     // a new world might not have a line yet
     {
-    // save current line text
-    CString strLine = CString (m_pCurrentLine->text, m_pCurrentLine->len);
-
+    int iMemoryAllocated;
     if (m_bUTF_8)
-      m_pCurrentLine->iMemoryAllocated = MAX ((UINT) m_pCurrentLine->len, page14.m_nWrapColumn) * 4;
+      iMemoryAllocated = MAX ((UINT) m_pCurrentLine->len, page14.m_nWrapColumn) * 4;
     else
-      m_pCurrentLine->iMemoryAllocated = MAX ((UINT) m_pCurrentLine->len, page14.m_nWrapColumn);
+      iMemoryAllocated = MAX ((UINT) m_pCurrentLine->len, page14.m_nWrapColumn);
 
-#ifdef USE_REALLOC
-
-    m_pCurrentLine->text  = (char *) realloc (m_pCurrentLine->text, 
-                                              m_pCurrentLine->iMemoryAllocated);  
-
-#else
-    delete [] m_pCurrentLine->text;
-    m_pCurrentLine->text = new char [m_pCurrentLine->iMemoryAllocated];
-#endif
-
-    // check we got it
-    ASSERT (m_pCurrentLine->text);
-
-    // put text back
-    memcpy (m_pCurrentLine->text, (LPCTSTR) strLine, m_pCurrentLine->len);
+    m_pCurrentLine->ResizeText (iMemoryAllocated);
     }   // end of having a current line
 
   if (m_nWrapColumn != page14.m_nWrapColumn)
@@ -1627,6 +1611,8 @@ void CMUSHclientDoc:: SavePrefsP14 (CPrefsP14 &page14)
   // need to be compiled so we recompile all of them
   if (utf8Changed)
     {
+    CPluginContextGuard pluginContextGuard (this, NULL);
+
     int counter;
     m_CurrentPlugin = NULL;
     counter = RecompileRegularExpressions ();     // do main world

--- a/doc.cpp
+++ b/doc.cpp
@@ -1941,9 +1941,11 @@ size_t COutputAppendTransaction::PrepareWrap (
 
 void COutputAppendTransaction::PublishWrap (
   const size_t iWrap,
-  const __int64 iNewLineCreationNumber)
+  const __int64 iNewLineCreationNumber,
+  std::unique_ptr<COutputLineBuffer> pTextBuffer)
   {
   ASSERT (iWrap < m_Wraps.size ());
+  m_Wraps [iWrap].pTextBuffer = std::move (pTextBuffer);
   m_Wraps [iWrap].iNewLineCreationNumber = iNewLineCreationNumber;
   m_Wraps [iWrap].bPublished = true;
   }
@@ -1958,6 +1960,8 @@ void COutputAppendTransaction::RestoreWrap (const CWrapMove & wrap)
   if (!pPreviousLine || !pNewLine ||
       pPreviousLine->len != wrap.iSplitLength)
     return;
+
+  wrap.pTextBuffer->RestoreCapacity (pPreviousLine);
 
   const __int64 iPreservedOwner = -m_iAppendCreationNumber;
   int iSourceOffset = 0;
@@ -2365,6 +2369,27 @@ Unicode range              UTF-8 bytes
             m_pCurrentLine->nCreationNumber;
           const size_t iPreparedWrap = iAppendCreationNumber ?
             pTransaction->PrepareWrap (m_pCurrentLine, last_space) : 0;
+          std::unique_ptr<COutputLineBuffer> pTextBuffer
+            (new COutputLineBuffer (iOldLineLength));
+          const auto RestoreShortenedLine = [&] ()
+            {
+            for (POSITION linepos = m_LineList.GetTailPosition (); linepos; )
+              {
+              CLine * pLine = m_LineList.GetPrev (linepos);
+              if (pLine->nCreationNumber == iPreviousLineCreationNumber)
+                {
+                if (pLine->len == last_space)
+                  {
+                  pTextBuffer->RestoreCapacity (pLine);
+                  memcpy (pLine->text + last_space, (LPCTSTR) strText, saved_count);
+                  pLine->len = iOldLineLength;
+                  }
+                break;
+                }
+              if (pLine->nCreationNumber < iPreviousLineCreationNumber)
+                break;
+              }
+            };
           m_pCurrentLine->len = last_space;
 
           bool bStartedNewLine = false;
@@ -2377,39 +2402,13 @@ Unicode range              UTF-8 bytes
             }
           catch (...)
             {
-            for (POSITION linepos = m_LineList.GetHeadPosition (); linepos; )
-              {
-              CLine * pLine = m_LineList.GetNext (linepos);
-              if (pLine->nCreationNumber == iPreviousLineCreationNumber &&
-                  pLine->len == last_space)
-                {
-                // The callback may have shrunk the temporarily shortened line.
-                if (pLine->iMemoryAllocated < iOldLineLength)
-                  pLine->ResizeText (iOldLineLength);
-                memcpy (pLine->text + last_space, (LPCTSTR) strText, saved_count);
-                pLine->len = iOldLineLength;
-                break;
-                }
-              }
+            RestoreShortenedLine ();
             throw;
             }
 
           if (!bStartedNewLine)
             {
-            for (POSITION linepos = m_LineList.GetHeadPosition (); linepos; )
-              {
-              CLine * pLine = m_LineList.GetNext (linepos);
-              if (pLine->nCreationNumber == iPreviousLineCreationNumber &&
-                  pLine->len == last_space)
-                {
-                // The callback may have shrunk the temporarily shortened line.
-                if (pLine->iMemoryAllocated < iOldLineLength)
-                  pLine->ResizeText (iOldLineLength);
-                memcpy (pLine->text + last_space, (LPCTSTR) strText, saved_count);
-                pLine->len = iOldLineLength;
-                break;
-                }
-            }
+            RestoreShortenedLine ();
             return false;
             }
 
@@ -2417,20 +2416,7 @@ Unicode range              UTF-8 bytes
             {
             // The callback supplied the continuation line. Keep the complete
             // old line and append the pending character to callback state.
-            for (POSITION linepos = m_LineList.GetHeadPosition (); linepos; )
-              {
-              CLine * pLine = m_LineList.GetNext (linepos);
-              if (pLine->nCreationNumber == iPreviousLineCreationNumber &&
-                  pLine->len == last_space)
-                {
-                // The callback may have shrunk the temporarily shortened line.
-                if (pLine->iMemoryAllocated < iOldLineLength)
-                  pLine->ResizeText (iOldLineLength);
-                memcpy (pLine->text + last_space, (LPCTSTR) strText, saved_count);
-                pLine->len = iOldLineLength;
-                break;
-                }
-              }
+            RestoreShortenedLine ();
             bFinishTransition = true;
             goto retry_character;
             }
@@ -2438,8 +2424,6 @@ Unicode range              UTF-8 bytes
           if (iAppendCreationNumber)
             {
             pTransaction->RecordCreatedLine ();
-            pTransaction->PublishWrap (
-              iPreparedWrap, m_pCurrentLine->nCreationNumber);
             }
 
           CLine * pPreviousLine = NULL;
@@ -2482,6 +2466,9 @@ Unicode range              UTF-8 bytes
           int iPublishedStyles = 0;
           try
             {
+            // A callback can reduce the wrap width before this line exists.
+            if (m_pCurrentLine->iMemoryAllocated <= saved_count)
+              m_pCurrentLine->ResizeText (saved_count + 1);
             pos = firstMovedPosition;
             for (int i = 0; i < iCount; i++)
               {
@@ -2512,7 +2499,7 @@ Unicode range              UTF-8 bytes
             while (iPublishedStyles-- > 0)
               DELETESTYLE (m_pCurrentLine->styleList.RemoveTail ());
 
-            pPreviousLine->len = iOldLineLength;
+            RestoreShortenedLine ();
             CLine * pFailedLine = m_pCurrentLine;
             const int iFailedLineCount = m_LineList.GetCount ();
             if (iFailedLineCount % JUMP_SIZE == 1)
@@ -2581,6 +2568,10 @@ Unicode range              UTF-8 bytes
                 }
               }
             }
+          if (iAppendCreationNumber)
+            pTransaction->PublishWrap (
+              iPreparedWrap, m_pCurrentLine->nCreationNumber,
+              std::move (pTextBuffer));
           }  // end of having something to move to the next line
         else  
           {   // saved_count == 0
@@ -3473,6 +3464,8 @@ POSITION pos;
 
     if (m_LineList.GetCount () >= JUMP_SIZE)
       RemoveChunk ();   // get rid of JUMP_SIZE lines
+    m_pCurrentLine = m_LineList.IsEmpty () ?
+      NULL : m_LineList.GetTail ();
     OnConnectionDisconnect ();    // close the world
     TMessageBox ("Ran out of memory. The world has been closed.");
 

--- a/doc.cpp
+++ b/doc.cpp
@@ -766,8 +766,11 @@ void CMUSHclientDoc::SetUpOutputWindow (void)
   if (!m_pCurrentLine)
     {
     m_total_lines = 0;
-    m_pCurrentLine = new CLine (++m_total_lines, m_nWrapColumn, 0, WHITE, BLACK, m_bUTF_8);
-    m_LineList.AddTail (m_pCurrentLine);
+    std::unique_ptr<CLine> pNewLine
+      (new CLine (m_total_lines + 1, m_nWrapColumn, 0, WHITE, BLACK, m_bUTF_8));
+    m_LineList.AddTail (pNewLine.get ());
+    m_pCurrentLine = pNewLine.release ();
+    m_total_lines++;
     }
 
   Note ("");
@@ -1586,38 +1589,664 @@ int count;
 }
 
 
-void CMUSHclientDoc::StartNewLine_KeepPreviousStyle (const int flags)
+bool CMUSHclientDoc::StartNewLine_KeepPreviousStyle (const int flags,
+                                                     bool * pbCreated,
+                                                     const bool bFinishTransition)
   {
-  CStyle * pPreviousStyle,
-         * pThisStyle;
-  CLine * pPreviousLine = m_pCurrentLine; // remember this line
+  if (pbCreated)
+    *pbCreated = false;
+  const __int64 iPreviousLineCreationNumber = m_pCurrentLine->nCreationNumber;
+  CStyle * pPreviousStyle = m_pCurrentLine->styleList.GetTail ();
+  unsigned short iPreviousFlags = pPreviousStyle->iFlags;
+  COLORREF iPreviousForeColour = pPreviousStyle->iForeColour;
+  COLORREF iPreviousBackColour = pPreviousStyle->iBackColour;
+  CAction * pPreviousAction = pPreviousStyle->pAction;
+  if (pPreviousAction)
+    pPreviousAction->AddRef ();
 
   // if saved_count is indeed zero we better start a new line anyway
-   StartNewLine (false, flags);
-   // get old style
-   pPreviousStyle = pPreviousLine->styleList.GetTail ();
-   // get new style
-   pThisStyle = m_pCurrentLine->styleList.GetTail ();
+   bool bStarted = false;
+   bool bCreated = false;
+   try
+     {
+     bStarted = bFinishTransition ?
+       FinishNewLine (flags, false, &bCreated) :
+       StartNewLine (false, flags, false, &bCreated);
+     }
+   catch (...)
+     {
+     if (pPreviousAction)
+       pPreviousAction->Release ();
+     throw;
+     }
+   if (!bStarted)
+     {
+     if (pPreviousAction)
+       pPreviousAction->Release ();
+     return false;
+     }
 
-   if (pThisStyle && pPreviousStyle)    // sanity check
+   if (pbCreated)
+     *pbCreated = bCreated;
+
+   // A line callback can supply the valid continuation line. In that case,
+   // keep its style instead of overwriting it with the previous line style.
+   if (!bCreated)
+     {
+     if (pPreviousAction)
+       pPreviousAction->Release ();
+     return true;
+     }
+
+   // A callback can change the previous line's style without creating a line.
+   // Resolve its identity again; the saved values remain a fallback if pruned.
+   for (POSITION pos = m_LineList.GetTailPosition (); pos; )
+     {
+     CLine * pLine = m_LineList.GetPrev (pos);
+     if (pLine->nCreationNumber == iPreviousLineCreationNumber)
+       {
+       CStyle * pLiveStyle = pLine->styleList.GetTail ();
+       iPreviousFlags = pLiveStyle->iFlags;
+       iPreviousForeColour = pLiveStyle->iForeColour;
+       iPreviousBackColour = pLiveStyle->iBackColour;
+       CAction * pLiveAction = pLiveStyle->pAction;
+       if (pLiveAction)
+         pLiveAction->AddRef ();
+       if (pPreviousAction)
+         pPreviousAction->Release ();
+       pPreviousAction = pLiveAction;
+       break;
+       }
+     if (pLine->nCreationNumber < iPreviousLineCreationNumber)
+       break;
+     }
+
+   // get new style
+   CStyle * pThisStyle = m_pCurrentLine->styleList.GetTail ();
+
+   if (pThisStyle)    // sanity check
      {
      // copy style across so new line has same style as old one
-     pThisStyle->iFlags = pPreviousStyle->iFlags & STYLE_BITS;
-     pThisStyle->iForeColour = pPreviousStyle->iForeColour;
-     pThisStyle->iBackColour = pPreviousStyle->iBackColour;
-     pThisStyle->pAction = pPreviousStyle->pAction;
-     if (pThisStyle->pAction)
-       pThisStyle->pAction->AddRef ();    // we are using it again
+     pThisStyle->iFlags = iPreviousFlags & STYLE_BITS;
+     pThisStyle->iForeColour = iPreviousForeColour;
+     pThisStyle->iBackColour = iPreviousBackColour;
+     pThisStyle->pAction = pPreviousAction;
+     pPreviousAction = NULL;  // transfer the retained reference to the style
      }  // end of valid pointers
+
+   if (pPreviousAction)
+     pPreviousAction->Release ();
+   return true;
   }  // end of CMUSHclientDoc::StartNewLine_KeepPreviousStyle
+
+COutputAppendTransaction::COutputAppendTransaction (
+  CMUSHclientDoc * pDoc,
+  const size_t iLength) :
+  m_pDoc (pDoc),
+  m_iAppendCreationNumber (App.GetUniqueNumber ()),
+  m_iFirstAffectedLineCreationNumber (m_iAppendCreationNumber),
+  m_bCommitted (false)
+  {
+  TrackLine (m_pDoc->m_pCurrentLine);
+  Reserve (iLength);
+  }
+
+COutputAppendTransaction::~COutputAppendTransaction ()
+  {
+  ASSERT (m_bCommitted);
+  }
+
+__int64 COutputAppendTransaction::Identity () const
+  { return m_iAppendCreationNumber; }
+
+void COutputAppendTransaction::Reserve (const size_t iLength)
+  {
+  m_CreatedLines.reserve (m_CreatedLines.size () + iLength + 2);
+  m_Wraps.reserve (m_Wraps.size () + iLength + 2);
+  m_LineBreaks.reserve (m_LineBreaks.size () + iLength + 2);
+  m_LineFlags.reserve (m_LineFlags.size () + iLength + 2);
+  m_ListCounts.reserve (m_ListCounts.size () + iLength + 2);
+  }
+
+// Line identities increase with tail insertion and survive pruning and style moves.
+// Keep an identity boundary, not a list position or a pointer across callbacks.
+void COutputAppendTransaction::TrackLine (const CLine * pLine)
+  {
+  if (pLine && pLine->nCreationNumber < m_iFirstAffectedLineCreationNumber)
+    m_iFirstAffectedLineCreationNumber = pLine->nCreationNumber;
+  }
+
+void COutputAppendTransaction::MarkCurrentLineStyles ()
+  {
+  if (!m_pDoc->m_pCurrentLine)
+    return;
+  TrackLine (m_pDoc->m_pCurrentLine);
+  for (POSITION pos = m_pDoc->m_pCurrentLine->styleList.GetHeadPosition ();
+       pos; )
+    {
+    CStyle * pStyle = m_pDoc->m_pCurrentLine->styleList.GetNext (pos);
+    if (pStyle->nOutputAppendCreationNumber == 0)
+      pStyle->nOutputAppendCreationNumber = -m_iAppendCreationNumber;
+    }
+  }
+
+CStyle * COutputAppendTransaction::PrepareAppendStyle ()
+  {
+  TrackLine (m_pDoc->m_pCurrentLine);
+  CStyle * pStyle = m_pDoc->m_pCurrentLine->styleList.GetTail ();
+  if (pStyle->nOutputAppendCreationNumber == m_iAppendCreationNumber &&
+      pStyle->iLength == 0)
+    return pStyle;
+
+  std::unique_ptr<CStyle> pNewStyle (NEWSTYLE);
+  pNewStyle->iFlags = pStyle->iFlags & STYLE_BITS;
+  pNewStyle->iForeColour = pStyle->iForeColour;
+  pNewStyle->iBackColour = pStyle->iBackColour;
+  pNewStyle->pAction = pStyle->pAction;
+  if (pNewStyle->pAction)
+    pNewStyle->pAction->AddRef ();
+  pNewStyle->nOutputAppendCreationNumber = m_iAppendCreationNumber;
+  m_pDoc->m_pCurrentLine->styleList.AddTail (pNewStyle.get ());
+  return pNewStyle.release ();
+  }
+
+void COutputAppendTransaction::OwnStyle (CStyle * pStyle)
+  {
+  ASSERT (pStyle);
+  // Normal append callers own the current tail style. Retain support for callers
+  // that explicitly supply a style in an earlier line or before publication.
+  if (m_pDoc->m_pCurrentLine &&
+      !m_pDoc->m_pCurrentLine->styleList.IsEmpty () &&
+      m_pDoc->m_pCurrentLine->styleList.GetTail () == pStyle)
+    TrackLine (m_pDoc->m_pCurrentLine);
+  else
+    {
+    bool bFound = false;
+    for (POSITION linepos = m_pDoc->m_LineList.GetTailPosition ();
+         linepos && !bFound; )
+      {
+      CLine * pLine = m_pDoc->m_LineList.GetPrev (linepos);
+      for (POSITION stylepos = pLine->styleList.GetTailPosition (); stylepos; )
+        if (pLine->styleList.GetPrev (stylepos) == pStyle)
+          {
+          TrackLine (pLine);
+          bFound = true;
+          break;
+          }
+      }
+    if (!bFound)
+      m_iFirstAffectedLineCreationNumber = 0; // publication location is unknown
+    }
+  pStyle->nOutputAppendCreationNumber = m_iAppendCreationNumber;
+  }
+
+void COutputAppendTransaction::RecordCreatedLine ()
+  {
+  CStyle * pStyle = m_pDoc->m_pCurrentLine->styleList.GetTail ();
+  CCreatedLine line;
+  line.iLineCreationNumber = m_pDoc->m_pCurrentLine->nCreationNumber;
+  line.iStyleCreationNumber = pStyle->nCreationNumber;
+  line.iStyleRangeCreationNumber = pStyle->nRangeCreationNumber;
+  line.iFlags = pStyle->iFlags;
+  line.iForeColour = pStyle->iForeColour;
+  line.iBackColour = pStyle->iBackColour;
+  line.pAction = pStyle->pAction;
+  m_CreatedLines.push_back (line);
+  OwnStyle (pStyle);
+  }
+
+CLine * COutputAppendTransaction::FindLine (
+  const __int64 iLineCreationNumber,
+  POSITION * pPosition) const
+  {
+  if (pPosition)
+    *pPosition = NULL;
+  for (POSITION pos = m_pDoc->m_LineList.GetTailPosition (); pos; )
+    {
+    POSITION current = pos;
+    CLine * pLine = m_pDoc->m_LineList.GetPrev (pos);
+    if (pLine->nCreationNumber == iLineCreationNumber)
+      {
+      if (pPosition)
+        *pPosition = current;
+      return pLine;
+      }
+    if (pLine->nCreationNumber < iLineCreationNumber)
+      break;
+    }
+  return NULL;
+  }
+
+bool COutputAppendTransaction::StartNewLine (
+  const bool bHardBreak,
+  const int iFlags,
+  const bool bResizePrevious,
+  bool * pbCreated)
+  {
+  Reserve (1);
+  CLineBreakState state;
+  state.iLineCreationNumber = m_pDoc->m_pCurrentLine ?
+    m_pDoc->m_pCurrentLine->nCreationNumber : 0;
+  state.bOldHardReturn = m_pDoc->m_pCurrentLine ?
+    m_pDoc->m_pCurrentLine->hard_return : false;
+  state.bExpectedHardReturn = state.bOldHardReturn;
+  state.bPublished = false;
+  m_LineBreaks.push_back (state);
+  const size_t iState = m_LineBreaks.size () - 1;
+
+  bool bCreated = false;
+  try
+    {
+    const bool bStarted = m_pDoc->StartNewLine (bHardBreak,
+                                                iFlags,
+                                                bResizePrevious,
+                                                &bCreated);
+    CLine * pOldLine = FindLine (state.iLineCreationNumber);
+    if (pOldLine && pOldLine->hard_return != state.bOldHardReturn)
+      {
+      m_LineBreaks [iState].bExpectedHardReturn = pOldLine->hard_return;
+      m_LineBreaks [iState].bPublished = true;
+      }
+    if (bCreated)
+      RecordCreatedLine ();
+    if (pbCreated)
+      *pbCreated = bCreated;
+    return bStarted;
+    }
+  catch (...)
+    {
+    CLine * pOldLine = FindLine (state.iLineCreationNumber);
+    if (pOldLine && pOldLine->hard_return != state.bOldHardReturn)
+      {
+      m_LineBreaks [iState].bExpectedHardReturn = pOldLine->hard_return;
+      m_LineBreaks [iState].bPublished = true;
+      }
+    throw;
+    }
+  }
+
+void COutputAppendTransaction::SetLineFlags (
+  CLine * pLine,
+  const unsigned char iFlags)
+  {
+  Reserve (1);
+  CLineFlagsState state;
+  state.iLineCreationNumber = pLine->nCreationNumber;
+  state.iOldFlags = pLine->flags;
+  state.iExpectedFlags = iFlags;
+  m_LineFlags.push_back (state);
+  pLine->flags = iFlags;
+  }
+
+void COutputAppendTransaction::SetListCount (const int iListCount)
+  {
+  Reserve (1);
+  CListCountState state;
+  state.iListMode = m_pDoc->m_iListMode;
+  state.iOldListCount = m_pDoc->m_iListCount;
+  state.iExpectedListCount = iListCount;
+  state.iListOwner = m_pDoc->m_iMXPListOwner;
+  m_ListCounts.push_back (state);
+  m_pDoc->m_iListCount = iListCount;
+  }
+
+size_t COutputAppendTransaction::PrepareWrap (
+  CLine * pPreviousLine,
+  const int iSplitLength)
+  {
+  TrackLine (pPreviousLine);
+  CWrapMove wrap;
+  wrap.iPreviousLineCreationNumber = pPreviousLine->nCreationNumber;
+  wrap.iNewLineCreationNumber = 0;
+  wrap.iSplitLength = iSplitLength;
+  wrap.bPublished = false;
+
+  const __int64 iPreservedOwner = -m_iAppendCreationNumber;
+  int iStyleStart = 0;
+  size_t iBackupCount = 0;
+  for (POSITION pos = pPreviousLine->styleList.GetHeadPosition (); pos; )
+    {
+    CStyle * pStyle = pPreviousLine->styleList.GetNext (pos);
+    const int iStyleEnd = iStyleStart + pStyle->iLength;
+    if (iStyleEnd > iSplitLength &&
+        pStyle->nOutputAppendCreationNumber == iPreservedOwner)
+      iBackupCount++;
+    iStyleStart = iStyleEnd;
+    }
+
+  wrap.styleBackups.reserve (iBackupCount);
+  iStyleStart = 0;
+  for (POSITION pos = pPreviousLine->styleList.GetHeadPosition (); pos; )
+    {
+    CStyle * pStyle = pPreviousLine->styleList.GetNext (pos);
+    const int iStyleEnd = iStyleStart + pStyle->iLength;
+    if (iStyleEnd > iSplitLength &&
+        pStyle->nOutputAppendCreationNumber == iPreservedOwner)
+      {
+      CWrapStyleBackup backup;
+      backup.iStyleCreationNumber = pStyle->nCreationNumber;
+      backup.iOldLength = pStyle->iLength;
+      backup.iRetainedLength = static_cast<unsigned short> (
+        MAX (MIN (iSplitLength - iStyleStart,
+                  static_cast<int> (pStyle->iLength)),
+             0));
+      wrap.styleBackups.push_back (backup);
+      }
+    iStyleStart = iStyleEnd;
+    }
+
+  m_Wraps.push_back (std::move (wrap));
+  return m_Wraps.size () - 1;
+  }
+
+void COutputAppendTransaction::PublishWrap (
+  const size_t iWrap,
+  const __int64 iNewLineCreationNumber)
+  {
+  ASSERT (iWrap < m_Wraps.size ());
+  m_Wraps [iWrap].iNewLineCreationNumber = iNewLineCreationNumber;
+  m_Wraps [iWrap].bPublished = true;
+  }
+
+void COutputAppendTransaction::RestoreWrap (const CWrapMove & wrap)
+  {
+  if (!wrap.bPublished)
+    return;
+
+  CLine * pPreviousLine = FindLine (wrap.iPreviousLineCreationNumber);
+  CLine * pNewLine = FindLine (wrap.iNewLineCreationNumber);
+  if (!pPreviousLine || !pNewLine ||
+      pPreviousLine->len != wrap.iSplitLength)
+    return;
+
+  const __int64 iPreservedOwner = -m_iAppendCreationNumber;
+  int iSourceOffset = 0;
+  int iRestoreOffset = pPreviousLine->len;
+  for (POSITION pos = pNewLine->styleList.GetHeadPosition (); pos; )
+    {
+    CStyle * pStyle = pNewLine->styleList.GetNext (pos);
+    if (pStyle->nOutputAppendCreationNumber == iPreservedOwner &&
+        pStyle->iLength > 0)
+      {
+      ASSERT (iRestoreOffset + pStyle->iLength <=
+              pPreviousLine->iMemoryAllocated);
+      memcpy (pPreviousLine->text + iRestoreOffset,
+              pNewLine->text + iSourceOffset,
+              pStyle->iLength);
+      iRestoreOffset += pStyle->iLength;
+      }
+    iSourceOffset += pStyle->iLength;
+    }
+
+  for (vector<CWrapStyleBackup>::const_iterator backup =
+         wrap.styleBackups.begin ();
+       backup != wrap.styleBackups.end (); ++backup)
+    for (POSITION pos = pPreviousLine->styleList.GetHeadPosition (); pos; )
+      {
+      CStyle * pStyle = pPreviousLine->styleList.GetNext (pos);
+      if (pStyle->nCreationNumber == backup->iStyleCreationNumber &&
+          pStyle->nOutputAppendCreationNumber == iPreservedOwner)
+        {
+        pStyle->iLength = backup->iOldLength;
+        break;
+        }
+      }
+
+  pPreviousLine->len = iRestoreOffset;
+
+  const int iOldNewLineLength = pNewLine->len;
+  int iReadOffset = 0;
+  int iWriteOffset = 0;
+  for (POSITION pos = pNewLine->styleList.GetHeadPosition (); pos; )
+    {
+    POSITION current = pos;
+    CStyle * pStyle = pNewLine->styleList.GetNext (pos);
+    const int iStyleLength = pStyle->iLength;
+    if (pStyle->nOutputAppendCreationNumber == iPreservedOwner)
+      {
+      if (pStyle->iFlags & START_TAG)
+        for (POSITION tagpos = m_pDoc->m_ActiveTagList.GetHeadPosition ();
+             tagpos; )
+          {
+          CActiveTag * pTag = m_pDoc->m_ActiveTagList.GetNext (tagpos);
+          if (pTag->nOpeningStyleCreationNumber == pStyle->nCreationNumber)
+            {
+            pTag->nOpeningLineCreationNumber =
+              pPreviousLine->nCreationNumber;
+            break;
+            }
+          }
+      iReadOffset += iStyleLength;
+      pNewLine->styleList.RemoveAt (current);
+      DELETESTYLE (pStyle);
+      continue;
+      }
+    if (iStyleLength > 0 && iWriteOffset != iReadOffset)
+      memmove (pNewLine->text + iWriteOffset,
+               pNewLine->text + iReadOffset,
+               iStyleLength);
+    iReadOffset += iStyleLength;
+    iWriteOffset += iStyleLength;
+    }
+  if (iReadOffset < iOldNewLineLength)
+    {
+    const int iUnstyledLength = iOldNewLineLength - iReadOffset;
+    if (iWriteOffset != iReadOffset)
+      memmove (pNewLine->text + iWriteOffset,
+               pNewLine->text + iReadOffset,
+               iUnstyledLength);
+    iWriteOffset += iUnstyledLength;
+    }
+  pNewLine->len = iWriteOffset;
+  }
+
+void COutputAppendTransaction::Commit ()
+  {
+  const __int64 iPreservedOwner = -m_iAppendCreationNumber;
+  for (vector<CWrapMove>::const_iterator wrap = m_Wraps.begin ();
+       wrap != m_Wraps.end (); ++wrap)
+    {
+    if (!wrap->bPublished)
+      continue;
+    CLine * pPreviousLine = FindLine (
+      wrap->iPreviousLineCreationNumber);
+    if (!pPreviousLine)
+      continue;
+    for (vector<CWrapStyleBackup>::const_iterator backup =
+           wrap->styleBackups.begin ();
+         backup != wrap->styleBackups.end (); ++backup)
+      {
+      if (backup->iRetainedLength != 0)
+        continue;
+      for (POSITION pos = pPreviousLine->styleList.GetHeadPosition (); pos; )
+        {
+        POSITION current = pos;
+        CStyle * pStyle = pPreviousLine->styleList.GetNext (pos);
+        if (pStyle->nCreationNumber != backup->iStyleCreationNumber ||
+            pStyle->nOutputAppendCreationNumber != iPreservedOwner ||
+            pStyle->iLength != 0)
+          continue;
+        pPreviousLine->styleList.RemoveAt (current);
+        DELETESTYLE (pStyle);
+        break;
+        }
+      }
+    }
+
+  for (POSITION linepos = m_pDoc->m_LineList.GetTailPosition (); linepos; )
+    {
+    CLine * pLine = m_pDoc->m_LineList.GetPrev (linepos);
+    if (pLine->nCreationNumber < m_iFirstAffectedLineCreationNumber)
+      break;
+    for (POSITION stylepos = pLine->styleList.GetHeadPosition (); stylepos; )
+      {
+      CStyle * pStyle = pLine->styleList.GetNext (stylepos);
+      if (pStyle->nOutputAppendCreationNumber == m_iAppendCreationNumber ||
+          pStyle->nOutputAppendCreationNumber == -m_iAppendCreationNumber)
+        pStyle->nOutputAppendCreationNumber = 0;
+      }
+    }
+  m_bCommitted = true;
+  }
+
+void COutputAppendTransaction::Rollback ()
+  {
+  if (m_bCommitted)
+    return;
+  m_bCommitted = true;
+
+  for (vector<CWrapMove>::reverse_iterator wrap = m_Wraps.rbegin ();
+       wrap != m_Wraps.rend (); ++wrap)
+    RestoreWrap (*wrap);
+
+  for (vector<CLineFlagsState>::reverse_iterator state =
+         m_LineFlags.rbegin ();
+       state != m_LineFlags.rend (); ++state)
+    {
+    CLine * pLine = FindLine (state->iLineCreationNumber);
+    if (pLine && pLine->flags == state->iExpectedFlags)
+      pLine->flags = state->iOldFlags;
+    }
+
+  for (vector<CLineBreakState>::reverse_iterator state =
+         m_LineBreaks.rbegin ();
+       state != m_LineBreaks.rend (); ++state)
+    {
+    if (!state->bPublished)
+      continue;
+    CLine * pLine = FindLine (state->iLineCreationNumber);
+    if (pLine && pLine->hard_return == state->bExpectedHardReturn)
+      pLine->hard_return = state->bOldHardReturn;
+    }
+
+  for (vector<CListCountState>::reverse_iterator state =
+         m_ListCounts.rbegin ();
+       state != m_ListCounts.rend (); ++state)
+    if (m_pDoc->m_iListMode == state->iListMode &&
+        m_pDoc->m_iListCount == state->iExpectedListCount &&
+        m_pDoc->m_iMXPListOwner == state->iListOwner)
+      m_pDoc->m_iListCount = state->iOldListCount;
+
+  for (POSITION linepos = m_pDoc->m_LineList.GetTailPosition (); linepos; )
+    {
+    CLine * pLine = m_pDoc->m_LineList.GetPrev (linepos);
+    if (pLine->nCreationNumber < m_iFirstAffectedLineCreationNumber)
+      break;
+    const int iOldLength = pLine->len;
+    int iReadOffset = 0;
+    int iWriteOffset = 0;
+
+    for (POSITION stylepos = pLine->styleList.GetHeadPosition (); stylepos; )
+      {
+      POSITION current = stylepos;
+      CStyle * pStyle = pLine->styleList.GetNext (stylepos);
+      const int iStyleLength = pStyle->iLength;
+      if (pStyle->nOutputAppendCreationNumber ==
+          m_iAppendCreationNumber)
+        {
+        iReadOffset += iStyleLength;
+        pLine->styleList.RemoveAt (current);
+        DELETESTYLE (pStyle);
+        continue;
+        }
+      if (pStyle->nOutputAppendCreationNumber ==
+          -m_iAppendCreationNumber)
+        pStyle->nOutputAppendCreationNumber = 0;
+
+      if (iStyleLength > 0 && iWriteOffset != iReadOffset)
+        memmove (pLine->text + iWriteOffset,
+                 pLine->text + iReadOffset,
+                 iStyleLength);
+      iReadOffset += iStyleLength;
+      iWriteOffset += iStyleLength;
+      }
+
+    if (iReadOffset < iOldLength)
+      {
+      const int iUnstyledLength = iOldLength - iReadOffset;
+      if (iWriteOffset != iReadOffset)
+        memmove (pLine->text + iWriteOffset,
+                 pLine->text + iReadOffset,
+                 iUnstyledLength);
+      iWriteOffset += iUnstyledLength;
+      }
+    pLine->len = iWriteOffset;
+    }
+
+  bool bDeletedLine = false;
+  bool bDeletedCurrentLine = false;
+  for (vector<CCreatedLine>::reverse_iterator identity =
+         m_CreatedLines.rbegin ();
+       identity != m_CreatedLines.rend (); ++identity)
+    {
+    POSITION current = NULL;
+    CLine * pLine = FindLine (identity->iLineCreationNumber, &current);
+    if (!pLine || pLine->len != 0 || pLine->styleList.GetCount () > 1)
+      continue;
+    if (pLine->styleList.GetCount () == 1)
+      {
+      CStyle * pStyle = pLine->styleList.GetHead ();
+      if (pStyle->nCreationNumber != identity->iStyleCreationNumber ||
+          pStyle->nRangeCreationNumber !=
+            identity->iStyleRangeCreationNumber ||
+          pStyle->iFlags != identity->iFlags ||
+          pStyle->iForeColour != identity->iForeColour ||
+          pStyle->iBackColour != identity->iBackColour ||
+          pStyle->pAction != identity->pAction)
+        continue;
+      }
+    if (pLine == m_pDoc->m_pCurrentLine)
+      bDeletedCurrentLine = true;
+    m_pDoc->m_LineList.RemoveAt (current);
+    delete pLine;
+    m_pDoc->m_total_lines--;
+    if (m_pDoc->m_pActiveCommandView == NULL &&
+        m_pDoc->m_pActiveOutputView == NULL &&
+        m_pDoc->m_new_lines > 0)
+      m_pDoc->m_new_lines--;
+    bDeletedLine = true;
+    }
+
+  if (bDeletedCurrentLine)
+    m_pDoc->m_pCurrentLine = m_pDoc->m_LineList.IsEmpty () ?
+      NULL : m_pDoc->m_LineList.GetTail ();
+
+  if (bDeletedLine)
+    {
+    m_pDoc->m_iOutputGeneration++;
+    if (m_pDoc->m_pLinePositions)
+      {
+      for (int i = 0; i <= m_pDoc->m_maxlines / JUMP_SIZE; i++)
+        m_pDoc->m_pLinePositions [i] = NULL;
+      int iLine = 0;
+      for (POSITION linepos = m_pDoc->m_LineList.GetHeadPosition ();
+           linepos; iLine++)
+        {
+        POSITION current = linepos;
+        m_pDoc->m_LineList.GetNext (linepos);
+        if (iLine % JUMP_SIZE == 0)
+          m_pDoc->m_pLinePositions [iLine / JUMP_SIZE] = current;
+        }
+      }
+    }
+  m_pDoc->RefreshMXPMissingTagAnchors ();
+  }
 
 // called from DisplayMsg to actually add to the current line
 // and also from the MXP routines to put stuff there
-void CMUSHclientDoc::AddToLine (LPCTSTR lpszText, const int flags)
+bool CMUSHclientDoc::AddToLine (LPCTSTR lpszText, const int flags)
+  { return AddToLineInternal (lpszText, flags, NULL); }
+
+bool CMUSHclientDoc::AddToLineInternal (
+  LPCTSTR lpszText,
+  const int flags,
+  COutputAppendTransaction * pTransaction)
   {
 const char * p ;
 unsigned char c;
 int saved_count;
+const __int64 iAppendCreationNumber =
+  pTransaction ? pTransaction->Identity () : 0;
 
   // incoming text from the MUD (only) is remembered also in m_strCurrentLine for triggers
 //  if (flags == 0)
@@ -1626,6 +2255,11 @@ int saved_count;
   for (p = lpszText; *p; p++)
     {
     c = *p;
+    bool bFinishTransition = false;
+
+retry_character:
+    if (!m_pCurrentLine)
+      return false;
     int iLineLength = m_pCurrentLine->len;
 
     // for Unicode the width of the line is characters, not stored bytes
@@ -1693,10 +2327,25 @@ Unicode range              UTF-8 bytes
 
       if (last_space < 0 ||   // if no break point found, break anyway at end of line
         (m_pCurrentLine->len - last_space) >= m_nWrapColumn)
-          StartNewLine_KeepPreviousStyle (flags);
+        {
+        bool bCreatedLine = false;
+        if (!StartNewLine_KeepPreviousStyle (flags, &bCreatedLine,
+                                             bFinishTransition))
+          return false;
+        // Recheck callback output with the normal word-wrap rules. The active
+        // transition has delivered its callbacks; finish it before this byte.
+        if (!bCreatedLine)
+          {
+          bFinishTransition = true;
+          goto retry_character;
+          }
+        if (iAppendCreationNumber && bCreatedLine)
+          pTransaction->RecordCreatedLine ();
+        }
       else
         {
         saved_count = m_pCurrentLine->len - last_space;
+        const int iOldLineLength = m_pCurrentLine->len;
 
         // note - saved_count should not be zero because length is 1-relative
         // (eg. 1) and last_space is zero-relative (eg. 0)
@@ -1704,7 +2353,6 @@ Unicode range              UTF-8 bytes
           {
           saved_count--;    // one less to copy
           last_space++;  // one more on this line (the space)
-          m_pCurrentLine->len = last_space; // this line is longer
           }   // end of indenting not wanted
 
         // saved_count might be zero now, because of no indenting
@@ -1713,75 +2361,265 @@ Unicode range              UTF-8 bytes
           // save portion of text destined for new line
           CString strText = CString (&m_pCurrentLine->text [last_space],
                                      saved_count); 
+          const __int64 iPreviousLineCreationNumber =
+            m_pCurrentLine->nCreationNumber;
+          const size_t iPreparedWrap = iAppendCreationNumber ?
+            pTransaction->PrepareWrap (m_pCurrentLine, last_space) : 0;
           m_pCurrentLine->len = last_space;
 
-          CLine * pPreviousLine = m_pCurrentLine; // remember this line
+          bool bStartedNewLine = false;
+          bool bCreatedNewLine = false;
+          try
+            {
+            bStartedNewLine = bFinishTransition ?
+              FinishNewLine (flags, false, &bCreatedNewLine) :
+              StartNewLine (false, flags, false, &bCreatedNewLine);
+            }
+          catch (...)
+            {
+            for (POSITION linepos = m_LineList.GetHeadPosition (); linepos; )
+              {
+              CLine * pLine = m_LineList.GetNext (linepos);
+              if (pLine->nCreationNumber == iPreviousLineCreationNumber &&
+                  pLine->len == last_space)
+                {
+                // The callback may have shrunk the temporarily shortened line.
+                if (pLine->iMemoryAllocated < iOldLineLength)
+                  pLine->ResizeText (iOldLineLength);
+                memcpy (pLine->text + last_space, (LPCTSTR) strText, saved_count);
+                pLine->len = iOldLineLength;
+                break;
+                }
+              }
+            throw;
+            }
 
-          StartNewLine (false, flags);
+          if (!bStartedNewLine)
+            {
+            for (POSITION linepos = m_LineList.GetHeadPosition (); linepos; )
+              {
+              CLine * pLine = m_LineList.GetNext (linepos);
+              if (pLine->nCreationNumber == iPreviousLineCreationNumber &&
+                  pLine->len == last_space)
+                {
+                // The callback may have shrunk the temporarily shortened line.
+                if (pLine->iMemoryAllocated < iOldLineLength)
+                  pLine->ResizeText (iOldLineLength);
+                memcpy (pLine->text + last_space, (LPCTSTR) strText, saved_count);
+                pLine->len = iOldLineLength;
+                break;
+                }
+            }
+            return false;
+            }
 
-          CStyle * pStyle;
+          if (!bCreatedNewLine)
+            {
+            // The callback supplied the continuation line. Keep the complete
+            // old line and append the pending character to callback state.
+            for (POSITION linepos = m_LineList.GetHeadPosition (); linepos; )
+              {
+              CLine * pLine = m_LineList.GetNext (linepos);
+              if (pLine->nCreationNumber == iPreviousLineCreationNumber &&
+                  pLine->len == last_space)
+                {
+                // The callback may have shrunk the temporarily shortened line.
+                if (pLine->iMemoryAllocated < iOldLineLength)
+                  pLine->ResizeText (iOldLineLength);
+                memcpy (pLine->text + last_space, (LPCTSTR) strText, saved_count);
+                pLine->len = iOldLineLength;
+                break;
+                }
+              }
+            bFinishTransition = true;
+            goto retry_character;
+            }
 
-          // delete empty style item new line already has
-          pStyle = m_pCurrentLine->styleList.GetTail ();
-          DELETESTYLE (pStyle);
-          m_pCurrentLine->styleList.RemoveTail ();
-        
-          memcpy (m_pCurrentLine->text, (LPCTSTR) strText, saved_count);
-          m_pCurrentLine->len = saved_count;
+          if (iAppendCreationNumber)
+            {
+            pTransaction->RecordCreatedLine ();
+            pTransaction->PublishWrap (
+              iPreparedWrap, m_pCurrentLine->nCreationNumber);
+            }
 
-          // now move the styles over to the new line
+          CLine * pPreviousLine = NULL;
+          for (POSITION linepos = m_LineList.GetHeadPosition (); linepos; )
+            {
+            CLine * pLine = m_LineList.GetNext (linepos);
+            if (pLine->nCreationNumber == iPreviousLineCreationNumber)
+              {
+              pPreviousLine = pLine;
+              break;
+              }
+            }
+          if (!pPreviousLine)
+            return false;
 
+          // Build replacement style runs before changing either published list.
           int iCount = 0,
               iOldLength = 0,
               iLength = 0;
-          POSITION pos;
+          POSITION pos,
+                   firstMovedPosition = NULL;
 
           // find number that have to move
           for (pos = pPreviousLine->styleList.GetHeadPosition(); pos; )
             {
-            pStyle = pPreviousLine->styleList.GetNext (pos);
+            POSITION current = pos;
+            CStyle * pStyle = pPreviousLine->styleList.GetNext (pos);
             iLength += pStyle->iLength;
             if (iLength > pPreviousLine->len)
+              {
+              if (!firstMovedPosition)
+                firstMovedPosition = current;
               iCount++;   // this one has to move
-            else 
+              }
+            else
               iOldLength += pStyle->iLength;
             }   // end of counting number to move
 
-          // move them  - copy from tail of old to head of new (going backwards)
-          for (pos = pPreviousLine->styleList.GetTailPosition(); iCount > 0 && pos; iCount--)
+          const int iSharedLength = pPreviousLine->len - iOldLength;
+          int iPublishedStyles = 0;
+          try
             {
-            pStyle = pPreviousLine->styleList.RemoveTail ();
-            m_pCurrentLine->styleList.AddHead (pStyle);
-            }   // end of moving them
-
-          // if one style is shared we have to make a copy and adjust lengths
-          if (iOldLength < pPreviousLine->len)
+            pos = firstMovedPosition;
+            for (int i = 0; i < iCount; i++)
+              {
+              CStyle * pOldStyle = pPreviousLine->styleList.GetNext (pos);
+              std::unique_ptr<CStyle> pNewStyle (NEWSTYLE);
+              pNewStyle->iLength = pOldStyle->iLength;
+              if (i == 0)
+                pNewStyle->iLength -= iSharedLength;
+              pNewStyle->iFlags = pOldStyle->iFlags;
+              pNewStyle->iForeColour = pOldStyle->iForeColour;
+              pNewStyle->iBackColour = pOldStyle->iBackColour;
+              pNewStyle->pAction = pOldStyle->pAction;
+              pNewStyle->nRangeCreationNumber =
+                pOldStyle->nRangeCreationNumber;
+              pNewStyle->nOutputAppendCreationNumber =
+                pOldStyle->nOutputAppendCreationNumber;
+              if (i > 0 || iSharedLength == 0)
+                pNewStyle->nCreationNumber = pOldStyle->nCreationNumber;
+              if (pNewStyle->pAction)
+                pNewStyle->pAction->AddRef ();
+              m_pCurrentLine->styleList.AddTail (pNewStyle.get ());
+              pNewStyle.release ();
+              iPublishedStyles++;
+              }
+            }
+          catch (...)
             {
-            int iDiff = pPreviousLine->len - iOldLength;  // amount we are short
-            // was copied - find out its details
+            while (iPublishedStyles-- > 0)
+              DELETESTYLE (m_pCurrentLine->styleList.RemoveTail ());
 
-            pStyle =  m_pCurrentLine->styleList.GetHead ();
-            pStyle->iLength -= iDiff;  // this line is that much smaller
-            CAction * pAction = pStyle->pAction;
-          
-            AddStyle (pStyle->iFlags & STYLE_BITS, 
-                      pStyle->iForeColour, 
-                      pStyle->iBackColour, 
-                      iDiff,  // old line has this much
-                      pAction,
-                      pPreviousLine);  // add to end of previous line
+            pPreviousLine->len = iOldLineLength;
+            CLine * pFailedLine = m_pCurrentLine;
+            const int iFailedLineCount = m_LineList.GetCount ();
+            if (iFailedLineCount % JUMP_SIZE == 1)
+              m_pLinePositions [iFailedLineCount / JUMP_SIZE] = NULL;
+            m_LineList.RemoveTail ();
+            m_pCurrentLine = pPreviousLine;
+            m_total_lines--;
+            if (m_pActiveCommandView == NULL &&
+                m_pActiveOutputView == NULL && m_new_lines > 0)
+              m_new_lines--;
+            delete pFailedLine;
+            throw;
+            }
 
-            } // end of shared style
+          memcpy (m_pCurrentLine->text, (LPCTSTR) strText, saved_count);
+          m_pCurrentLine->len = saved_count;
+
+          // The staged runs now cover the new line. Remove its default run.
+          DELETESTYLE (m_pCurrentLine->styleList.RemoveHead ());
+
+          int iStylesToRemove = iCount;
+          pos = firstMovedPosition;
+          if (iSharedLength > 0)
+            {
+            CStyle * pSharedStyle = pPreviousLine->styleList.GetNext (pos);
+            pSharedStyle->iLength = iSharedLength;
+            iStylesToRemove--;
+            }
+          while (iStylesToRemove-- > 0)
+            {
+            POSITION current = pos;
+            CStyle * pMovedStyle =
+              pPreviousLine->styleList.GetNext (pos);
+            if (iAppendCreationNumber &&
+                pMovedStyle->nOutputAppendCreationNumber ==
+                  -iAppendCreationNumber)
+              pMovedStyle->iLength = 0;
+            else
+              {
+              pPreviousLine->styleList.RemoveAt (current);
+              DELETESTYLE (pMovedStyle);
+              }
+            }
+
+          // A wrapped opening marker keeps its style identity but changes
+          // lines. Keep the fallback anchor on the marker's current line.
+          for (POSITION markerpos =
+                 m_pCurrentLine->styleList.GetHeadPosition ();
+               markerpos; )
+            {
+            CStyle * pMarkerStyle =
+              m_pCurrentLine->styleList.GetNext (markerpos);
+            if ((pMarkerStyle->iFlags & START_TAG) == 0)
+              continue;
+
+            for (POSITION tagpos = m_ActiveTagList.GetHeadPosition ();
+                 tagpos; )
+              {
+              CActiveTag * pTag = m_ActiveTagList.GetNext (tagpos);
+              if (pTag->nOpeningStyleCreationNumber ==
+                  pMarkerStyle->nCreationNumber)
+                {
+                pTag->nOpeningLineCreationNumber =
+                  m_pCurrentLine->nCreationNumber;
+                break;
+                }
+              }
+            }
           }  // end of having something to move to the next line
         else  
           {   // saved_count == 0
-          StartNewLine_KeepPreviousStyle (flags);
+          bool bCreatedLine = false;
+          if (!StartNewLine_KeepPreviousStyle (flags, &bCreatedLine,
+                                             bFinishTransition))
+            return false;
+          if (!bCreatedLine)
+            {
+            bFinishTransition = true;
+            goto retry_character;
+            }
+          if (iAppendCreationNumber && bCreatedLine)
+            pTransaction->RecordCreatedLine ();
           }  // end saved_count == 0
 
         } // end of line wrapping wanted and possible
       }   // end of line being full
 
     ASSERT (m_pCurrentLine->text);
+
+    if (pTransaction)
+      pTransaction->TrackLine (m_pCurrentLine);
+    CStyle * pAppendStyle = m_pCurrentLine->styleList.GetTail ();
+    if (pAppendStyle->nOutputAppendCreationNumber !=
+        iAppendCreationNumber)
+      {
+      std::unique_ptr<CStyle> pNewStyle (NEWSTYLE);
+      pNewStyle->iFlags = pAppendStyle->iFlags & STYLE_BITS;
+      pNewStyle->iForeColour = pAppendStyle->iForeColour;
+      pNewStyle->iBackColour = pAppendStyle->iBackColour;
+      pNewStyle->pAction = pAppendStyle->pAction;
+      if (pNewStyle->pAction)
+        pNewStyle->pAction->AddRef ();
+      pNewStyle->nOutputAppendCreationNumber =
+        iAppendCreationNumber;
+      m_pCurrentLine->styleList.AddTail (pNewStyle.get ());
+      pNewStyle.release ();
+      }
 
     // add character to line
     m_pCurrentLine->text [m_pCurrentLine->len] = c;
@@ -1792,6 +2630,7 @@ Unicode range              UTF-8 bytes
     m_pCurrentLine->styleList.GetTail ()->iLength++; 
 
     } // end of processing each character
+  return true;
   } // end of AddToLine
 
 
@@ -1937,7 +2776,10 @@ CString strLine (lpszText, size);
     // make sure notes start on a new line
     if ((flags & COMMENT) != (m_pCurrentLine->flags & COMMENT) && 
         m_pCurrentLine->len > 0)
-      StartNewLine (true, flags);
+      {
+      if (!StartNewLine (true, flags))
+        return;
+      }
     else
       {
       if (m_bKeepCommandsOnSameLine)  // for Simen Brekken
@@ -1955,12 +2797,14 @@ CString strLine (lpszText, size);
         {
         if ((flags & NOTE_OR_COMMAND) != (m_pCurrentLine->flags & NOTE_OR_COMMAND) && 
             m_pCurrentLine->len > 0)
-            StartNewLine (true, flags);
+            if (!StartNewLine (true, flags))
+              return;
         } // end of commands going onto a new line
       }   // end of not changing to/from a note
     }
   else
-    StartNewLine (true, 0);
+    if (!StartNewLine (true, 0))
+      return;
 
 // if line length is currently zero (ie. we are starting a new one)
 // then we will set the default style depending on the flags, this will
@@ -2226,9 +3070,11 @@ CString strLine (lpszText, size);
               if (m_cLastChar == c)
                 {  // two newlines in a row - start a real new line
                 // we'll do two because the original text had a blank line.
-                StartNewLine (true, flags);
+                if (!StartNewLine (true, flags))
+                  return;
                 m_pCurrentLine->flags = flags;    // remember flags for this line
-                StartNewLine (true, flags);   // and another
+                if (!StartNewLine (true, flags))   // and another
+                  return;
                 m_pCurrentLine->flags = flags;    // remember flags for this line
                 }  // end of \n\n
               else
@@ -2244,9 +3090,15 @@ CString strLine (lpszText, size);
                 if (last_space != (m_pCurrentLine->len - 1))
                   {
                   if (m_cLastChar == '.' && m_pCurrentLine->len < m_nWrapColumn)
-                    AddToLine ("  ", flags);  // two spaces after period
+                    {
+                    if (!AddToLine ("  ", flags))  // two spaces after period
+                      return;
+                    }
                   else
-                    AddToLine (" ", flags);  // convert newline to space
+                    {
+                    if (!AddToLine (" ", flags))  // convert newline to space
+                      return;
+                    }
                   }   // end of newline which does not follow a space
                 }  // end of not two newlines in a row
               m_cLastChar = c;  // remember it was a newline
@@ -2257,7 +3109,8 @@ CString strLine (lpszText, size);
                   (flags & NOTE_OR_COMMAND)           // input/note mode honours newlines
                   )
                 {
-                StartNewLine (true, flags);
+                if (!StartNewLine (true, flags))
+                  return;
                 SetNewLineColour (flags);
                 }
             break;  // end of newline
@@ -2267,26 +3120,24 @@ CString strLine (lpszText, size);
             if (m_bCarriageReturnClearsLine && !(flags & NOTE_OR_COMMAND) && p [1] != '\n')
               {
 
-              // delete existing styles list
+              // build and publish the replacement before deleting existing styles
+              std::unique_ptr<CStyle> pNewStyle (NEWSTYLE);
+              pNewStyle->iFlags = 0;
+              pNewStyle->iForeColour = WHITE;
+              pNewStyle->iBackColour = BLACK;
 
-              for (POSITION pos = m_pCurrentLine->styleList.GetHeadPosition(); pos; )
-                  DELETESTYLE (m_pCurrentLine->styleList.GetNext (pos));
+              int iOldStyleCount = m_pCurrentLine->styleList.GetCount ();
+              m_pCurrentLine->styleList.AddTail (pNewStyle.get ());
 
-              m_pCurrentLine->styleList.RemoveAll();
+              for (int iStyle = 0; iStyle < iOldStyleCount; iStyle++)
+                DELETESTYLE (m_pCurrentLine->styleList.RemoveHead ());
 
-              // add back one default style
-
-              CStyle * pStyle; 
-
-              // have at least one style item in the list
-              m_pCurrentLine->styleList.AddTail (pStyle = NEWSTYLE);
-
-              pStyle->iFlags = 0;
-              pStyle->iForeColour = WHITE;
-              pStyle->iBackColour = BLACK;
+              pNewStyle.release ();
 
               m_pCurrentLine->hard_return = false;
               m_pCurrentLine->len = 0;
+
+              RefreshMXPMissingTagAnchors ();
 
               }   // end of letting a \r delete line contents
 
@@ -2321,14 +3172,16 @@ CString strLine (lpszText, size);
               if ((m_cLastChar == '.' || m_cLastChar == '!' || m_cLastChar == '?')
                   && m_pCurrentLine->len < m_nWrapColumn)
                 {
-                AddToLine ("  ", flags);
+                if (!AddToLine ("  ", flags))
+                  return;
                 m_cLastChar = c;  // remember it
                 break;
                 }
 
               }   // end of <p> mode            
 
-            AddToLine (" ", flags);
+            if (!AddToLine (" ", flags))
+              return;
 
             // a newline followed by only a space still counts as a newline
             if (m_cLastChar != '\n' && !(flags & NOTE_OR_COMMAND))
@@ -2337,12 +3190,16 @@ CString strLine (lpszText, size);
 
       case '\t':  i = ((m_pCurrentLine->len + 8) & 0xFFF8);
                   if (m_pCurrentLine->len >= m_nWrapColumn)
-                    StartNewLine (false, flags);
+                    {
+                    if (!StartNewLine (false, flags))
+                      return;
+                    }
                   else
                     {
                     spaces = i - m_pCurrentLine->len;  // no. of spaces
                     for (i = 0; i < spaces; i++)
-                        AddToLine (" ", flags);
+                      if (!AddToLine (" ", flags))
+                        return;
 
                     }   // end of being inside wrap column
                   break;    // end of tab
@@ -2357,7 +3214,8 @@ CString strLine (lpszText, size);
                     {
                     if (m_phase == HAVE_IAC)
                       {
-                      AddToLine (cOneCharacterLine, flags);
+                      if (!AddToLine (cOneCharacterLine, flags))
+                        return;
                       m_cLastChar = c;  // remember it
                       m_phase = NONE;
                       }
@@ -2392,7 +3250,8 @@ CString strLine (lpszText, size);
                   // note NO break here, if not in MXP mode we FALL THROUGH
 
       default:
-                  AddToLine (cOneCharacterLine, flags);
+                  if (!AddToLine (cOneCharacterLine, flags))
+                    return;
                   if (!(flags & NOTE_OR_COMMAND))
                     m_cLastChar = c;  // remember it
                   break;
@@ -2436,9 +3295,12 @@ CString strLine (lpszText, size);
 
 
 
-void CMUSHclientDoc::StartNewLine (const bool hard_break, const int flags)
+bool CMUSHclientDoc::StartNewLine (const bool hard_break, const int flags,
+                                  const bool bResizePrevious,
+                                  bool * pbCreated)
   {
-POSITION pos;
+  if (pbCreated)
+    *pbCreated = false;
 
   // we may not have a current line
   if (m_pCurrentLine)
@@ -2450,18 +3312,23 @@ POSITION pos;
     // new - for people on the forum who insist on getting lines without a \n at
     // the end - tell plugins about this line
 
+    __int64 iLineCreationNumber = m_pCurrentLine->nCreationNumber;
     if (!(flags & NOTE_OR_COMMAND))
       SendLineToPlugin ();
+
+    if (!m_pCurrentLine)
+      return false;
+    if (m_pCurrentLine->nCreationNumber != iLineCreationNumber)
+      return true;
 
   //  TRACE1 ("Received line: %s\n", (LPCTSTR) CString (m_pCurrentLine->text, m_pCurrentLine->len));
 
     if (hard_break)
       {
-      CLine * pSavedLine = m_pCurrentLine;
-      LARGE_INTEGER saved_time = m_pCurrentLine->m_lineHighPerformanceTime;
+      __int64 iSavedLineCreationNumber = m_pCurrentLine->nCreationNumber;
       if (ProcessPreviousLine () &&
-          m_pCurrentLine->len == 0)
-        return;   // return if omit from output (no need to add another line)
+          m_pCurrentLine && m_pCurrentLine->len == 0)
+        return true;   // omit already supplied a valid empty current line
 
       // if the line has changed then the trigger or script added a new one,
       // so we don't need to add a second.
@@ -2471,14 +3338,28 @@ POSITION pos;
 
       // added in version 4.41, also check timestamp, due to problem with lines being deleted
       // by DeleteLines in a trigger script.
-      if ((pSavedLine != m_pCurrentLine || 
-          saved_time.QuadPart != m_pCurrentLine->m_lineHighPerformanceTime.QuadPart) &&
+      if (!m_pCurrentLine)
+        return false;
+      if (iSavedLineCreationNumber != m_pCurrentLine->nCreationNumber &&
           m_pCurrentLine->len == 0)
-        return;
+        return true;
 
       }
     }
 
+
+  return FinishNewLine (flags, bResizePrevious, pbCreated);
+  } // end of CMUSHclientDoc::StartNewLine
+
+// Complete a line transition after its callbacks and trigger processing.
+// Append reentry uses this phase after recomputing the callback line's wrap.
+bool CMUSHclientDoc::FinishNewLine (const int flags,
+                                   const bool bResizePrevious,
+                                   bool * pbCreated)
+  {
+POSITION pos;
+  if (pbCreated)
+    *pbCreated = false;
 
   // if our buffer is full, remove the JUMP_SIZE items
 
@@ -2507,59 +3388,6 @@ POSITION pos;
 
   try
     {
-
-  // we may not have a current line
-    if (m_pCurrentLine)
-      {
-
-  // We are about to move onto a new line. For space reasons, reallocate them
-  // memory used by the pointers. However to keep from getting a null pointer,
-  // keep at least a single character
-
-    // save current line text
-     CString strLine = CString (m_pCurrentLine->text, m_pCurrentLine->len);
-
-     m_pCurrentLine->iMemoryAllocated = MAX (m_pCurrentLine->len, 1);
-
-#ifdef USE_REALLOC
-      m_pCurrentLine->text  = (char *) realloc (m_pCurrentLine->text, 
-                                               m_pCurrentLine->iMemoryAllocated);
-
-#else
-
-    delete [] m_pCurrentLine->text;
-    m_pCurrentLine->text = new char [m_pCurrentLine->iMemoryAllocated];
-
-
-#endif
-      
-    ASSERT (m_pCurrentLine->text);
-
-    // put text back
-    memcpy (m_pCurrentLine->text, (LPCTSTR) strLine, m_pCurrentLine->len);
-
-      // if we have more than one style, and the last one is empty, get rid of it
-      // unless it is a start tag marker
-      /*
-
-  // Commented out because of bug #418 - a style change at the very end
-  // of the line was being discarded.    Changed in version 3.18.
-
-      if (m_pCurrentLine->styleList.GetCount () > 1)
-        {
-        // find current style
-        CStyle * pStyle = m_pCurrentLine->styleList.GetTail ();
-
-        if (pStyle->iLength == 0 && (pStyle->iFlags & START_TAG) == 0)
-          {
-          DELETESTYLE (pStyle);
-          m_pCurrentLine->styleList.RemoveTail ();
-          }
-        }   // end of having more than one style
-        */
-
-      } // end of having a current line
-
 // start a new line
 
     int      iFlags = m_iFlags;             
@@ -2598,15 +3426,34 @@ POSITION pos;
           }
         } // end of note 
 
-    m_pCurrentLine = new CLine (++m_total_lines, 
-                                m_nWrapColumn,
-                                iFlags,       // style flags
-                                iForeColour,  
-                                iBackColour,
-                                m_bUTF_8);
+    std::unique_ptr<CLine> pNewLine
+      (new CLine (m_total_lines + 1,
+                  m_nWrapColumn,
+                  iFlags,       // style flags
+                  iForeColour,
+                  iBackColour,
+                  m_bUTF_8));
 
-    m_pCurrentLine->flags = flags;
-    pos = m_LineList.AddTail (m_pCurrentLine);
+    pNewLine->flags = flags;
+    pos = m_LineList.AddTail (pNewLine.get ());
+
+    // Shrink the old line only after the new line and its list node exist.
+    // If shrinking fails, remove the unpublished new line again.
+    try
+      {
+      if (bResizePrevious && m_pCurrentLine)
+        m_pCurrentLine->ResizeText (MAX (m_pCurrentLine->len, 1));
+      }
+    catch (...)
+      {
+      m_LineList.RemoveAt (pos);
+      throw;
+      }
+
+    m_pCurrentLine = pNewLine.release ();
+    if (pbCreated)
+      *pbCreated = true;
+    m_total_lines++;
 
 // add every "JUMP_SIZE" line positions to the positions array
 
@@ -2624,11 +3471,14 @@ POSITION pos;
   catch (CMemoryException * e)
     {
 
-    RemoveChunk ();   // get rid of JUMP_SIZE lines
+    if (m_LineList.GetCount () >= JUMP_SIZE)
+      RemoveChunk ();   // get rid of JUMP_SIZE lines
     OnConnectionDisconnect ();    // close the world
     TMessageBox ("Ran out of memory. The world has been closed.");
 
     e->Delete ();
+
+    return false;
 
     } // end of catch block
 
@@ -2655,7 +3505,9 @@ POSITION pos;
 
   App.m_bUpdateActivity = TRUE;
 
-  }   // end of CMUSHclientDoc::StartNewLine
+  return true;
+
+  }   // end of CMUSHclientDoc::FinishNewLine
 
 const bool CMUSHclientDoc::CheckScriptingAvailable (const char * sWhat,
                                                     const DISPID dispid,
@@ -4381,13 +5233,12 @@ long i;
 
 // do a new line positions array
 
-  delete [] m_pLinePositions;
-  m_pLinePositions = new POSITION [(nNewBufferSize / JUMP_SIZE) + 1];
+  POSITION * pNewLinePositions = new POSITION [(nNewBufferSize / JUMP_SIZE) + 1];
 
 // clear all elements
 
   for (i = 0; i <= nNewBufferSize / JUMP_SIZE; i++)
-    m_pLinePositions [i] = NULL;
+    pNewLinePositions [i] = NULL;
 
 // re-seed positions array
 
@@ -4396,9 +5247,12 @@ long i;
       i++)
         {
         if (i % JUMP_SIZE == 0)
-          m_pLinePositions [i / JUMP_SIZE] = pos;
+          pNewLinePositions [i / JUMP_SIZE] = pos;
         m_LineList.GetNext (pos);
         } // end of for loop
+
+  delete [] m_pLinePositions;
+  m_pLinePositions = pNewLinePositions;
 
 // refresh view to show different scroll bars
 
@@ -4512,6 +5366,8 @@ long CMUSHclientDoc::GetLastLine (void)
  void CMUSHclientDoc::RemoveChunk (void)
    {
   int i;
+
+  m_iOutputGeneration++;
 
 // remove JUMP_SIZE lines
 
@@ -4901,20 +5757,24 @@ void CMUSHclientDoc::ClearOutput (void)
     return;
 
 POSITION pos;
+  std::unique_ptr<CLine> pNewLine
+    (new CLine (1,
+                m_nWrapColumn,
+                0, WHITE, BLACK,
+                m_bUTF_8));
 
-// delete lines list
+  // Publish the replacement node before deleting the existing output.
+  int iOldLineCount = m_LineList.GetCount ();
+  if (iOldLineCount)
+    m_iOutputGeneration++;
+  POSITION newLinePosition = m_LineList.AddTail (pNewLine.get ());
+  CLine * pPublishedLine = pNewLine.release ();
 
-  DELETE_LIST (m_LineList);
+  for (int iLine = 0; iLine < iOldLineCount; iLine++)
+    delete m_LineList.RemoveHead ();
 
-// put one line in line list
-
-  m_total_lines = 0;
-  m_pCurrentLine = new CLine (++m_total_lines, 
-                              m_nWrapColumn,
-                              0, WHITE, BLACK,
-                              m_bUTF_8);
-
-  m_LineList.AddTail (m_pCurrentLine);
+  m_pCurrentLine = pPublishedLine;
+  m_total_lines = 1;
 //  m_strCurrentLine.Empty ();
 
   // clear all elements in our positions array
@@ -4922,7 +5782,9 @@ POSITION pos;
   for (int i = 0; i <= m_maxlines / JUMP_SIZE; i++)
     m_pLinePositions [i] = NULL;
 
-  m_pLinePositions [0] = m_LineList.GetHeadPosition ();
+  m_pLinePositions [0] = newLinePosition;
+
+  RefreshMXPMissingTagAnchors ();
 
   // previous find won't work now
 
@@ -5603,23 +6465,16 @@ CStyle * CMUSHclientDoc::AddStyle (const unsigned short iFlags,
   if (!pLine)
      return NULL;
 
+  CStyle * pOldStyle = NULL;
+  POSITION oldStylePosition = NULL;
   if (!pLine->styleList.IsEmpty ())
     {
-    // find current style
-    CStyle * pOldStyle = pLine->styleList.GetTail ();
-
-    // We want the new style, but did the old one have a text run?
-    // if not, we don't really need that
-
+    pOldStyle = pLine->styleList.GetTail ();
     if (pOldStyle->iLength == 0 && (pOldStyle->iFlags & START_TAG) == 0)
-      {
-      DELETESTYLE (pOldStyle);
-      pLine->styleList.RemoveTail ();
-      }   // end of redundant style
-    } // end of having at least one style
+      oldStylePosition = pLine->styleList.GetTailPosition ();
+    }
 
-// create new style item
-CStyle * pNewStyle = NEWSTYLE;
+std::unique_ptr<CStyle> pNewStyle (NEWSTYLE);
 
 // use new styles
    pNewStyle->iFlags      = iFlags;
@@ -5629,10 +6484,15 @@ CStyle * pNewStyle = NEWSTYLE;
    pNewStyle->pAction = GetAction (strAction, strHint, strVariable);
 
 // add to line style list
-   pLine->styleList.AddTail (pNewStyle); 
+   pLine->styleList.AddTail (pNewStyle.get ());
 
+   if (oldStylePosition)
+     {
+     pLine->styleList.RemoveAt (oldStylePosition);
+     DELETESTYLE (pOldStyle);
+     }
 
-   return pNewStyle;
+   return pNewStyle.release ();
 
   } // end of CMUSHclientDoc::AddStyle 
 
@@ -5652,27 +6512,16 @@ CStyle * CMUSHclientDoc::AddStyle (const unsigned short iFlags,
   if (!pLine)
      return NULL;
 
-  // we are using this action once more
-  if (pAction)
-    pAction->AddRef ();
-
+  CStyle * pOldStyle = NULL;
+  POSITION oldStylePosition = NULL;
   if (!pLine->styleList.IsEmpty ())
     {
-    // find current style
-    CStyle * pOldStyle = pLine->styleList.GetTail ();
-
-    // We want the new style, but did the old one have a text run?
-    // if not, we don't really need that
-
+    pOldStyle = pLine->styleList.GetTail ();
     if (pOldStyle->iLength == 0 && (pOldStyle->iFlags & START_TAG) == 0)
-      {
-      DELETESTYLE (pOldStyle);
-      pLine->styleList.RemoveTail ();
-      }   // end of redundant style
-    } // end of having at least one style
+      oldStylePosition = pLine->styleList.GetTailPosition ();
+    }
 
-// create new style item
-CStyle * pNewStyle = NEWSTYLE;
+std::unique_ptr<CStyle> pNewStyle (NEWSTYLE);
 
 // use new styles
    pNewStyle->iFlags      = iFlags;
@@ -5680,13 +6529,155 @@ CStyle * pNewStyle = NEWSTYLE;
    pNewStyle->iBackColour = iBackColour;
    pNewStyle->iLength     = iLength;
    pNewStyle->pAction = pAction;
+   if (pAction)
+     pAction->AddRef ();
 
 // add to line style list
-   pLine->styleList.AddTail (pNewStyle); 
+   pLine->styleList.AddTail (pNewStyle.get ());
 
-   return pNewStyle;
+   if (oldStylePosition)
+     {
+     pLine->styleList.RemoveAt (oldStylePosition);
+     DELETESTYLE (pOldStyle);
+     }
+
+   return pNewStyle.release ();
 
   } // end of CMUSHclientDoc::AddStyle 
+
+
+void CMUSHclientDoc::RefreshMXPMissingTagAnchors (void)
+  {
+  if (!m_pCurrentLine || m_ActiveTagList.IsEmpty ())
+    return;
+
+  // Lines have increasing identities. New markers and ranges start on the
+  // current tail; wraps and style splits keep those identities. The last
+  // indexed line at or before an identity cannot be after its origin line.
+  // Keep the preceding block, including an older line reused after deletion.
+  // All positions are local: this function allocates nothing and calls no
+  // callbacks, including when an output transaction rolls back in a destructor.
+  const auto FindAnchorStart = [this] (const __int64 iIdentity) -> POSITION
+    {
+    POSITION start = m_LineList.GetHeadPosition ();
+    if (!m_pLinePositions)
+      return start;
+    int low = 0;
+    int high = (m_LineList.GetCount () - 1) / JUMP_SIZE;
+    while (low <= high)
+      {
+      const int middle = low + (high - low) / 2;
+      POSITION candidate = m_pLinePositions [middle];
+      if (!candidate)
+        return m_LineList.GetHeadPosition ();
+      if (m_LineList.GetAt (candidate)->nCreationNumber <= iIdentity)
+        {
+        start = candidate;
+        low = middle + 1;
+        }
+      else
+        high = middle - 1;
+      }
+    return start;
+    };
+
+  const auto HasOpeningMarker = [] (CLine * pLine, const __int64 iIdentity)
+    {
+    for (POSITION pos = pLine->styleList.GetHeadPosition (); pos; )
+      {
+      CStyle * pStyle = pLine->styleList.GetNext (pos);
+      if ((pStyle->iFlags & START_TAG) &&
+          pStyle->nCreationNumber == iIdentity)
+        return true;
+      }
+    return false;
+    };
+
+  for (POSITION tagpos = m_ActiveTagList.GetHeadPosition (); tagpos; )
+    {
+    CActiveTag * pTag = m_ActiveTagList.GetNext (tagpos);
+    bool bOpeningMarkerPresent = false;
+    // Wrapping records the marker's new line. Check that line first, even
+    // when the line where the marker was created has already been pruned.
+    for (POSITION pos = FindAnchorStart (pTag->nOpeningLineCreationNumber);
+         pos; )
+      {
+      CLine * pLine = m_LineList.GetNext (pos);
+      if (pLine->nCreationNumber > pTag->nOpeningLineCreationNumber)
+        break;
+      if (pLine->nCreationNumber == pTag->nOpeningLineCreationNumber)
+        {
+        bOpeningMarkerPresent =
+          HasOpeningMarker (pLine, pTag->nOpeningStyleCreationNumber);
+        break;
+        }
+      }
+
+    // A transaction can retain an earlier copy of a moved marker. If the
+    // new line was deleted, that copy still prevents a fallback update.
+    // RestoreWrap removes the moved copy when it records the earlier line.
+    if (!bOpeningMarkerPresent &&
+        pTag->nOpeningStyleCreationNumber < pTag->nOpeningLineCreationNumber)
+      for (POSITION pos = FindAnchorStart (pTag->nOpeningStyleCreationNumber);
+           pos; )
+        {
+        CLine * pLine = m_LineList.GetNext (pos);
+        if (pLine->nCreationNumber >= pTag->nOpeningLineCreationNumber)
+          break;
+        if (HasOpeningMarker (pLine, pTag->nOpeningStyleCreationNumber))
+          {
+          bOpeningMarkerPresent = true;
+          break;
+          }
+        }
+    if (bOpeningMarkerPresent)
+      continue;
+
+    // A fallback range can predate the opening line, or span several lines.
+    // Its birth identity includes the earliest retained fragment, unlike the
+    // saved fallback line, which can initially name only the current tail.
+    __int64 iBoundaryIdentity = pTag->nOpeningLineCreationNumber;
+    if (pTag->nFallbackStyleRangeNumber &&
+        pTag->nFallbackStyleRangeNumber < iBoundaryIdentity)
+      iBoundaryIdentity = pTag->nFallbackStyleRangeNumber;
+    CLine * pBoundaryLine = NULL;
+    CStyle * pBoundaryStyle = NULL;
+    for (POSITION linepos = FindAnchorStart (iBoundaryIdentity);
+         linepos && !pBoundaryStyle; )
+      {
+      CLine * pLine = m_LineList.GetNext (linepos);
+      for (POSITION stylepos = pLine->styleList.GetHeadPosition ();
+           stylepos; )
+        {
+        CStyle * pStyle = pLine->styleList.GetNext (stylepos);
+        const bool bExistingFallback =
+          pTag->nFallbackStyleRangeNumber &&
+          pStyle->nRangeCreationNumber ==
+            pTag->nFallbackStyleRangeNumber;
+        const bool bPostOpeningStyle =
+          pLine->nCreationNumber > pTag->nOpeningLineCreationNumber ||
+          (pLine->nCreationNumber == pTag->nOpeningLineCreationNumber &&
+           pStyle->nCreationNumber > pTag->nOpeningStyleCreationNumber);
+        if (bExistingFallback || bPostOpeningStyle)
+          {
+          pBoundaryLine = pLine;
+          pBoundaryStyle = pStyle;
+          break;
+          }
+        }
+      }
+
+    if (!pBoundaryStyle)
+      {
+      pBoundaryLine = m_pCurrentLine;
+      pBoundaryStyle = m_pCurrentLine->styleList.GetTail ();
+      }
+
+    pTag->nFallbackLineCreationNumber = pBoundaryLine->nCreationNumber;
+    pTag->nFallbackStyleRangeNumber =
+      pBoundaryStyle->nRangeCreationNumber;
+    }
+  } // end of CMUSHclientDoc::RefreshMXPMissingTagAnchors
 
 
 void CMUSHclientDoc::OnDisplayNocommandecho() 

--- a/doc.h
+++ b/doc.h
@@ -15,6 +15,7 @@
 #include "miniwindow.h"
 #include "plugins.h"
 #include "version.h"
+#include "output_line_buffer.h"
 
 #define COMPRESS_BUFFER_LENGTH 10000   // size of decompression buffer
 extern CString MUSHCLIENT_VERSION;
@@ -2978,7 +2979,8 @@ class COutputAppendTransaction
     void SetListCount (const int iListCount);
     size_t PrepareWrap (CLine * pPreviousLine, const int iSplitLength);
     void PublishWrap (const size_t iWrap,
-                      const __int64 iNewLineCreationNumber);
+                      const __int64 iNewLineCreationNumber,
+                      std::unique_ptr<COutputLineBuffer> pTextBuffer);
     void Commit ();
     void Rollback ();
 
@@ -3010,6 +3012,7 @@ class COutputAppendTransaction
       __int64 iNewLineCreationNumber;
       int iSplitLength;
       vector<CWrapStyleBackup> styleBackups;
+      std::unique_ptr<COutputLineBuffer> pTextBuffer;
       bool bPublished;
       };
 

--- a/doc.h
+++ b/doc.h
@@ -755,6 +755,7 @@ public:
 // new in version 8
 
   LONG    m_maxlines;   // maximum lines in scrollback buffer
+  __int64 m_iOutputGeneration;  // changes when output line positions become invalid
   LONG    m_nHistoryLines;  // maximum lines in command history
   unsigned short  m_nWrapColumn;    // column to wrap at
 
@@ -1172,6 +1173,10 @@ public:
   int m_iMXP_previousMode; // previous mode before mode 4 (secure-once mode)
   bool m_bInParagraph; // discard newlines (wrap)
   bool m_bMXP_script;   // in script collection mode
+  __int64 m_iMXPParagraphOwner;
+  __int64 m_iMXPPreOwner;
+  __int64 m_iMXPScriptOwner;
+  __int64 m_iMXPListOwner;
   bool m_bSuppressNewline;        // newline does NOT start a new line
 
   // NB - lists are being done in a hurry - I should really allow for nesting them
@@ -1200,6 +1205,7 @@ public:
 
   __int64 m_iMXPerrors;
   __int64 m_iMXPtags;
+  __int64 m_iMXPGeneration;  // changes when MXP is reset, stopped, or restarted
   __int64 m_iMXPentities;
 
   // end MXP stuff
@@ -1485,8 +1491,12 @@ public:
                const bool bLogIt);
 	void ReceiveMsg();
 	void DisplayMsg(LPCTSTR lpszText, int size, const int flags, const bool fake = false);
-  void AddToLine (LPCTSTR lpszText, const int flags);
-  void StartNewLine_KeepPreviousStyle (const int flags);
+  bool AddToLine (LPCTSTR lpszText, const int flags);
+  bool AddToLineInternal (LPCTSTR lpszText, const int flags,
+                          COutputAppendTransaction * pTransaction);
+  bool StartNewLine_KeepPreviousStyle (const int flags,
+                                       bool * pbCreated = NULL,
+                                       const bool bFinishTransition = false);
   void Phase_ESC (const unsigned char c);  
   void Phase_UTF8 (const unsigned char c);  
   void Phase_ANSI (const unsigned char c);           
@@ -1535,22 +1545,29 @@ public:
   void MXP_Attlist (CString strName, CString strTag);
   void MXP_StartTag (CString strTag);
   void MXP_EndTag (CString strTag);
-  void MXP_CloseTag (CString strTag, const bool bOpen = false);
+  bool MXP_PrepareCloseTag (CString strTag, const bool bOpen,
+                            const __int64 iExpectedOpeningStyleCreationNumber,
+                            const vector<int> & closeActions,
+                            const CActiveTag * pActiveTag,
+                            CPreparedMXPClose & preparedClose);
+  void MXP_FinishCloseTag (const CPreparedMXPClose & preparedClose);
   void MXP_CloseOpenTags (void);
   void MXP_CloseAllTags (void);
   void MXP_On (const bool bPueblo = false, const bool bManual = false);     // turning MXP/Pueblo on
   void MXP_Off (const bool bCompletely = false);  // turning MXP off
-  void MXP_OpenAtomicTag (const CString strTag,   // name
+  bool MXP_OpenAtomicTag (const CString strTag,   // name
                           int iAction,            // action code
                           CStyle * pStyle,        // style it should modify
+                          __int64 & iResultStyleCreationNumber, // exact style identity
                           CString & strAction,    // new action
                           CString & strHint,      // new hint
                           CString & strVariable,  // new variable
-                          CArgumentList & ArgumentList);  // args
+                          CArgumentList & ArgumentList,
+                          const __int64 iStateOwner,
+                          COutputAppendTransaction * pOutputTransaction,
+                          vector<CDeferredMXPMessage> & deferredMessages);  // args
   void MXP_CloseAtomicTag (const int iAction, 
-                           const CString & strText,
-                           const POSITION firstlinepos,
-                           const POSITION firststylepos);
+                           const CPreparedMXPClose & preparedClose);
   CString MXP_GetEntity (CString & strName);
   bool BuildArgumentList (CArgumentList & ArgumentList, 
                           CString strTag);
@@ -1620,17 +1637,30 @@ public:
                      CAction *            pAction = NULL,
                      CLine *              pLine = NULL);
 
+  void RefreshMXPMissingTagAnchors (void);
+
   void RememberStyle (const CStyle * pStyle); 
 
-  void StartNewLine (const bool hard_break, const int flags);
+  bool StartNewLine (const bool hard_break, const int flags,
+                     const bool bResizePrevious = true,
+                     bool * pbCreated = NULL);
+  bool FinishNewLine (const int flags, const bool bResizePrevious,
+                      bool * pbCreated);
   bool ProcessPreviousLine (void);
   void SendLineToPlugin (void);
   void SetNewLineColour (const int flags);
 
+  struct CTriggerLineSnapshot
+    {
+    __int64 iCreationNumber;
+    int iColumn;  // byte offset in the original paragraph
+    int iLength;
+    };
+
   void ProcessOneTriggerSequence (CString & strCurrentLine,
                             CPaneLine & StyledLine,
                             CString & strResponse,
-                            const POSITION prevpos,
+                            const vector<CTriggerLineSnapshot> & triggerLines,
                             bool & bNoLog,
                             bool & bNoOutput,
                             bool & bChangedColour,
@@ -1648,7 +1678,8 @@ public:
 
   void WriteToLog (const char * text, size_t len);
   void WriteToLog (const CString & strText);
-  void LogLineInHTMLcolour (POSITION startpos);
+  void LogLineInHTMLcolour (POSITION startpos,
+                            const map<__int64, int> * pLineLengths = NULL);
   void LogCommand (const char * text);
   void OutputBadUTF8characters (void);
 
@@ -2923,6 +2954,102 @@ public:
 	DECLARE_INTERFACE_MAP()
 
 };
+
+/////////////////////////////////////////////////////////////////////////////
+
+class COutputAppendTransaction
+  {
+  public:
+    COutputAppendTransaction (CMUSHclientDoc * pDoc, const size_t iLength);
+    ~COutputAppendTransaction ();
+
+    __int64 Identity () const;
+    void Reserve (const size_t iLength);
+    void TrackLine (const CLine * pLine);
+    void MarkCurrentLineStyles ();
+    CStyle * PrepareAppendStyle ();
+    void OwnStyle (CStyle * pStyle);
+    void RecordCreatedLine ();
+    bool StartNewLine (const bool bHardBreak,
+                       const int iFlags,
+                       const bool bResizePrevious,
+                       bool * pbCreated);
+    void SetLineFlags (CLine * pLine, const unsigned char iFlags);
+    void SetListCount (const int iListCount);
+    size_t PrepareWrap (CLine * pPreviousLine, const int iSplitLength);
+    void PublishWrap (const size_t iWrap,
+                      const __int64 iNewLineCreationNumber);
+    void Commit ();
+    void Rollback ();
+
+  private:
+    COutputAppendTransaction (const COutputAppendTransaction &);
+    COutputAppendTransaction & operator= (const COutputAppendTransaction &);
+
+    struct CCreatedLine
+      {
+      __int64 iLineCreationNumber;
+      __int64 iStyleCreationNumber;
+      __int64 iStyleRangeCreationNumber;
+      unsigned short iFlags;
+      COLORREF iForeColour;
+      COLORREF iBackColour;
+      CAction * pAction;
+      };
+
+    struct CWrapStyleBackup
+      {
+      __int64 iStyleCreationNumber;
+      unsigned short iOldLength;
+      unsigned short iRetainedLength;
+      };
+
+    struct CWrapMove
+      {
+      __int64 iPreviousLineCreationNumber;
+      __int64 iNewLineCreationNumber;
+      int iSplitLength;
+      vector<CWrapStyleBackup> styleBackups;
+      bool bPublished;
+      };
+
+    struct CLineBreakState
+      {
+      __int64 iLineCreationNumber;
+      bool bOldHardReturn;
+      bool bExpectedHardReturn;
+      bool bPublished;
+      };
+
+    struct CLineFlagsState
+      {
+      __int64 iLineCreationNumber;
+      unsigned char iOldFlags;
+      unsigned char iExpectedFlags;
+      };
+
+    struct CListCountState
+      {
+      int iListMode;
+      int iOldListCount;
+      int iExpectedListCount;
+      __int64 iListOwner;
+      };
+
+    void RestoreWrap (const CWrapMove & wrap);
+    CLine * FindLine (const __int64 iLineCreationNumber,
+                      POSITION * pPosition = NULL) const;
+
+    CMUSHclientDoc * m_pDoc;
+    __int64 m_iAppendCreationNumber;
+    __int64 m_iFirstAffectedLineCreationNumber;
+    vector<CCreatedLine> m_CreatedLines;
+    vector<CWrapMove> m_Wraps;
+    vector<CLineBreakState> m_LineBreaks;
+    vector<CLineFlagsState> m_LineFlags;
+    vector<CListCountState> m_ListCounts;
+    bool m_bCommitted;
+  };
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/doc_construct.cpp
+++ b/doc_construct.cpp
@@ -211,6 +211,7 @@ int i;
   m_InputFontHeight = 0;
   m_InputFontWidth = 0;
   m_total_lines = 0;
+  m_iOutputGeneration = 0;
   m_newlines_received = 0;
   m_last_line_with_IAC_GA = 0;
   m_nTotalLinesSent = 0;
@@ -262,6 +263,10 @@ int i;
   m_bInParagraph = false;
   m_bMXP_script = false;
   m_bPreMode = false;
+  m_iMXPParagraphOwner = 0;
+  m_iMXPPreOwner = 0;
+  m_iMXPScriptOwner = 0;
+  m_iMXPListOwner = 0;
   m_iMXP_defaultMode = eMXP_open;
   m_iMXP_mode = m_iMXP_defaultMode;
   m_cLastChar = 0;
@@ -386,6 +391,7 @@ int i;
   
   m_iMXPerrors = 0;     
   m_iMXPtags = 0;       
+  m_iMXPGeneration = 0;
   m_iMXPentities = 0;   
 
   // scripting support

--- a/mushview.cpp
+++ b/mushview.cpp
@@ -3299,21 +3299,10 @@ void CMUSHView::AutoWrapWindowWidth (CMUSHclientDoc* pDoc)
 
     if (pDoc->m_pCurrentLine)     // a new world might not have a line yet
       {
-      // save current line text
-      CString strLine = CString (pDoc->m_pCurrentLine->text, pDoc->m_pCurrentLine->len);
-
-  #ifdef USE_REALLOC
-      pDoc->m_pCurrentLine->text  = (char *) realloc (pDoc->m_pCurrentLine->text, 
-                                               MAX (pDoc->m_pCurrentLine->len, iWidth) 
-                                               * sizeof (char));
-  #else
-      delete [] pDoc->m_pCurrentLine->text;
-      pDoc->m_pCurrentLine->text = new char [MAX (pDoc->m_pCurrentLine->len, iWidth)];
-  #endif
-
-      // put text back
-      memcpy (pDoc->m_pCurrentLine->text, (LPCTSTR) strLine, pDoc->m_pCurrentLine->len);
-      ASSERT (pDoc->m_pCurrentLine->text);
+      int iMemoryAllocated = MAX (pDoc->m_pCurrentLine->len, iWidth);
+      if (pDoc->m_bUTF_8)
+        iMemoryAllocated *= 4;
+      pDoc->m_pCurrentLine->ResizeText (iMemoryAllocated);
     
       }   // end of having a current line
 

--- a/mxp/mxpClose.cpp
+++ b/mxp/mxpClose.cpp
@@ -18,8 +18,32 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 
 #define MAX_TEXT 1000     // max size for &text; variable
 
-void CMUSHclientDoc::MXP_CloseTag (CString strTag, const bool bOpen)
+bool CMUSHclientDoc::MXP_PrepareCloseTag (
+  CString strTag,
+  const bool bOpen,
+  const __int64 iExpectedOpeningStyleCreationNumber,
+  const vector<int> & closeActions,
+  const CActiveTag * pActiveTag,
+  CPreparedMXPClose & preparedClose)
   {
+  preparedClose = CPreparedMXPClose ();
+  preparedClose.strTag = strTag;
+  preparedClose.closeActions = closeActions;
+  preparedClose.iActiveTagCreationNumber =
+    pActiveTag ? pActiveTag->nCreationNumber : 0;
+  if (pActiveTag)
+    {
+    preparedClose.bOpeningInParagraph = pActiveTag->bOpeningInParagraph;
+    preparedClose.bOpeningPreMode = pActiveTag->bOpeningPreMode;
+    preparedClose.bOpeningMXPScript = pActiveTag->bOpeningMXPScript;
+    preparedClose.iOpeningListMode = pActiveTag->iOpeningListMode;
+    preparedClose.iOpeningListCount = pActiveTag->iOpeningListCount;
+    preparedClose.iOpeningParagraphOwner =
+      pActiveTag->iOpeningParagraphOwner;
+    preparedClose.iOpeningPreOwner = pActiveTag->iOpeningPreOwner;
+    preparedClose.iOpeningScriptOwner = pActiveTag->iOpeningScriptOwner;
+    preparedClose.iOpeningListOwner = pActiveTag->iOpeningListOwner;
+    }
 
   POSITION linepos = 0, 
            stylepos, 
@@ -42,8 +66,9 @@ void CMUSHclientDoc::MXP_CloseTag (CString strTag, const bool bOpen)
       oldstylepos = stylepos;   // where we found it
       pStyle = pLine->styleList.GetPrev (stylepos);
 
-      if ((pStyle->iFlags & START_TAG) &&
-           pStyle->pAction)
+      if ((pStyle->iFlags & START_TAG) && pStyle->pAction &&
+          (!iExpectedOpeningStyleCreationNumber ||
+           pStyle->nCreationNumber == iExpectedOpeningStyleCreationNumber))
         if (pStyle->pAction->m_strAction == strTag)
           bFoundit = true;
 
@@ -55,26 +80,115 @@ void CMUSHclientDoc::MXP_CloseTag (CString strTag, const bool bOpen)
       }   // end of style loop
     } // end of line loop
 
-  if (!bFoundit)
+  bool bOpeningMarkerMissing = !bFoundit && pActiveTag;
+
+  if (!bFoundit && !bOpeningMarkerMissing)
     {
     MXP_error (DBG_WARNING, wrnMXP_OpenTagNotInOutputBuffer,
               TFormat ("Opening MXP tag <%s> not found in output buffer", 
               (LPCTSTR) strTag)); 
-    return;
+    return false;
     }
 
-  // OK - tag was opened at pStyle in pLine at position oldstylepos
+  if (bOpeningMarkerMissing)
+    {
+    oldlinepos = NULL;
+    oldstylepos = NULL;
+    pLine = NULL;
+    pStyle = NULL;
 
-CString strVariable = "mxp_";
-bool bHaveVariable = false;
+    // A destructive tail change publishes an exact replacement boundary.
+    // Find that range first because a reused older line can contain new text.
+    if (pActiveTag->nFallbackStyleRangeNumber)
+      for (POSITION candidateLinePosition = m_LineList.GetHeadPosition ();
+           candidateLinePosition && !oldstylepos; )
+        {
+        POSITION currentLinePosition = candidateLinePosition;
+        CLine * pCandidateLine = m_LineList.GetNext (candidateLinePosition);
+        for (POSITION candidateStylePosition =
+               pCandidateLine->styleList.GetHeadPosition ();
+             candidateStylePosition; )
+          {
+          POSITION currentStylePosition = candidateStylePosition;
+          CStyle * pCandidateStyle =
+            pCandidateLine->styleList.GetNext (candidateStylePosition);
+          if (pCandidateLine->nCreationNumber <
+                pActiveTag->nFallbackLineCreationNumber ||
+              pCandidateStyle->nRangeCreationNumber !=
+              pActiveTag->nFallbackStyleRangeNumber)
+            continue;
 
-   if (pStyle->pAction &&
+          oldlinepos = currentLinePosition;
+          oldstylepos = currentStylePosition;
+          pLine = pCandidateLine;
+          break;
+          }
+        }
+
+    // Front pruning does not need a replacement boundary. Use only lines and
+    // styles that were created after the original opening point.
+    for (POSITION candidateLinePosition = m_LineList.GetHeadPosition ();
+         candidateLinePosition && !oldstylepos; )
+      {
+      POSITION currentLinePosition = candidateLinePosition;
+      CLine * pCandidateLine = m_LineList.GetNext (candidateLinePosition);
+
+      if (pCandidateLine->nCreationNumber <
+          pActiveTag->nOpeningLineCreationNumber)
+        continue;
+
+      POSITION candidateStylePosition =
+        pCandidateLine->styleList.GetHeadPosition ();
+
+      if (pCandidateLine->nCreationNumber ==
+          pActiveTag->nOpeningLineCreationNumber)
+        {
+        while (candidateStylePosition)
+          {
+          POSITION currentStylePosition = candidateStylePosition;
+          CStyle * pCandidateStyle =
+            pCandidateLine->styleList.GetNext (candidateStylePosition);
+          if (pCandidateStyle->nCreationNumber >
+              pActiveTag->nOpeningStyleCreationNumber)
+            {
+            oldstylepos = currentStylePosition;
+            break;
+            }
+          }
+        }
+
+      if (!oldstylepos &&
+          pCandidateLine->nCreationNumber >
+            pActiveTag->nOpeningLineCreationNumber)
+        oldstylepos = pCandidateLine->styleList.GetHeadPosition ();
+
+      if (oldstylepos)
+        {
+        oldlinepos = currentLinePosition;
+        pLine = pCandidateLine;
+        break;
+        }
+      }
+    }
+
+CString & strVariable = preparedClose.strVariable;
+bool & bHaveVariable = preparedClose.bHaveVariable;
+strVariable = "mxp_";
+
+   if (bOpeningMarkerMissing && !pActiveTag->strVariable.IsEmpty ())
+     {
+     bHaveVariable = true;
+     strVariable += pActiveTag->strVariable;
+     }
+   else if (!bOpeningMarkerMissing && pStyle->pAction &&
      !pStyle->pAction->m_strVariable.IsEmpty ())
      {
      bHaveVariable = true;
      strVariable += pStyle->pAction->m_strVariable;
      }
-   else if (((strTag == "var") || (strTag == "v")) && !strFoundVariable.IsEmpty ())
+   else if (!bOpeningMarkerMissing &&
+            ((strTag == "var") || (strTag == "v")) &&
+            !strFoundVariable.IsEmpty ())
      {
      // <var>blah</var> is a bit different
      bHaveVariable = true;
@@ -83,27 +197,42 @@ bool bHaveVariable = false;
  
   // establish text of characters between start tag and end of buffer
 
-  CString strText;
+  CString & strText = preparedClose.strText;
   bool bStart = false;
+  set<__int64> & contentStyleRangeNumbers =
+    preparedClose.contentStyleRangeNumbers;
   int iBytesToGo = MAX_TEXT;
   char * p = strText.GetBuffer (MAX_TEXT);
 
-  for (linepos = oldlinepos; linepos && iBytesToGo > 2; )
+  for (linepos = oldlinepos; linepos; )
     {
+    POSITION currentLinePosition = linepos;
     CLine * pLine2 = m_LineList.GetNext (linepos);
     int iCol = 0;
     int iLen = 0;
  
     for (stylepos = pLine2->styleList.GetHeadPosition () ; stylepos; )
       {
+      POSITION currentStylePosition = stylepos;
       CStyle * pStyle2 = pLine2->styleList.GetNext (stylepos);
-      if (pStyle2 == pStyle)
+      if ((!bOpeningMarkerMissing && pStyle2 == pStyle) ||
+          (bOpeningMarkerMissing &&
+           currentLinePosition == oldlinepos &&
+           currentStylePosition == oldstylepos))
         bStart = true;
       if (bStart)
+        {
         iLen += pStyle2->iLength; // count length
+        if (contentStyleRangeNumbers.empty ())
+          preparedClose.iFirstContentLineCreationNumber = pLine2->nCreationNumber;
+        contentStyleRangeNumbers.insert (pStyle2->nRangeCreationNumber);
+        }
       else
         iCol += pStyle2->iLength; // starting column
       }   // end of each style
+
+    if (iBytesToGo <= 2)
+      continue;
 
     int iCopy = MIN (iLen, iBytesToGo);
 
@@ -126,6 +255,68 @@ bool bHaveVariable = false;
     }   // end of each line
 
   strText.ReleaseBuffer (MAX_TEXT - iBytesToGo);
+
+  if (!bOpeningMarkerMissing)
+    contentStyleRangeNumbers.erase (pStyle->nRangeCreationNumber);
+
+  // Publish the restored style before any callback. A callback can open a new
+  // tag, and that tag must inherit the style outside the tag being closed.
+  CStyle * pRestoredStyle = NULL;
+
+  if (bOpeningMarkerMissing)
+    {
+    pRestoredStyle = AddStyle (pActiveTag->iOpeningFlags,
+                               pActiveTag->iOpeningForeColour,
+                               pActiveTag->iOpeningBackColour,
+                               0,
+                               pActiveTag->pOpeningAction);
+    }
+  else
+    {
+    // The opening marker remembers the style that must be restored.
+    CStyle * pLastStyle = m_pCurrentLine->styleList.GetTail ();
+    POSITION lastStylePosition =
+      m_pCurrentLine->styleList.GetTailPosition ();
+
+    m_pCurrentLine->styleList.AddTail (pStyle);
+    pLine->styleList.RemoveAt (oldstylepos);
+
+    if (pLastStyle->iLength == 0 &&
+        (pLastStyle->iFlags & START_TAG) == 0)
+      {
+      m_pCurrentLine->styleList.RemoveAt (lastStylePosition);
+      DELETESTYLE (pLastStyle);
+      }
+
+    pStyle->iFlags &= ~START_TAG;
+    CAction * pTagAction = pStyle->pAction;
+    pStyle->pAction = pActiveTag ? pActiveTag->pOpeningAction : NULL;
+    if (pStyle->pAction)
+      pStyle->pAction->AddRef ();
+    if (pTagAction)
+      pTagAction->Release ();
+
+    pRestoredStyle = pStyle;
+    }
+
+  RememberStyle (pRestoredStyle);
+
+  return true;
+  } // end of CMUSHclientDoc::MXP_PrepareCloseTag
+
+void CMUSHclientDoc::MXP_FinishCloseTag (
+  const CPreparedMXPClose & preparedClose)
+  {
+  CPluginContextGuard pluginContextGuard (this, NULL);
+
+  const CString & strTag = preparedClose.strTag;
+  const CString & strText = preparedClose.strText;
+  const CString & strVariable = preparedClose.strVariable;
+  const bool bHaveVariable = preparedClose.bHaveVariable;
+
+  exception_ptr pendingException;
+  try
+    {
 
   // call script if required
   if (m_dispidOnMXP_CloseTag != DISPID_UNKNOWN)
@@ -183,22 +374,29 @@ bool bHaveVariable = false;
                               (LPCTSTR) strTag,
                               (LPCTSTR) strText));
 
-  m_CurrentPlugin = NULL;
-
   // if this tag had a FLAG directive, set the desired variable - prefixed with mxp_
   if (bHaveVariable)
     {
-    CVariable * variable_item;
+    CVariable * old_variable_item = NULL;
+    m_VariableMap.Lookup (strVariable, old_variable_item);
 
-    // get rid of old variable, if any
-    if (m_VariableMap.Lookup (strVariable, variable_item))
+    CVariable * variable_item = new CVariable;
+    try
+      {
+      variable_item->nUpdateNumber = App.GetUniqueNumber ();   // for concurrency checks
+      variable_item->strLabel = strVariable;
+      variable_item->strContents = strText;
+      m_VariableMap.SetAt (strVariable, variable_item);
+      }
+    catch (...)
+      {
       delete variable_item;
+      throw;
+      }
 
-    // create new variable item and insert in variable map
-    m_VariableMap.SetAt (strVariable, variable_item = new CVariable);
+    delete old_variable_item;
     m_bVariablesChanged = true;
 //    SetModifiedFlag (TRUE);
-    variable_item->nUpdateNumber = App.GetUniqueNumber ();   // for concurrency checks
 
     // if auto-mapping, add to auto-map string
 
@@ -218,10 +416,6 @@ bool bHaveVariable = false;
       // update status line
       DrawMappingStatusLine ();
       }
-
-    // set up variable item contents
-    variable_item->strLabel = strVariable;
-    variable_item->strContents = strText;
 
     // call script if required
     if (m_dispidOnMXP_SetVariable != DISPID_UNKNOWN)
@@ -296,112 +490,167 @@ bool bHaveVariable = false;
 
     } // end of setting the variable's contents
 
-// see if we know of this element
-
-CAtomicElement * pAtomicElement;
-  
-  // atomic element?
-  if (App.m_ElementMap.Lookup (strTag, pAtomicElement))
-    MXP_CloseAtomicTag (pAtomicElement->iAction, 
-                        strText,
-                        oldlinepos,
-                        oldstylepos);
-  else
+    }
+  catch (...)
     {
-    CElement * pElement;
-
-    // custom element?
-    if (!m_CustomElementMap.Lookup (strTag, pElement))
-      {
-        MXP_error (DBG_ERROR, errMXP_ClosingUnknownTag,
-                  TFormat ("Unknown MXP element: <%s>" ,
-                          (LPCTSTR) m_strMXPstring));
-      return;
-      }
-
-    CElementItem * pElementItem;
-
-    for (POSITION pos = pElement->ElementItemList.GetHeadPosition (); pos; )
-      {
-      pElementItem = pElement->ElementItemList.GetNext (pos);
-      MXP_CloseAtomicTag (pElementItem->pAtomicElement->iAction, 
-                          strText,
-                          oldlinepos,
-                          oldstylepos);
-      } // end of doing each one
-    } // end of user-defined element
-
-  // I don't need the opening style tag any more, and as it remembers the style at
-  // the moment it was made it will make a good way of restoring existing styles 
-  // eg. underline off 
-
-  pLine->styleList.RemoveAt (oldstylepos);
-
-  // however if the last thing on the current line is a zero-length style,
-  // we may as well get rid of it.
-
-  CStyle * pLastStyle = m_pCurrentLine->styleList.GetTail ();
-
-  if (pLastStyle->iLength == 0 && (pLastStyle->iFlags & START_TAG) == 0)
-    {
-    DELETESTYLE (pLastStyle);
-    m_pCurrentLine->styleList.RemoveTail ();
+    pendingException = current_exception ();
     }
 
-  m_pCurrentLine->styleList.AddTail (pStyle);
+  // Keep the original callback-before-close-action order. Range actions use
+  // the saved logical identities, so callback-created output is not included.
+  for (vector<int>::const_iterator it = preparedClose.closeActions.begin ();
+       it != preparedClose.closeActions.end (); ++it)
+    try
+      {
+      MXP_CloseAtomicTag (*it, preparedClose);
+      }
+    catch (...)
+      {
+      if (!pendingException)
+        pendingException = current_exception ();
+      }
 
-  pStyle->iFlags &= ~START_TAG;   // isn't a start tag any more
-  pStyle->pAction->Release ();     // get rid of style name
-  pStyle->pAction = NULL;
+  if (pendingException)
+    rethrow_exception (pendingException);
 
-  RememberStyle (pStyle);
-
-  } // end of  CMUSHclientDoc::MXP_CloseTag
+  } // end of CMUSHclientDoc::MXP_FinishCloseTag
 
 
+
+struct CTagToClose
+  {
+  __int64 iCreationNumber;
+  __int64 iOpeningStyleCreationNumber;
+  CString strName;
+  vector<int> closeActions;
+  };
+
+static void CloseMXPTags (CMUSHclientDoc * pDoc,
+                          bool CActiveTag::*pStopFlag,
+                          void (*pWarn) (CMUSHclientDoc *, const CString &))
+  {
+  vector<CTagToClose> tagsToClose;
+
+  for (POSITION pos = pDoc->m_ActiveTagList.GetTailPosition (); pos; )
+    {
+    CActiveTag * pTag = pDoc->m_ActiveTagList.GetPrev (pos);
+    if (pTag->*pStopFlag)
+      break;
+
+    CTagToClose tagToClose;
+    tagToClose.iCreationNumber = pTag->nCreationNumber;
+    tagToClose.iOpeningStyleCreationNumber =
+      pTag->nOpeningStyleCreationNumber;
+    tagToClose.strName = pTag->strName;
+    tagToClose.closeActions = pTag->closeActions;
+    tagsToClose.push_back (tagToClose);
+    }
+
+  vector<CPreparedMXPClose> preparedCloses;
+  preparedCloses.reserve (tagsToClose.size ());
+  exception_ptr prepareException;
+
+  for (vector<CTagToClose>::const_iterator it = tagsToClose.begin ();
+       it != tagsToClose.end (); ++it)
+    {
+    CActiveTag * pTag = NULL;
+    POSITION tagPosition = NULL;
+    for (POSITION pos = pDoc->m_ActiveTagList.GetTailPosition (); pos; )
+      {
+      POSITION current = pos;
+      CActiveTag * pCandidate = pDoc->m_ActiveTagList.GetPrev (pos);
+      if (pCandidate->nCreationNumber == it->iCreationNumber)
+        {
+        pTag = pCandidate;
+        tagPosition = current;
+        break;
+        }
+      }
+
+    if (!pTag)
+      continue;
+
+    bool bCloseSlotAdded = false;
+    bool bPrepared = false;
+    try
+      {
+      preparedCloses.push_back (CPreparedMXPClose ());
+      bCloseSlotAdded = true;
+      bPrepared = pDoc->MXP_PrepareCloseTag (it->strName,
+                                           false,
+                                           it->iOpeningStyleCreationNumber,
+                                           it->closeActions,
+                                           pTag,
+                                           preparedCloses.back ());
+      }
+    catch (...)
+      {
+      if (bCloseSlotAdded)
+        preparedCloses.pop_back ();
+      prepareException = current_exception ();
+      break;
+      }
+
+    if (!bPrepared)
+      {
+      preparedCloses.pop_back ();
+      continue;
+      }
+
+    pDoc->m_ActiveTagList.RemoveAt (tagPosition);
+    delete pTag;
+    }
+
+  exception_ptr finishException;
+  for (vector<CPreparedMXPClose>::const_iterator it = preparedCloses.begin ();
+       it != preparedCloses.end (); ++it)
+    {
+    try
+      {
+      pWarn (pDoc, it->strTag);
+      }
+    catch (...)
+      {
+      if (!finishException)
+        finishException = current_exception ();
+      }
+
+    try
+      {
+      pDoc->MXP_FinishCloseTag (*it);
+      }
+    catch (...)
+      {
+      if (!finishException)
+        finishException = current_exception ();
+      }
+    }
+
+  if (prepareException)
+    rethrow_exception (prepareException);
+  if (finishException)
+    rethrow_exception (finishException);
+  } // end of CloseMXPTags
 
 void CMUSHclientDoc::MXP_CloseOpenTags (void)
   {
-
-// see if we know of this element
-
-  while (!m_ActiveTagList.IsEmpty ())
-    {
-    CActiveTag * pTag = m_ActiveTagList.GetTail ();
-
-    // don't close securely-opened tags here
-    if (pTag->bSecure)
-      return;
-
-    CString strTag = pTag->strName;
-
-    MXP_error (DBG_WARNING, wrnMXP_OpenTagClosedAtEndOfLine,
-              TFormat ("End-of-line closure of open MXP tag: <%s>", 
-              (LPCTSTR) strTag)); 
-    MXP_CloseTag (strTag);
-
-    m_ActiveTagList.RemoveTail ();  // get rid of it
-    delete pTag;
-    }
-
-  }  // end of CMUSHclientDoc::MXP_CloseOpenTags
+  CloseMXPTags (this, &CActiveTag::bSecure,
+    [] (CMUSHclientDoc * pDoc, const CString & strTag)
+      {
+      pDoc->MXP_error (DBG_WARNING, wrnMXP_OpenTagClosedAtEndOfLine,
+                       TFormat ("End-of-line closure of open MXP tag: <%s>",
+                                (LPCTSTR) strTag));
+      });
+  } // end of CMUSHclientDoc::MXP_CloseOpenTags
 
 void CMUSHclientDoc::MXP_CloseAllTags (void)
   {
-  while (!m_ActiveTagList.IsEmpty ())
-    {
-    CActiveTag * pTag = m_ActiveTagList.GetTail ();
-
-    // if protected from reset, stop closing
-    if (pTag->bNoReset)
-      return;
-
-    MXP_error (DBG_WARNING, wrnMXP_TagClosedAtReset,
-              TFormat ("<reset> closure of MXP tag: <%s>", 
-              (LPCTSTR) pTag->strName)); 
-    MXP_CloseTag (pTag->strName);
-    m_ActiveTagList.RemoveTail ();
-    delete pTag;
-    }
+  CloseMXPTags (this, &CActiveTag::bNoReset,
+    [] (CMUSHclientDoc * pDoc, const CString & strTag)
+      {
+      pDoc->MXP_error (DBG_WARNING, wrnMXP_TagClosedAtReset,
+                       TFormat ("<reset> closure of MXP tag: <%s>",
+                                (LPCTSTR) strTag));
+      });
   } // end of CMUSHclientDoc::MXP_CloseAllTags
 

--- a/mxp/mxpCloseAtomic.cpp
+++ b/mxp/mxpCloseAtomic.cpp
@@ -14,17 +14,87 @@
 static char BASED_CODE THIS_FILE[] = __FILE__;
 #endif
 
+static void RebaseClosingStateOwners (
+  CActiveTagList & activeTags,
+  const int iAction,
+  const CPreparedMXPClose & preparedClose)
+  {
+  for (POSITION pos = activeTags.GetHeadPosition (); pos; )
+    {
+    CActiveTag * pTag = activeTags.GetNext (pos);
+    switch (iAction)
+      {
+      case MXP_ACTION_P:
+        if (pTag->iOpeningParagraphOwner ==
+            preparedClose.iActiveTagCreationNumber)
+          {
+          pTag->bOpeningInParagraph = preparedClose.bOpeningInParagraph;
+          pTag->iOpeningParagraphOwner =
+            preparedClose.iOpeningParagraphOwner;
+          }
+        break;
+
+      case MXP_ACTION_PRE:
+        if (pTag->iOpeningPreOwner ==
+            preparedClose.iActiveTagCreationNumber)
+          {
+          pTag->bOpeningPreMode = preparedClose.bOpeningPreMode;
+          pTag->iOpeningPreOwner = preparedClose.iOpeningPreOwner;
+          }
+        break;
+
+      case MXP_ACTION_SCRIPT:
+        if (pTag->iOpeningScriptOwner ==
+            preparedClose.iActiveTagCreationNumber)
+          {
+          pTag->bOpeningMXPScript = preparedClose.bOpeningMXPScript;
+          pTag->iOpeningScriptOwner = preparedClose.iOpeningScriptOwner;
+          }
+        break;
+
+      case MXP_ACTION_UL:
+      case MXP_ACTION_OL:
+        if (pTag->iOpeningListOwner ==
+            preparedClose.iActiveTagCreationNumber)
+          {
+          pTag->iOpeningListMode = preparedClose.iOpeningListMode;
+          pTag->iOpeningListCount = preparedClose.iOpeningListCount;
+          pTag->iOpeningListOwner = preparedClose.iOpeningListOwner;
+          }
+        break;
+      }
+    }
+  }
+
+struct CStagedMXPActionStyle
+  {
+  CStagedMXPActionStyle () : pStyle (NULL), pAction (NULL),
+    iFlags (0), iForeColour (0), iBackColour (0) { }
+  ~CStagedMXPActionStyle ()
+    {
+    if (pAction)
+      pAction->Release ();
+    }
+
+  CStyle * pStyle;
+  CAction * pAction;
+  unsigned short iFlags;
+  COLORREF iForeColour;
+  COLORREF iBackColour;
+  };
 
 // do the action required to close a single atomic tag (iAction)
-void CMUSHclientDoc::MXP_CloseAtomicTag (const int iAction, 
-                                         const CString & strText,
-                                         const POSITION firstlinepos,
-                                         const POSITION firststylepos)
+void CMUSHclientDoc::MXP_CloseAtomicTag (
+  const int iAction,
+  const CPreparedMXPClose & preparedClose)
   {
+  const CString & strText = preparedClose.strText;
+  const set<__int64> & contentStyleRangeNumbers =
+    preparedClose.contentStyleRangeNumbers;
   POSITION linepos, 
            stylepos;
-  int iCount = 0;
-  CAction * pAction = NULL;;
+
+  RebaseClosingStateOwners (m_ActiveTagList, iAction, preparedClose);
 
   // now take any closing action 
   switch (iAction)
@@ -32,20 +102,36 @@ void CMUSHclientDoc::MXP_CloseAtomicTag (const int iAction,
     case MXP_ACTION_SEND: 
     case MXP_ACTION_HYPERLINK:
 
-      // put send action into every style
+      {
+      vector<std::unique_ptr<CStagedMXPActionStyle> > stagedStyles;
 
-      for (linepos = firstlinepos; linepos; iCount++)
+      // Lines keep increasing identities when styles split or move forward.
+      // Locate the first surviving content line from the tail, then retain
+      // the original forward action order without scanning older history.
+      POSITION firstContentLine = 0;
+      if (!contentStyleRangeNumbers.empty ())
+        for (POSITION scan = m_LineList.GetTailPosition (); scan; )
+          {
+          POSITION current = scan;
+          CLine * pCandidate = m_LineList.GetPrev (scan);
+          if (pCandidate->nCreationNumber <
+              preparedClose.iFirstContentLineCreationNumber)
+            break;
+          firstContentLine = current;
+          }
+
+      for (linepos = firstContentLine; linepos; )
         {
         CLine * pLine2 = m_LineList.GetNext (linepos);
- 
-        if (iCount == 0)    // first line - start at first style
-           stylepos = firststylepos;
-        else
-          stylepos = pLine2->styleList.GetHeadPosition ();
+        stylepos = pLine2->styleList.GetHeadPosition ();
 
         for ( ; stylepos; )
           {
           CStyle * pStyle2 = pLine2->styleList.GetNext (stylepos);
+          if (contentStyleRangeNumbers.find (
+                pStyle2->nRangeCreationNumber) ==
+              contentStyleRangeNumbers.end ())
+            continue;
           if ((pStyle2->iFlags & ACTIONTYPE) &&
               (pStyle2->iFlags & START_TAG) == 0)
             {
@@ -59,6 +145,13 @@ void CMUSHclientDoc::MXP_CloseAtomicTag (const int iAction,
               strVariable = pStyle2->pAction->m_strVariable;
               }
 
+            std::unique_ptr<CStagedMXPActionStyle> pStaged
+              (new CStagedMXPActionStyle);
+            pStaged->pStyle = pStyle2;
+            pStaged->iFlags = pStyle2->iFlags;
+            pStaged->iForeColour = pStyle2->iForeColour;
+            pStaged->iBackColour = pStyle2->iBackColour;
+
             if (m_bUseCustomLinkColour && !m_bMudCanChangeLinkColour)
               {
               COLORREF colour1,
@@ -67,76 +160,102 @@ void CMUSHclientDoc::MXP_CloseAtomicTag (const int iAction,
               // find current foreground and background RGB values
               GetStyleRGB (pStyle2, colour1, colour2);
 
-              pStyle2->iForeColour = m_iHyperlinkColour;    // override hyperlink colour
-              pStyle2->iBackColour = colour2;    // keep background
-              pStyle2->iFlags &= ~COLOURTYPE;  // clear bits, eg. custom
-              pStyle2->iFlags |= COLOUR_RGB;
+              pStaged->iForeColour = m_iHyperlinkColour;
+              pStaged->iBackColour = colour2;
+              pStaged->iFlags &= ~COLOURTYPE;
+              pStaged->iFlags |= COLOUR_RGB;
               } // end of changing colour back to wanted link colour
 
             if (m_bUnderlineHyperlinks && !m_bMudCanRemoveUnderline)
-              pStyle2->iFlags |= UNDERLINE;    // make sure underlined
+              pStaged->iFlags |= UNDERLINE;
 
             if (strAction.IsEmpty ())
               { // no action defined - use &text; as the action
-               if (pAction == NULL)
-                 {
-                 pAction = GetAction (strText, strHint, strVariable);
-                 pStyle2->pAction = pAction;
-                 }
-               else
-                 {
-                 pStyle2->pAction = pAction;  // remember in case nested <send>s
-                 pAction->AddRef ();
-                 }
+              pStaged->pAction = GetAction (strText, strHint, strVariable);
               }
             else
               {   // we have an strAction already
               // replace the &text; sequence
               strAction.Replace ("&text;", strText);
               strHint.Replace ("&text;", strText);
-              pStyle2->pAction->Release ();
-              pStyle2->pAction = GetAction (strAction, strHint, strVariable);
-              // remember replacement text for next time
-              if (pAction == NULL)
-                pAction = pStyle2->pAction; 
+              pStaged->pAction = GetAction (strAction, strHint, strVariable);
               } // end of having text to send
 
+            stagedStyles.push_back (std::move (pStaged));
             }  // end of being an ordinary "send" style
           } // end of doing each style on this line
         } // end of doing each line
+
+      for (vector<std::unique_ptr<CStagedMXPActionStyle> >::iterator it =
+             stagedStyles.begin (); it != stagedStyles.end (); ++it)
+        {
+        CStagedMXPActionStyle * pStaged = it->get ();
+        CAction * pOldAction = pStaged->pStyle->pAction;
+        pStaged->pStyle->iFlags = pStaged->iFlags;
+        pStaged->pStyle->iForeColour = pStaged->iForeColour;
+        pStaged->pStyle->iBackColour = pStaged->iBackColour;
+        pStaged->pStyle->pAction = pStaged->pAction;
+        pStaged->pAction = NULL;
+        if (pOldAction)
+          pOldAction->Release ();
+        }
+      }
       break;  // end of MXP_ACTION_SEND or MXP_ACTION_HYPERLINK
 
       // end script
     case MXP_ACTION_SCRIPT:
+      if (m_iMXPScriptOwner == preparedClose.iActiveTagCreationNumber)
+        {
+        m_bMXP_script = preparedClose.bOpeningMXPScript;
+        m_iMXPScriptOwner = preparedClose.iOpeningScriptOwner;
+        }
       MXP_error (DBG_INFO, infoMXP_ScriptCollectionCompleted,
                 "Script collection mode completed.");
-      m_bMXP_script = false;
       break;  // end of MXP_ACTION_SCRIPT
 
       // end new para
     case MXP_ACTION_P:
-       m_bInParagraph = false;      
-       StartNewLine (true, 0);
+       if (m_iMXPParagraphOwner == preparedClose.iActiveTagCreationNumber)
+         {
+         m_bInParagraph = preparedClose.bOpeningInParagraph;
+         m_iMXPParagraphOwner = preparedClose.iOpeningParagraphOwner;
+         }
+       if (!StartNewLine (true, 0))
+         return;
        break;  // end of MXP_ACTION_P
 
     case MXP_ACTION_PRE: 
-      m_bPreMode = false;
+      if (m_iMXPPreOwner == preparedClose.iActiveTagCreationNumber)
+        {
+        m_bPreMode = preparedClose.bOpeningPreMode;
+        m_iMXPPreOwner = preparedClose.iOpeningPreOwner;
+        }
       break;  // end of MXP_ACTION_PRE
 
      case MXP_ACTION_UL:   
-       m_iListMode = eNoList;
-       m_iListCount = 0;
+       if (m_iMXPListOwner == preparedClose.iActiveTagCreationNumber)
+         {
+         m_iListMode = preparedClose.iOpeningListMode;
+         m_iListCount = preparedClose.iOpeningListCount;
+         m_iMXPListOwner = preparedClose.iOpeningListOwner;
+         }
        // wrap up previous line if necessary
        if (m_pCurrentLine->len > 0)
-          StartNewLine (true, 0);
+          if (!StartNewLine (true, 0))
+            return;
        break;  // end of MXP_ACTION_UL
      
      case MXP_ACTION_OL:   
-       m_iListMode = eNoList;
-       m_iListCount = 0;
+       if (m_iMXPListOwner == preparedClose.iActiveTagCreationNumber)
+         {
+         m_iListMode = preparedClose.iOpeningListMode;
+         m_iListCount = preparedClose.iOpeningListCount;
+         m_iMXPListOwner = preparedClose.iOpeningListOwner;
+         }
        // wrap up previous line if necessary
        if (m_pCurrentLine->len > 0)
-          StartNewLine (true, 0);
+          if (!StartNewLine (true, 0))
+            return;
 
        break;  // end of MXP_ACTION_OL
 

--- a/mxp/mxpDefs.cpp
+++ b/mxp/mxpDefs.cpp
@@ -23,6 +23,16 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 
 #define DEFINITIONS_MUST_BE_SECURE true
 
+class CElementArgumentListGuard
+  {
+  public:
+    CElementArgumentListGuard (CArgumentList & list) : m_list (list) { }
+    ~CElementArgumentListGuard () { DELETE_LIST (m_list); }
+
+  private:
+    CArgumentList & m_list;
+  };
+
 // handle definition-style tag, eg. <!ELEMENT blah> or <!ENTITY blah>
 
 void CMUSHclientDoc::MXP_Definition (CString strTag)
@@ -111,16 +121,14 @@ CString strName;
 // here for <!ELEMENT blah>
 void CMUSHclientDoc::MXP_Element (CString strName, CString strTag)
   {
-static CArgumentList ArgumentList;
+CArgumentList ArgumentList;
+CElementArgumentListGuard argumentListGuard (ArgumentList);
 
   // get arguments to !ELEMENT definition
   if (BuildArgumentList (ArgumentList, strTag))
-    {
-    DELETE_LIST (ArgumentList);
     return;
-    }
 
-CElement * pElement;
+CElement * pElement = NULL;
 bool bDelete = GetKeyword (ArgumentList, "delete");
 
   strName.MakeLower (); // case-insensitive?
@@ -137,23 +145,31 @@ bool bDelete = GetKeyword (ArgumentList, "delete");
     return;
     }
 
-// if element already defined, delete old one
-  if (m_CustomElementMap.Lookup (strName, pElement))
+// if element already exists, remember it until the replacement is ready
+  CElement * pOldElement = NULL;
+  if (m_CustomElementMap.Lookup (strName, pOldElement))
     {
     if (!bDelete)
       MXP_error (DBG_WARNING, wrnMXP_ReplacingElement, 
                  TFormat ("Replacing previously-defined MXP element: <%s>", 
                 (LPCTSTR) strName)); 
-    DELETE_LIST (pElement->ElementItemList);
-    DELETE_LIST (pElement->AttributeList);
-    delete pElement;
+    pOldElement = NULL;
+    m_CustomElementMap.Lookup (strName, pOldElement);
     } // end of existing element
 
   if (bDelete)
+    {
+    if (pOldElement)
+      {
+      m_CustomElementMap.RemoveKey (strName);
+      delete pOldElement;
+      }
     return; // all done!
+    }
 
-// add new element to map
-m_CustomElementMap.SetAt (strName, pElement = new CElement);
+// build the complete replacement before changing the live map
+std::unique_ptr<CElement> newElement (new CElement);
+pElement = newElement.get ();
 
   pElement->strName = strName;
 
@@ -275,17 +291,17 @@ CString strArgument;
 
     // yes?  add to list
 
-    CElementItem * pElementItem = new CElementItem;
+    std::unique_ptr<CElementItem> pElementItem (new CElementItem);
 
     if (BuildArgumentList (pElementItem->ArgumentList, strAtom))  // add arguments
       {     // bad arguments
       DELETE_LIST (pElementItem->ArgumentList);
-      delete pElementItem;
       return;
       }
 
-    pElement->ElementItemList.AddTail (pElementItem );
     pElementItem->pAtomicElement = element_item;    // which atomic element
+    pElement->ElementItemList.AddTail (pElementItem.get ());
+    pElementItem.release ();
 
     p++; // skip >
 
@@ -352,7 +368,12 @@ CString strArgument;
 
     } // end of having a flag
 
-  DELETE_LIST (ArgumentList);
+  // A warning or error callback can redefine the element while this one builds.
+  pOldElement = NULL;
+  m_CustomElementMap.Lookup (strName, pOldElement);
+  m_CustomElementMap.SetAt (strName, pElement);
+  newElement.release ();
+  delete pOldElement;
 
   } // end of CMUSHclientDoc::MXP_Element
 
@@ -375,23 +396,25 @@ CElement * pElement;
     } // end of no element matching
 
 CArgumentList ArgumentList;
+CElementArgumentListGuard argumentListGuard (ArgumentList);
 
   // build into an argument list
   if (BuildArgumentList (ArgumentList, strTag))
-    {
-    DELETE_LIST (ArgumentList);
     return;
+
+  // Transfer ownership after each successful insertion. If AddTail throws,
+  // the guard deletes only the arguments that have not been transferred.
+  while (!ArgumentList.IsEmpty ())
+    {
+    pElement->AttributeList.AddTail (ArgumentList.GetHead ());
+    ArgumentList.RemoveHead ();
     }
-
-  // add to any existing arguments - is this wise? :)
-  pElement->AttributeList.AddTail (&ArgumentList);
-
-  // nb - arguments get moved to argument list - no need to delete them
   } // end of CMUSHclientDoc::MXP_Attlist
 
 // here for <!ENTITY blah>
 void CMUSHclientDoc::MXP_Entity (CString strName, CString strTag)
   {
+  CPluginContextGuard pluginContextGuard (this, NULL);
 
   // case insensitive
   strName.MakeLower ();
@@ -457,8 +480,6 @@ void CMUSHclientDoc::MXP_Entity (CString strName, CString strTag)
                                 CFormat ("%s=%s",
                                 (LPCTSTR) strName,
                                 (LPCTSTR) strFixedValue));
-
-    m_CurrentPlugin = NULL;
 
     }
 

--- a/mxp/mxpEnd.cpp
+++ b/mxp/mxpEnd.cpp
@@ -39,12 +39,8 @@ CString strName;
 
   strName.MakeLower (); // case insensitive
 
-  // should just have tag name, not </tag blah blah>
-  if (!strTag.IsEmpty ())
-    MXP_error (DBG_WARNING, wrnMXP_ArgumentsToClosingTag,
-              TFormat ("Closing MXP tag </%s %s> has inappropriate arguments", 
-              (LPCTSTR) strName,
-              (LPCTSTR) strTag)); 
+  const CString strClosingArguments = strTag;
+  const bool bWarnClosingArguments = !strClosingArguments.IsEmpty ();
 
 
   // make sure tag is in active taglist
@@ -52,10 +48,12 @@ CString strName;
   // this test effectively checks that tag is known (otherwise it won't be in the list)
 
   CActiveTag * pTag = NULL;
+  size_t iTagsToClose = 0;
 
   for (POSITION pos = m_ActiveTagList.GetTailPosition (); pos; )
     {
     pTag = m_ActiveTagList.GetPrev (pos);
+    iTagsToClose++;
 
     if (pTag->strName == strName)
       break;
@@ -64,11 +62,17 @@ CString strName;
       // check we don't cross over some secure tags when finding it
       if (!bSecure && pTag->bSecure)
         {
+        const CString strBlockingTag = pTag->strName;
+        if (bWarnClosingArguments)
+          MXP_error (DBG_WARNING, wrnMXP_ArgumentsToClosingTag,
+                    TFormat ("Closing MXP tag </%s %s> has inappropriate arguments",
+                             (LPCTSTR) strName,
+                             (LPCTSTR) strClosingArguments));
         MXP_error (DBG_WARNING, wrnMXP_OpenTagBlockedBySecureTag,
                   TFormat ("Cannot close open MXP tag <%s> "
                                          "- blocked by secure tag <%s>", 
                                         (LPCTSTR) strName,
-                                        (LPCTSTR) pTag->strName)); 
+                                        (LPCTSTR) strBlockingTag));
         return;
         }
       pTag = NULL;
@@ -78,6 +82,11 @@ CString strName;
 
   if (!pTag)
     {
+    if (bWarnClosingArguments)
+      MXP_error (DBG_WARNING, wrnMXP_ArgumentsToClosingTag,
+                TFormat ("Closing MXP tag </%s %s> has inappropriate arguments",
+                         (LPCTSTR) strName,
+                         (LPCTSTR) strClosingArguments));
     MXP_error (DBG_WARNING, wrnMXP_OpenTagNotThere,
               TFormat ("Closing MXP tag </%s> does not have corresponding opening tag", 
               (LPCTSTR) strName)); 
@@ -86,6 +95,11 @@ CString strName;
 
   if (!bSecure && pTag->bSecure)
     {
+    if (bWarnClosingArguments)
+      MXP_error (DBG_WARNING, wrnMXP_ArgumentsToClosingTag,
+                TFormat ("Closing MXP tag </%s %s> has inappropriate arguments",
+                         (LPCTSTR) strName,
+                         (LPCTSTR) strClosingArguments));
     MXP_error (DBG_WARNING, wrnMXP_TagOpenedInSecureMode,
               TFormat ("Cannot close open MXP tag <%s> "
                        "- it was opened in secure mode.", 
@@ -97,23 +111,139 @@ CString strName;
   // eg.  <b> <i> </b> </i>  
   //  in the above example the </b> will also close the <i>
 
-  while (true)
+  struct CTagToClose
     {
-
-    pTag = m_ActiveTagList.RemoveTail ();
-    CString strTag = pTag->strName;
-    delete pTag;
-    
-    if (strTag != strName)
-      MXP_error (DBG_WARNING, wrnMXP_ClosingOutOfSequenceTag,
-                TFormat ("Closing out-of-sequence MXP tag: <%s>", 
-                (LPCTSTR) strTag)); 
-
-    MXP_CloseTag (strTag);
-
-
-    if (strTag == strName)
-      break;  // stop once we have found the tag we are supposed to close
+    __int64 iCreationNumber;
+    __int64 iOpeningStyleCreationNumber;
+    CString strName;
+    vector<int> closeActions;
+    };
+  vector<CTagToClose> tagsToClose;
+  tagsToClose.reserve (iTagsToClose);
+  POSITION snapshotPosition = m_ActiveTagList.GetTailPosition ();
+  for (size_t i = 0; i < iTagsToClose; i++)
+    {
+    CActiveTag * pSnapshotTag = m_ActiveTagList.GetPrev (snapshotPosition);
+    CTagToClose tagToClose;
+    tagToClose.iCreationNumber = pSnapshotTag->nCreationNumber;
+    tagToClose.iOpeningStyleCreationNumber =
+      pSnapshotTag->nOpeningStyleCreationNumber;
+    tagToClose.strName = pSnapshotTag->strName;
+      tagToClose.closeActions = pSnapshotTag->closeActions;
+      tagsToClose.push_back (tagToClose);
     }
+
+  struct CPreparedTagClose
+    {
+    CPreparedMXPClose close;
+    bool bOutOfSequence;
+    };
+  vector<CPreparedTagClose> preparedCloses;
+  preparedCloses.reserve (tagsToClose.size ());
+  exception_ptr prepareException;
+
+  for (vector<CTagToClose>::const_iterator it = tagsToClose.begin ();
+       it != tagsToClose.end ();
+       ++it)
+    {
+    CActiveTag * pDetachedTag = NULL;
+    POSITION tagPosition = NULL;
+    for (POSITION pos = m_ActiveTagList.GetTailPosition (); pos; )
+      {
+      POSITION current = pos;
+      CActiveTag * pCandidate = m_ActiveTagList.GetPrev (pos);
+      if (pCandidate->nCreationNumber == it->iCreationNumber)
+        {
+        pDetachedTag = pCandidate;
+        tagPosition = current;
+        break;
+        }
+      }
+
+    if (!pDetachedTag)
+      continue;
+
+    bool bCloseSlotAdded = false;
+    bool bPrepared = false;
+    try
+      {
+      CPreparedTagClose preparedTagClose;
+      preparedTagClose.bOutOfSequence = false;
+      preparedCloses.push_back (preparedTagClose);
+      bCloseSlotAdded = true;
+      CPreparedTagClose & publishedClose = preparedCloses.back ();
+      publishedClose.bOutOfSequence = it->strName != strName;
+      bPrepared = MXP_PrepareCloseTag (it->strName,
+                                       false,
+                                       it->iOpeningStyleCreationNumber,
+                                       it->closeActions,
+                                       pDetachedTag,
+                                       publishedClose.close);
+      }
+    catch (...)
+      {
+      if (bCloseSlotAdded)
+        preparedCloses.pop_back ();
+      prepareException = current_exception ();
+      break;
+      }
+
+    if (!bPrepared)
+      {
+      preparedCloses.pop_back ();
+      continue;
+      }
+
+    m_ActiveTagList.RemoveAt (tagPosition);
+    delete pDetachedTag;
+    }
+
+  // All target styles are now restored. Callbacks cannot open a tag between
+  // two restores and make it cross an outer close.
+  exception_ptr finishException;
+  if (bWarnClosingArguments)
+    try
+      {
+      MXP_error (DBG_WARNING, wrnMXP_ArgumentsToClosingTag,
+                TFormat ("Closing MXP tag </%s %s> has inappropriate arguments",
+                         (LPCTSTR) strName,
+                         (LPCTSTR) strClosingArguments));
+      }
+    catch (...)
+      {
+      finishException = current_exception ();
+      }
+
+  for (vector<CPreparedTagClose>::const_iterator it = preparedCloses.begin ();
+       it != preparedCloses.end (); ++it)
+    {
+    if (it->bOutOfSequence)
+      try
+        {
+        MXP_error (DBG_WARNING, wrnMXP_ClosingOutOfSequenceTag,
+                  TFormat ("Closing out-of-sequence MXP tag: <%s>",
+                           (LPCTSTR) it->close.strTag));
+        }
+      catch (...)
+        {
+        if (!finishException)
+          finishException = current_exception ();
+        }
+
+    try
+      {
+      MXP_FinishCloseTag (it->close);
+      }
+    catch (...)
+      {
+      if (!finishException)
+        finishException = current_exception ();
+      }
+    }
+
+  if (prepareException)
+    rethrow_exception (prepareException);
+  if (finishException)
+    rethrow_exception (finishException);
 
   } // end of CMUSHclientDoc::MXP_EndTag

--- a/mxp/mxpEntities.cpp
+++ b/mxp/mxpEntities.cpp
@@ -49,9 +49,8 @@ CString strEntityContents = MXP_GetEntity (m_strMXPstring);
   if (!strEntityContents.IsEmpty ())
     {
 //  if the entity happens to be < & > etc. don't reprocess it
-    m_bMXP = false;
+    CValueStateGuard<bool> mxpGuard (m_bMXP, false);
     DisplayMsg (strEntityContents, strEntityContents.GetLength (), 0, true);  // fake packet
-    m_bMXP = true;
     }
 
   } // end of CMUSHclientDoc::MXP_collected_entity

--- a/mxp/mxpOnOff.cpp
+++ b/mxp/mxpOnOff.cpp
@@ -14,6 +14,133 @@
 static char BASED_CODE THIS_FILE[] = __FILE__;
 #endif
 
+static CStyle * FindMXPStyle (CLineList & lines,
+                              const __int64 iCreationNumber)
+  {
+  for (POSITION linepos = lines.GetHeadPosition (); linepos; )
+    {
+    CLine * pLine = lines.GetNext (linepos);
+    for (POSITION stylepos = pLine->styleList.GetHeadPosition (); stylepos; )
+      {
+      CStyle * pStyle = pLine->styleList.GetNext (stylepos);
+      if (pStyle->nCreationNumber == iCreationNumber)
+        return pStyle;
+      }
+    }
+  return NULL;
+  }
+
+static void RestoreAndDeleteMXPTag (CMUSHclientDoc * pDoc,
+                                    POSITION current,
+                                    CActiveTag * pTag)
+  {
+  CStyle * pMarker =
+    FindMXPStyle (pDoc->m_LineList, pTag->nOpeningStyleCreationNumber);
+  if (pMarker && (pMarker->iFlags & START_TAG))
+    {
+    CAction * pReplacementAction = pTag->pOpeningAction;
+    if (pReplacementAction)
+      pReplacementAction->AddRef ();
+    if (pMarker->pAction)
+      pMarker->pAction->Release ();
+    pMarker->iFlags = pTag->iOpeningFlags;
+    pMarker->iForeColour = pTag->iOpeningForeColour;
+    pMarker->iBackColour = pTag->iOpeningBackColour;
+    pMarker->pAction = pReplacementAction;
+    }
+
+  pDoc->m_ActiveTagList.RemoveAt (current);
+  delete pTag;
+  }
+
+static void DiscardMXPTags (CMUSHclientDoc * pDoc,
+                            const set<__int64> & identities)
+  {
+  for (POSITION pos = pDoc->m_ActiveTagList.GetHeadPosition (); pos; )
+    {
+    POSITION current = pos;
+    CActiveTag * pTag = pDoc->m_ActiveTagList.GetNext (pos);
+    if (identities.find (pTag->nCreationNumber) == identities.end ())
+      continue;
+
+    RestoreAndDeleteMXPTag (pDoc, current, pTag);
+    }
+  }
+
+static void DiscardMXPTagsCreatedAfter (CMUSHclientDoc * pDoc,
+                                        const __int64 iBoundary)
+  {
+  for (POSITION pos = pDoc->m_ActiveTagList.GetHeadPosition (); pos; )
+    {
+    POSITION current = pos;
+    CActiveTag * pTag = pDoc->m_ActiveTagList.GetNext (pos);
+    if (pTag->nCreationNumber <= iBoundary)
+      continue;
+
+    RestoreAndDeleteMXPTag (pDoc, current, pTag);
+    }
+  }
+
+static void RebaseMXPResetState (CMUSHclientDoc * pDoc,
+                                 const __int64 iBoundary)
+  {
+  for (POSITION pos = pDoc->m_ActiveTagList.GetHeadPosition (); pos; )
+    {
+    CActiveTag * pTag = pDoc->m_ActiveTagList.GetNext (pos);
+    if (pTag->nCreationNumber <= iBoundary)
+      continue;
+
+    if (pTag->iOpeningParagraphOwner < iBoundary)
+      {
+      pTag->bOpeningInParagraph = false;
+      pTag->iOpeningParagraphOwner = 0;
+      }
+    if (pTag->iOpeningPreOwner < iBoundary)
+      {
+      pTag->bOpeningPreMode = false;
+      pTag->iOpeningPreOwner = 0;
+      }
+    if (pTag->iOpeningScriptOwner < iBoundary)
+      {
+      pTag->bOpeningMXPScript = false;
+      pTag->iOpeningScriptOwner = 0;
+      }
+    if (pTag->iOpeningListOwner < iBoundary)
+      {
+      pTag->iOpeningListMode = eNoList;
+      pTag->iOpeningListCount = 0;
+      pTag->iOpeningListOwner = 0;
+      }
+    }
+  }
+
+static void PublishMXPResetOpeningStyle (CMUSHclientDoc * pDoc,
+                                         const unsigned short iFlags,
+                                         const COLORREF iForeColour,
+                                         const COLORREF iBackColour,
+                                         CAction * pAction)
+  {
+  CStyle * pStyle = pDoc->m_pCurrentLine->styleList.GetTail ();
+  if (pStyle->iLength == 0 && (pStyle->iFlags & START_TAG) == 0)
+    {
+    if (pAction)
+      pAction->AddRef ();
+    if (pStyle->pAction)
+      pStyle->pAction->Release ();
+    pStyle->iFlags = iFlags;
+    pStyle->iForeColour = iForeColour;
+    pStyle->iBackColour = iBackColour;
+    pStyle->pAction = pAction;
+    }
+  else
+    pStyle = pDoc->AddStyle (iFlags,
+                             iForeColour,
+                             iBackColour,
+                             0,
+                             pAction);
+  pDoc->RememberStyle (pStyle);
+  }
+
 
 // this is for an MXP reset or MXP off
 // if bCompletely is true then we are turning MXP right off, otherwise
@@ -21,28 +148,164 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 void CMUSHclientDoc::MXP_Off (const bool bCompletely)
   {
 
-  if (m_pCurrentLine)          // provided we have a line yet :)
-    InterpretANSIcode (0);    // go back to white on black
-
-  // do nothing else if already off
+  // MXP off still resets ANSI state when MXP is already disabled.
   if (!m_bMXP)
+    {
+    if (m_pCurrentLine)
+      InterpretANSIcode (0);
     return;
+    }
+
+  // Build every allocation-backed reset snapshot before changing ANSI state,
+  // generation, status, or active tags.
+  const __int64 iResetBoundary = App.GetUniqueNumber ();
+  set<__int64> resetTargets;
+  for (POSITION pos = m_ActiveTagList.GetTailPosition (); pos; )
+    {
+    CActiveTag * pTag = m_ActiveTagList.GetPrev (pos);
+    if (pTag->bNoReset)
+      break;
+    resetTargets.insert (pTag->nCreationNumber);
+    }
+  bool bHaveResetOpeningStyle = false;
+  unsigned short iResetOpeningFlags = 0;
+  COLORREF iResetOpeningForeColour = 0;
+  COLORREF iResetOpeningBackColour = 0;
+  CAction * pResetOpeningAction = NULL;
+  for (POSITION pos = m_ActiveTagList.GetHeadPosition (); pos; )
+    {
+    CActiveTag * pTag = m_ActiveTagList.GetNext (pos);
+    if (resetTargets.find (pTag->nCreationNumber) == resetTargets.end ())
+      continue;
+    bHaveResetOpeningStyle = true;
+    iResetOpeningFlags = pTag->iOpeningFlags;
+    iResetOpeningForeColour = pTag->iOpeningForeColour;
+    iResetOpeningBackColour = pTag->iOpeningBackColour;
+    pResetOpeningAction = pTag->pOpeningAction;
+    if (pResetOpeningAction)
+      pResetOpeningAction->AddRef ();
+    break;
+    }
+
+  exception_ptr pendingException;
+  if (m_pCurrentLine)          // provided we have a line yet :)
+    {
+    try
+      {
+      InterpretANSIcode (0);    // go back to white on black
+      }
+    catch (...)
+      {
+      pendingException = current_exception ();
+      }
+    }
+
+  m_iMXPGeneration++;
 
   if (bCompletely)
-    Frame.SetStatusMessageNow (Translate ("Closing down MXP"));
+    try
+      {
+      Frame.SetStatusMessageNow (Translate ("Closing down MXP"));
+      }
+    catch (...)
+      {
+      if (!pendingException)
+        pendingException = current_exception ();
+      }
 
-  MXP_CloseAllTags ();
-  m_bInParagraph = false; 
-  m_bMXP_script = false;    // cancel scripts
-  m_bPreMode = false;       // no more preformatted text
-  m_iListMode = eNoList;    // no more ordered/unordered lists
-  m_iListCount = 0;
+  bool bCloseFailed = false;
+  try
+    {
+    MXP_CloseAllTags ();
+    }
+  catch (...)
+    {
+    if (!pendingException)
+      pendingException = current_exception ();
+    bCloseFailed = true;
+    }
 
-  MXP_error (DBG_INFO, infoMXP_ResetReceived, "MXP reset.");
+  bool bResetTargetsRemain = false;
+  if (bCloseFailed)
+    for (POSITION pos = m_ActiveTagList.GetHeadPosition (); pos; )
+      if (resetTargets.find (
+            m_ActiveTagList.GetNext (pos)->nCreationNumber) !=
+          resetTargets.end ())
+        {
+        bResetTargetsRemain = true;
+        break;
+        }
+
+  if (bCloseFailed)
+    {
+    DiscardMXPTags (this, resetTargets);
+    if (bResetTargetsRemain &&
+        !bCompletely && bHaveResetOpeningStyle && m_pCurrentLine)
+      try
+        {
+        PublishMXPResetOpeningStyle (this,
+                                     iResetOpeningFlags,
+                                     iResetOpeningForeColour,
+                                     iResetOpeningBackColour,
+                                     pResetOpeningAction);
+        }
+      catch (...)
+        {
+        if (!pendingException)
+          pendingException = current_exception ();
+        }
+    }
+
+  if (pResetOpeningAction)
+    pResetOpeningAction->Release ();
+
+  RebaseMXPResetState (this, iResetBoundary);
+
+  if (bCompletely || m_iMXPParagraphOwner < iResetBoundary)
+    {
+    m_bInParagraph = false;
+    m_iMXPParagraphOwner = 0;
+    }
+  if (bCompletely || m_iMXPScriptOwner < iResetBoundary)
+    {
+    m_bMXP_script = false;    // cancel scripts
+    m_iMXPScriptOwner = 0;
+    }
+  if (bCompletely || m_iMXPPreOwner < iResetBoundary)
+    {
+    m_bPreMode = false;       // no more preformatted text
+    m_iMXPPreOwner = 0;
+    }
+  if (bCompletely || m_iMXPListOwner < iResetBoundary)
+    {
+    m_iListMode = eNoList;    // no more ordered/unordered lists
+    m_iListCount = 0;
+    m_iMXPListOwner = 0;
+    }
+
+  try
+    {
+    MXP_error (DBG_INFO, infoMXP_ResetReceived, "MXP reset.");
+    }
+  catch (...)
+    {
+    if (!pendingException)
+      pendingException = current_exception ();
+    }
 
   if (bCompletely)
     {
-    MXP_mode_change (eMXP_open);  // back to open mode
+    try
+      {
+      MXP_mode_change (eMXP_open);  // back to open mode
+      }
+    catch (...)
+      {
+      if (!pendingException)
+        pendingException = current_exception ();
+      m_iMXP_defaultMode = eMXP_open;
+      m_iMXP_mode = eMXP_open;
+      }
 
     // if not using MXP (any more) then turn collection phase off
     if (
@@ -56,12 +319,43 @@ void CMUSHclientDoc::MXP_Off (const bool bCompletely)
        m_phase == HAVE_MXP_WELCOME
        )
       m_phase = NONE;
-    if (m_bPuebloActive)
-      MXP_error (DBG_INFO, infoMXP_off, "Pueblo turned off.");
-    else
-      MXP_error (DBG_INFO, infoMXP_off, "MXP turned off.");
+    try
+      {
+      if (m_bPuebloActive)
+        MXP_error (DBG_INFO, infoMXP_off, "Pueblo turned off.");
+      else
+        MXP_error (DBG_INFO, infoMXP_off, "MXP turned off.");
+      }
+    catch (...)
+      {
+      if (!pendingException)
+        pendingException = current_exception ();
+      }
     m_bPuebloActive = false;
     m_bMXP = false;
+
+    DiscardMXPTagsCreatedAfter (this, iResetBoundary);
+    m_bInParagraph = false;
+    m_bMXP_script = false;
+    m_bPreMode = false;
+    m_iListMode = eNoList;
+    m_iListCount = 0;
+    m_iMXPParagraphOwner = 0;
+    m_iMXPPreOwner = 0;
+    m_iMXPScriptOwner = 0;
+    m_iMXPListOwner = 0;
+    if (m_pCurrentLine)
+      {
+      try
+        {
+        InterpretANSIcode (0);
+        }
+      catch (...)
+        {
+        if (!pendingException)
+          pendingException = current_exception ();
+        }
+      }
 
     // execute "close" script
     if (m_dispidOnMXP_Stop != DISPID_UNKNOWN)
@@ -71,18 +365,37 @@ void CMUSHclientDoc::MXP_Off (const bool bCompletely)
         DISPPARAMS params = { NULL, NULL, 0, 0 };
         long nInvocationCount = 0;
 
-        ExecuteScript (m_dispidOnMXP_Stop,  
-                     m_strOnMXP_Stop,
-                     eWorldAction,
-                     "MXP shutdown", 
-                     "stopping MXP",
-                     params, 
-                     nInvocationCount); 
+        try
+          {
+          ExecuteScript (m_dispidOnMXP_Stop,
+                         m_strOnMXP_Stop,
+                         eWorldAction,
+                         "MXP shutdown",
+                         "stopping MXP",
+                         params,
+                         nInvocationCount);
+          }
+        catch (...)
+          {
+          if (!pendingException)
+            pendingException = current_exception ();
+          }
         }
       } // end of executing close script
-    SendToAllPluginCallbacks (ON_PLUGIN_MXP_STOP);
+    try
+      {
+      SendToAllPluginCallbacks (ON_PLUGIN_MXP_STOP);
+      }
+    catch (...)
+      {
+      if (!pendingException)
+        pendingException = current_exception ();
+      }
 
     } // end of turn MXP off completely
+
+  if (pendingException)
+    rethrow_exception (pendingException);
   }  // end of CMUSHclientDoc::MXP_Off
 
 
@@ -93,10 +406,44 @@ void CMUSHclientDoc::MXP_On (const bool bPueblo, const bool bManual)
   if (m_bMXP)
     return;
 
+  m_iMXPGeneration++;
+  const __int64 iStartingGeneration = m_iMXPGeneration;
+
+  m_bMXP_script = false;
+  m_bPreMode = false;
+  m_iLastOutstandingTagCount = 0;
+  m_iMXPerrors = 0;
+  m_iMXPtags = 0;
+  m_iMXPentities = 0;
+  m_iListMode = eNoList;
+  m_iListCount = 0;
+  m_iMXPParagraphOwner = 0;
+  m_iMXPPreOwner = 0;
+  m_iMXPScriptOwner = 0;
+  m_iMXPListOwner = 0;
+
+  if (!bManual)
+    {
+    m_iMXP_defaultMode = m_iMXP_mode = eMXP_open;
+    DELETE_MAP (m_CustomElementMap, CElement);
+    DELETE_LIST (m_ActiveTagList);
+    m_CustomEntityMap.RemoveAll ();
+    }
+
+  const __int64 iStartBoundary = App.GetUniqueNumber ();
+  m_bMXP = true;
+  m_bPuebloActive = bPueblo;
+
+  try
+    {
+
   if (bPueblo)
     MXP_error (DBG_INFO, infoMXP_on, "Pueblo turned on.");
   else
     MXP_error (DBG_INFO, infoMXP_on, "MXP turned on.");
+
+  if (m_iMXPGeneration != iStartingGeneration || !m_bMXP)
+    return;
 
   // execute "open" script
   if (m_dispidOnMXP_Start != DISPID_UNKNOWN)
@@ -117,42 +464,33 @@ void CMUSHclientDoc::MXP_On (const bool bPueblo, const bool bManual)
         }
     } // end of executing open script
 
+  if (m_iMXPGeneration != iStartingGeneration || !m_bMXP)
+    return;
+
  SendToAllPluginCallbacks (ON_PLUGIN_MXP_START);
 
- m_bMXP = true;
- m_bPuebloActive = bPueblo;
- m_bMXP_script = false;
- m_bPreMode = false;
- m_iLastOutstandingTagCount = 0;
- m_iMXPerrors = 0;     
- m_iMXPtags = 0;       
- m_iMXPentities = 0; 
- m_iListMode = eNoList;
- m_iListCount = 0;
-
- // if they turn it on manually we want to leave everything set up
- //  (eg. they turn it off, they turn it on again)
-
- if (!bManual)
-   {
-   // make sure we are back to open as default
-
-   m_iMXP_defaultMode = m_iMXP_mode = eMXP_open;
-
-  // delete old definitions - we will assume we start from scratch here
-
-  // delete custom elements map
-
-    DELETE_MAP (m_CustomElementMap, CElement); 
-
-  // delete active tags list
-
-    DELETE_LIST (m_ActiveTagList);
-
-  // delete custom entities list
-
-    m_CustomEntityMap.RemoveAll ();
-   }
+  if (m_iMXPGeneration != iStartingGeneration || !m_bMXP)
+    return;
+    }
+  catch (...)
+    {
+    if (m_iMXPGeneration == iStartingGeneration)
+      {
+      m_bMXP = false;
+      m_bPuebloActive = false;
+      DiscardMXPTagsCreatedAfter (this, iStartBoundary);
+      m_bInParagraph = false;
+      m_bMXP_script = false;
+      m_bPreMode = false;
+      m_iListMode = eNoList;
+      m_iListCount = 0;
+      m_iMXPParagraphOwner = 0;
+      m_iMXPPreOwner = 0;
+      m_iMXPScriptOwner = 0;
+      m_iMXPListOwner = 0;
+      }
+    throw;
+    }
 
  }  // end of CMUSHclientDoc::MXP_On
 

--- a/mxp/mxpOpenAtomic.cpp
+++ b/mxp/mxpOpenAtomic.cpp
@@ -24,14 +24,53 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 
 extern tConfigurationNumericOption OptionsTable [];
 
+static void MarkMXPArgumentsUsed (CArgumentList & arguments)
+  {
+  for (POSITION pos = arguments.GetHeadPosition (); pos; )
+    arguments.GetNext (pos)->bUsed = true;
+  }
+
+static void QueueMXPMessage (vector<CDeferredMXPMessage> & messages,
+                             const int iLevel,
+                             const long iMessageNumber,
+                             const CString & strMessage)
+  {
+  messages.push_back (
+    CDeferredMXPMessage (iLevel, iMessageNumber, strMessage));
+  }
+
+class CScopedMXPAction
+  {
+  public:
+    CScopedMXPAction (CAction * pAction) : m_pAction (pAction) { }
+    ~CScopedMXPAction ()
+      {
+      if (m_pAction)
+        m_pAction->Release ();
+      }
+    CAction * Release ()
+      {
+      CAction * pAction = m_pAction;
+      m_pAction = NULL;
+      return pAction;
+      }
+
+  private:
+    CAction * m_pAction;
+  };
+
 // do the action required to open a single atomic tag (iAction)
-void CMUSHclientDoc::MXP_OpenAtomicTag (const CString strTag,
+bool CMUSHclientDoc::MXP_OpenAtomicTag (const CString strTag,
                                         int iAction, 
                                         CStyle * pStyle,
+                                        __int64 & iResultStyleCreationNumber,
                                         CString & strAction,    // new action
                                         CString & strHint,      // new hint
                                         CString & strVariable,   // new variable
-                                        CArgumentList & ArgumentList)
+                                        CArgumentList & ArgumentList,
+                                        const __int64 iStateOwner,
+                                        COutputAppendTransaction * pOutputTransaction,
+                                        vector<CDeferredMXPMessage> & deferredMessages)
   {
 CString strArgument;
 CString strArgumentName;
@@ -42,50 +81,11 @@ COLORREF colour1,
 unsigned short iFlags      = pStyle->iFlags;      
 COLORREF       iForeColour = pStyle->iForeColour; 
 COLORREF       iBackColour = pStyle->iBackColour; 
-
-  // call script if required
-  if ((m_dispidOnMXP_OpenTag != DISPID_UNKNOWN) || m_bPluginProcessesOpenTag)
-    {
-    // dummy-up an argument list
-    CString strArgument;
-    CArgument * pArgument;
-    POSITION pos;
-
-    // put the arguments into the array
-
-    for (pos = ArgumentList.GetHeadPosition (); pos; )
-      {
-      pArgument = ArgumentList.GetNext (pos);
-      
-      // empty ones we will put there by position
-      if (pArgument->strName.IsEmpty ())
-        strArgument += CFormat ("'%s'",
-                      (LPCTSTR) pArgument->strValue);
-      else
-        strArgument += CFormat ("%s='%s'",
-                      (LPCTSTR) pArgument->strName,
-                      (LPCTSTR) pArgument->strValue);
-
-      if (pos)
-        strArgument += " ";
-
-      }      // end of looping through each argument
-
-    bool bNotWanted = MXP_StartTagScript (strTag, strArgument, ArgumentList);
-
-    // re-get current style in case the script did a world.note
-    pStyle = m_pCurrentLine->styleList.GetTail ();
-
-    // put things backt to how they were
-    pStyle->iFlags      = iFlags;      
-    pStyle->iForeColour = iForeColour; 
-    pStyle->iBackColour = iBackColour; 
-
-    if (bNotWanted)
-      return;   // they didn't want to go ahead with this tag
-
-    }
-
+const __int64 iOpeningActiveTagCreationNumber =
+  m_ActiveTagList.IsEmpty () ? 0 :
+    m_ActiveTagList.GetTail ()->nCreationNumber;
+// Save the identity before an action can run a packet or output callback.
+iResultStyleCreationNumber = pStyle->nCreationNumber;
 
 // find current foreground and background RGB values
   GetStyleRGB (pStyle, colour1, colour2);
@@ -134,17 +134,21 @@ COLORREF       iBackColour = pStyle->iBackColour;
          strArgument = GetArgument (ArgumentList, "fore", 1, true);  // get foreground colour
          if (!m_bIgnoreMXPcolourChanges)
            if (SetColour (strArgument, pStyle->iForeColour)) 
-             MXP_error (DBG_ERROR, errMXP_UnknownColour,
+             {
+             QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_UnknownColour,
                         TFormat ("Unknown colour: \"%s\"" ,
                                  (LPCTSTR) strArgument));
+             }
 
          // background colour
          strArgument = GetArgument (ArgumentList, "back", 2, true);  // get background colour
          if (!m_bIgnoreMXPcolourChanges)
            if (SetColour (strArgument, pStyle->iBackColour)) 
-             MXP_error (DBG_ERROR, errMXP_UnknownColour,
+             {
+             QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_UnknownColour,
                         TFormat ("Unknown colour: \"%s\"" ,
                                  (LPCTSTR) strArgument));
+             }
          }
          break;   // end of COLOR
 
@@ -263,9 +267,11 @@ COLORREF       iBackColour = pStyle->iBackColour;
               // foreground colour
               if (!m_bIgnoreMXPcolourChanges)
                 if (SetColour (strItem, pStyle->iForeColour)) 
-                  MXP_error (DBG_ERROR, errMXP_UnknownColour,
+                  {
+                  QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_UnknownColour,
                               TFormat ("Unknown colour: \"%s\"" ,
                                       (LPCTSTR) strItem));
+                  }
               } // end of colour
 
             } // end of handling each item in the list
@@ -276,9 +282,11 @@ COLORREF       iBackColour = pStyle->iBackColour;
 
           if (!m_bIgnoreMXPcolourChanges)
             if (SetColour (strArgument, pStyle->iBackColour)) 
-              MXP_error (DBG_ERROR, errMXP_UnknownColour,
+              {
+              QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_UnknownColour,
                         TFormat ("Unknown colour: \"%s\"" ,
                                   (LPCTSTR) strArgument));
+              }
 
           // get font size argument to avoid warnings about unused arguments
           strArgument = GetArgument (ArgumentList,"size", 0, true);  // get font size
@@ -296,7 +304,7 @@ COLORREF       iBackColour = pStyle->iBackColour;
                      );
 
             SendPacket (strVersion, strVersion.GetLength ());  // send version info back
-            MXP_error (DBG_INFO, infoMXP_VersionSent,
+            QueueMXPMessage (deferredMessages, DBG_INFO, infoMXP_VersionSent,
                       TFormat ("Sent version response: %s" ,
                                 (LPCTSTR) strVersion.Mid (4)));
 
@@ -317,7 +325,7 @@ COLORREF       iBackColour = pStyle->iBackColour;
                      );
 
             SendPacket (strAFK, strAFK.GetLength ());  // send AFK info back
-            MXP_error (DBG_INFO, infoMXP_AFKSent,
+            QueueMXPMessage (deferredMessages, DBG_INFO, infoMXP_AFKSent,
                       TFormat ("Sent AFK response: %s" ,
                                 (LPCTSTR) strAFK.Mid (4)));
             } // end of AFK
@@ -367,10 +375,11 @@ COLORREF       iBackColour = pStyle->iBackColour;
                 // should be one or two words, eg. send.prompt or color
                 if (questionlist.GetCount () > 2)
                   {
-                  MXP_error (DBG_ERROR, errMXP_InvalidSupportArgument,
+                  QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_InvalidSupportArgument,
                             TFormat ("Invalid <support> argument: %s" ,
                                       (LPCTSTR) pArgument->strValue));
-                  return;
+                  MarkMXPArgumentsUsed (ArgumentList);
+                  return true;
                   }
                 
                 CString strTag =  questionlist.RemoveHead ();
@@ -379,10 +388,11 @@ COLORREF       iBackColour = pStyle->iBackColour;
                 // check valid name requested
                 if (!IsValidName (strTag))
                   {
-                  MXP_error (DBG_ERROR, errMXP_InvalidSupportArgument,
+                  QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_InvalidSupportArgument,
                             TFormat ("Invalid <support> argument: %s" ,
                                       (LPCTSTR) strTag));
-                  return;
+                  MarkMXPArgumentsUsed (ArgumentList);
+                  return true;
                   }
 
                 // look up main element name
@@ -427,10 +437,11 @@ COLORREF       iBackColour = pStyle->iBackColour;
                   // check valid name requested
                   if (!IsValidName (strSubtag))
                     {
-                    MXP_error (DBG_ERROR, errMXP_InvalidSupportArgument,
+                    QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_InvalidSupportArgument,
                               TFormat ("Invalid <support> argument: %s" ,
                                         (LPCTSTR) strSubtag));
-                    return;
+                    MarkMXPArgumentsUsed (ArgumentList);
+                    return true;
                     }
 
                   // so, see if that word is in our arguments list
@@ -457,7 +468,7 @@ COLORREF       iBackColour = pStyle->iBackColour;
                                           ENDLINE);
 
             SendPacket (strMessage, strMessage.GetLength ());  // send version info back
-            MXP_error (DBG_INFO, infoMXP_SupportsSent,
+            QueueMXPMessage (deferredMessages, DBG_INFO, infoMXP_SupportsSent,
                       TFormat ("Sent supports response: %s" ,
                                 (LPCTSTR) strMessage.Mid (4)));
 
@@ -503,7 +514,7 @@ COLORREF       iBackColour = pStyle->iBackColour;
                                           ENDLINE);
 
             SendPacket (strMessage, strMessage.GetLength ());  // send version info back
-            MXP_error (DBG_INFO, infoMXP_OptionsSent,
+            QueueMXPMessage (deferredMessages, DBG_INFO, infoMXP_OptionsSent,
                       TFormat ("Sent options response: %s" ,
                                 (LPCTSTR) strMessage.Mid (4)));
 
@@ -527,23 +538,23 @@ COLORREF       iBackColour = pStyle->iBackColour;
               int iResult = FindBaseOption (pArgument->strName, OptionsTable, iItem);
 
               if (iResult != eOK)
-                MXP_error (DBG_ERROR, errMXP_InvalidOptionArgument,
+                QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_InvalidOptionArgument,
                           TFormat ("Option named '%s' not known.",
                           (LPCTSTR) pArgument->strName));      
               else if (!(OptionsTable [iItem].iFlags & OPT_SERVER_CAN_WRITE))
-                MXP_error (DBG_ERROR, errMXP_CannotChangeOption,
+                QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_CannotChangeOption,
                           TFormat ("Option named '%s' cannot be changed.",
                           (LPCTSTR) pArgument->strName));      
               else
                 {
                 iResult = SetOptionItem (iItem, atol (pArgument->strValue), true, false);
                 if (iResult == eOK)
-                  MXP_error (DBG_INFO, infoMXP_OptionChanged,
+                  QueueMXPMessage (deferredMessages, DBG_INFO, infoMXP_OptionChanged,
                             TFormat ("Option named '%s' changed to '%s'.",
                             (LPCTSTR) pArgument->strName,
                             (LPCTSTR) pArgument->strValue)); 
                 else
-                  MXP_error (DBG_ERROR, errMXP_OptionOutOfRange,
+                  QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_OptionOutOfRange,
                             TFormat ("Option named '%s' could not be changed to '%s' (out of range).",
                             (LPCTSTR) pArgument->strName,
                             (LPCTSTR) pArgument->strValue));      
@@ -563,21 +574,21 @@ COLORREF       iBackColour = pStyle->iBackColour;
               {
               CString strPacket = m_name + ENDLINE;
               SendPacket (strPacket, strPacket.GetLength ());  // send name to MUD
-              MXP_error (DBG_INFO, infoMXP_CharacterNameSent,
+              QueueMXPMessage (deferredMessages, DBG_INFO, infoMXP_CharacterNameSent,
                           TFormat ("Sent character name: %s" ,
                                   (LPCTSTR) m_name));      
               }
             else if (m_connect_now != eConnectMXP)
-              MXP_error (DBG_WARNING, wrnMXP_CharacterNameRequestedButNotDefined,
+              QueueMXPMessage (deferredMessages, DBG_WARNING, wrnMXP_CharacterNameRequestedButNotDefined,
                         Translate ("Character name requested but auto-connect not set to MXP."));      
             else
-              MXP_error (DBG_WARNING, wrnMXP_CharacterNameRequestedButNotDefined,
+              QueueMXPMessage (deferredMessages, DBG_WARNING, wrnMXP_CharacterNameRequestedButNotDefined,
                         Translate ("Character name requested but none defined."));      
             break;  // end of USER
 
     case MXP_ACTION_PASSWORD:
             if (m_nTotalLinesSent > 10)     // security check
-              MXP_error (DBG_WARNING, wrnMXP_PasswordNotSent,
+              QueueMXPMessage (deferredMessages, DBG_WARNING, wrnMXP_PasswordNotSent,
                         "Too many lines sent to MUD - password not sent.");      
             else
             if (!m_password.IsEmpty () && 
@@ -585,14 +596,14 @@ COLORREF       iBackColour = pStyle->iBackColour;
               {
               CString strPacket = m_password + ENDLINE;
               SendPacket (strPacket, strPacket.GetLength ());  // send password to MUD
-              MXP_error (DBG_INFO, infoMXP_PasswordSent,
+              QueueMXPMessage (deferredMessages, DBG_INFO, infoMXP_PasswordSent,
                         "Sent password to world.");      
               }
             else if (m_connect_now != eConnectMXP)
-              MXP_error (DBG_WARNING, wrnMXP_PasswordRequestedButNotDefined,
+              QueueMXPMessage (deferredMessages, DBG_WARNING, wrnMXP_PasswordRequestedButNotDefined,
                         "Password requested but auto-connect not set to MXP.");      
             else
-              MXP_error (DBG_WARNING, wrnMXP_PasswordRequestedButNotDefined,
+              QueueMXPMessage (deferredMessages, DBG_WARNING, wrnMXP_PasswordRequestedButNotDefined,
                         "Password requested but none defined.");      
             break;  // end of PASSWORD
 
@@ -601,14 +612,31 @@ COLORREF       iBackColour = pStyle->iBackColour;
           // experimental
           m_cLastChar = 0;
           m_bInParagraph = true;      
+          m_iMXPParagraphOwner = iStateOwner;
           break;  // end of MXP_ACTION_P
     
           // new line
     case MXP_ACTION_BR:
           bIgnoreUnusedArgs = true; // don't worry about args for now :)
 
-          StartNewLine (true, 0);
-          SetNewLineColour (0);
+          {
+          ASSERT (pOutputTransaction);
+          if (!pOutputTransaction)
+            return false;
+          pOutputTransaction->Reserve (2);
+          bool bCreatedLine = false;
+          if (!pOutputTransaction->StartNewLine (
+                true, 0, true, &bCreatedLine))
+            return false;
+          if (bCreatedLine)
+            {
+            SetNewLineColour (0);
+            iResultStyleCreationNumber =
+              m_pCurrentLine->styleList.GetTail ()->nCreationNumber;
+            }
+          else
+            iResultStyleCreationNumber = 0;
+          }
           break;  // end of MXP_ACTION_BR
 
           // reset
@@ -659,17 +687,29 @@ COLORREF       iBackColour = pStyle->iBackColour;
           break;  // end of MXP_ACTION_MXP
 
     case MXP_ACTION_SCRIPT:
-          MXP_error (DBG_INFO, infoMXP_ScriptCollectionStarted,
-                      "Script collection mode entered (discarding script).");
           m_bMXP_script = true;
+          m_iMXPScriptOwner = iStateOwner;
+          QueueMXPMessage (deferredMessages, DBG_INFO, infoMXP_ScriptCollectionStarted,
+                      "Script collection mode entered (discarding script).");
           break;  // end of MXP_ACTION_SCRIPT
 
     case MXP_ACTION_HR: 
 
           {
+          ASSERT (pOutputTransaction);
+          if (!pOutputTransaction)
+            return false;
+          pOutputTransaction->Reserve (3);
+          bool bOwnHorizontalLine = true;
           // wrap up previous line if necessary
           if (m_pCurrentLine->len > 0)
-             StartNewLine (true, 0);
+            {
+            bool bCreatedLine = false;
+            if (!pOutputTransaction->StartNewLine (
+                  true, 0, true, &bCreatedLine))
+              return false;
+            bOwnHorizontalLine = bCreatedLine;
+            }
 
           /*
           CString strLine;
@@ -678,34 +718,85 @@ COLORREF       iBackColour = pStyle->iBackColour;
           strLine.ReleaseBuffer (m_nWrapColumn);
           AddToLine (strLine, 0);
           */
-          // mark line as HR line
-          m_pCurrentLine->flags = HORIZ_RULE;
+          // Do not overwrite a continuation line supplied by a callback.
+          if (!bOwnHorizontalLine)
+            {
+            iResultStyleCreationNumber = 0;
+            break;
+            }
+          pOutputTransaction->SetLineFlags (m_pCurrentLine, HORIZ_RULE);
           
-          StartNewLine (true, 0); // now finish this line
+          bool bCreatedLine = false;
+          if (!pOutputTransaction->StartNewLine (
+                true, 0, true, &bCreatedLine)) // now finish this line
+            return false;
+          iResultStyleCreationNumber = bCreatedLine ?
+            m_pCurrentLine->styleList.GetTail ()->nCreationNumber : 0;
           }
           break;  // end of MXP_ACTION_HR
 
     case MXP_ACTION_PRE: 
           m_bPreMode = true;
+          m_iMXPPreOwner = iStateOwner;
           break;  // end of MXP_ACTION_PRE
 
      case MXP_ACTION_UL:   
           m_iListMode = eUnorderedList;
           m_iListCount = 0;
+          m_iMXPListOwner = iStateOwner;
           break;  // end of MXP_ACTION_UL
      case MXP_ACTION_OL:   
           m_iListMode = eOrderedList;
           m_iListCount = 0;
+          m_iMXPListOwner = iStateOwner;
           break;  // end of MXP_ACTION_OL
      case MXP_ACTION_LI:   
          {
+          ASSERT (pOutputTransaction);
+          if (!pOutputTransaction)
+            return false;
           // wrap up previous line if necessary
           if (m_pCurrentLine->len > 0)
-             StartNewLine (true, 0);
+            {
+            bool bCreatedLine = false;
+            if (!pOutputTransaction->StartNewLine (
+                  true, 0, true, &bCreatedLine))
+              return false;
+            if (!bCreatedLine)
+              {
+              iResultStyleCreationNumber = 0;
+              break;
+              }
+            }
           CString strListItem = " * ";
-          if (m_iListMode == eOrderedList)
-            strListItem.Format (" %i. ", ++m_iListCount);
-          AddToLine (strListItem, 0);
+          const bool bOrderedList = m_iListMode == eOrderedList;
+          const int iOpeningListCount = m_iListCount;
+          const __int64 iOpeningListOwner = m_iMXPListOwner;
+          if (bOrderedList)
+            strListItem.Format (" %i. ", iOpeningListCount + 1);
+          pOutputTransaction->Reserve (strListItem.GetLength () + 1);
+          pOutputTransaction->MarkCurrentLineStyles ();
+          iResultStyleCreationNumber =
+            pOutputTransaction->PrepareAppendStyle ()->nCreationNumber;
+          if (!AddToLineInternal (strListItem, 0, pOutputTransaction))
+            return false;
+          if (bOrderedList)
+            {
+            if (m_iListMode != eOrderedList ||
+                m_iListCount != iOpeningListCount ||
+                m_iMXPListOwner != iOpeningListOwner)
+              return false;
+            pOutputTransaction->SetListCount (iOpeningListCount + 1);
+            }
+          const __int64 iCurrentActiveTagCreationNumber =
+            m_ActiveTagList.IsEmpty () ? 0 :
+              m_ActiveTagList.GetTail ()->nCreationNumber;
+          if (iCurrentActiveTagCreationNumber !=
+              iOpeningActiveTagCreationNumber)
+            iResultStyleCreationNumber = 0;
+          else
+            iResultStyleCreationNumber =
+              m_pCurrentLine->styleList.GetTail ()->nCreationNumber;
           }
           break;  // end of MXP_ACTION_LI
 
@@ -747,17 +838,38 @@ COLORREF       iBackColour = pStyle->iBackColour;
             {
 
             CString strOldAction = strAction;
+            CString strOldHint = strHint;
+            CString strOldVariable = strVariable;
             int iFlags = pStyle->iFlags;
             COLORREF iForeColour = pStyle->iForeColour;
             COLORREF iBackColour = pStyle->iBackColour;
 
+            strArgument += strFilename;   // append filename to URL
+            CString strImagePlaceholder = "[";
+            strImagePlaceholder += strArgument;
+            strImagePlaceholder += "]";
+            CScopedMXPAction replacementAction (
+              GetAction (strArgument, strHint, strVariable));
+
+            ASSERT (pOutputTransaction);
+            if (!pOutputTransaction)
+              return false;
+            pOutputTransaction->Reserve (
+              strImagePlaceholder.GetLength () + 2);
+
             // ensure on new line
             if (m_pCurrentLine->len > 0)
-               StartNewLine (true, 0);
+              {
+              bool bCreatedLine = false;
+              if (!pOutputTransaction->StartNewLine (
+                    true, 0, true, &bCreatedLine))
+                return false;
+              }
 
-            // starting a new line may have deleted pStyle
-
-            pStyle = m_pCurrentLine->styleList.GetTail ();
+            // Starting a new line can publish callback output. Keep it outside
+            // the image-owned style so rollback does not remove it.
+            pOutputTransaction->MarkCurrentLineStyles ();
+            pStyle = pOutputTransaction->PrepareAppendStyle ();
 
             if (m_bUseCustomLinkColour)
               {
@@ -767,7 +879,6 @@ COLORREF       iBackColour = pStyle->iBackColour;
               pStyle->iFlags |= COLOUR_RGB;
               }
 
-            strArgument += strFilename;   // append filename to URL
             strAction = strArgument;   // hyperlink
             pStyle->iFlags &= ~ACTIONTYPE;   // cancel old actions
             pStyle->iFlags |= ACTION_HYPERLINK;   // send-to action
@@ -775,21 +886,50 @@ COLORREF       iBackColour = pStyle->iBackColour;
             if (m_bUnderlineHyperlinks)
               pStyle->iFlags |= UNDERLINE;   // send-to action
 
-            AddToLine ("[", 0);          
-            AddToLine (strArgument, 0);
-            AddToLine ("]", 0);
-
-            // have to add the action now, before we start a new line
-            pStyle->pAction = GetAction (strAction, strHint, strVariable);
+            // Install the action before output because wrapping copies styles.
+            CAction * pOldAction = pStyle->pAction;
+            pStyle->pAction = replacementAction.Release ();
+            if (pOldAction)
+              pOldAction->Release ();
             strAction.Empty ();
+            strHint.Empty ();
+            strVariable.Empty ();
+            if (!AddToLineInternal (strImagePlaceholder,
+                                    0,
+                                    pOutputTransaction))
+              return false;
 
-            StartNewLine (true, 0);   // new line after image tag
+            bool bCreatedLine = false;
+            if (!pOutputTransaction->StartNewLine (
+                  true, 0, true, &bCreatedLine))
+              return false;
+
+            const __int64 iCurrentActiveTagCreationNumber =
+              m_ActiveTagList.IsEmpty () ? 0 :
+                m_ActiveTagList.GetTail ()->nCreationNumber;
+            if (iCurrentActiveTagCreationNumber !=
+                iOpeningActiveTagCreationNumber)
+              {
+              // The image output styles received the replacement action.
+              // strAction, strHint and strVariable remain empty. Keep the
+              // callback's style instead of restoring the old one with AddStyle.
+              iResultStyleCreationNumber = 0;
+              break;
+              }
+
             // go back to old style (ie. lose the underlining)
-            AddStyle (iFlags, 
-                     iForeColour, 
-                     iBackColour, 
-                     0, 
-                     strOldAction);
+            CStyle * pResultStyle = AddStyle (iFlags,
+                                     iForeColour,
+                                     iBackColour,
+                                     0,
+                                     strOldAction,
+                                     strOldHint,
+                                     strOldVariable);
+            pOutputTransaction->OwnStyle (pResultStyle);
+            iResultStyleCreationNumber = pResultStyle->nCreationNumber;
+            strAction = strOldAction;
+            strHint = strOldHint;
+            strVariable = strOldVariable;
 
             }
         }
@@ -811,11 +951,12 @@ COLORREF       iBackColour = pStyle->iBackColour;
 
           if (!IsValidName (strVariable))
             {
-            MXP_error (DBG_ERROR, errMXP_InvalidDefinition,
+            QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_InvalidDefinition,
                       TFormat ("Invalid MXP entity name: <!%s>", 
                       (LPCTSTR) strVariable)); 
             strVariable.Empty ();
-            return;
+            MarkMXPArgumentsUsed (ArgumentList);
+            return true;
             }
 
             { // protect local variable
@@ -823,11 +964,12 @@ COLORREF       iBackColour = pStyle->iBackColour;
 
             if (App.m_EntityMap.Lookup (strVariable, strEntityContents))
               {
-              MXP_error (DBG_ERROR, errMXP_CannotRedefineEntity,
+              QueueMXPMessage (deferredMessages, DBG_ERROR, errMXP_CannotRedefineEntity,
                         TFormat ("Cannot redefine entity: &%s;", 
                         (LPCTSTR) strVariable)); 
               strVariable.Empty ();
-              return;
+              MarkMXPArgumentsUsed (ArgumentList);
+              return true;
               }
               }
 
@@ -837,15 +979,17 @@ COLORREF       iBackColour = pStyle->iBackColour;
     default:
           {
           // warn them it is not implemented
-          MXP_error (DBG_WARNING, wrnMXP_TagNotImplemented,
+          QueueMXPMessage (deferredMessages, DBG_WARNING, wrnMXP_TagNotImplemented,
                      TFormat ("MXP tag <%s> is not implemented" ,
                              (LPCTSTR) strTag));
           }   // end of default
 
     } // end of switch on iAction
 
-  if (!bIgnoreUnusedArgs)
-    CheckArgumentsUsed (strTag, ArgumentList);
+  if (bIgnoreUnusedArgs)
+    MarkMXPArgumentsUsed (ArgumentList);
+
+  return true;
 
   } // end of CMUSHclientDoc::MXP_OpenAtomicTag
 

--- a/mxp/mxpStart.cpp
+++ b/mxp/mxpStart.cpp
@@ -295,6 +295,9 @@ class CMXPStartTransaction
                           const __int64 iStateOwner) :
       m_pDoc (pDoc),
       m_iStateOwner (iStateOwner),
+      m_iOpeningOutputGeneration (pDoc->m_iOutputGeneration),
+      m_iFirstResultLineCreationNumber (pDoc->m_pCurrentLine ?
+        pDoc->m_pCurrentLine->nCreationNumber : 0),
       m_bOpeningInParagraph (pDoc->m_bInParagraph),
       m_bOpeningPreMode (pDoc->m_bPreMode),
       m_bOpeningMXPScript (pDoc->m_bMXP_script),
@@ -495,7 +498,31 @@ class CMXPStartTransaction
       }
 
     CStyle * ResolveStyle (const __int64 iCreationNumber) const
-      { return FindStyle (iCreationNumber); }
+      {
+      if (!iCreationNumber)
+        return NULL;
+
+      // Deleting output can resume an older retained line. Keep the full
+      // lookup when that happens during this transaction.
+      if (m_pDoc->m_iOutputGeneration != m_iOpeningOutputGeneration)
+        return FindStyle (iCreationNumber);
+
+      // Without deletion, results stay on the opening line or a newer line.
+      // A note callback can replace the result without deleting any lines.
+      for (POSITION linepos = m_pDoc->m_LineList.GetTailPosition (); linepos; )
+        {
+        CLine * pLine = m_pDoc->m_LineList.GetPrev (linepos);
+        if (pLine->nCreationNumber < m_iFirstResultLineCreationNumber)
+          break;
+        for (POSITION stylepos = pLine->styleList.GetTailPosition (); stylepos; )
+          {
+          CStyle * pStyle = pLine->styleList.GetPrev (stylepos);
+          if (pStyle->nCreationNumber == iCreationNumber)
+            return pStyle;
+          }
+        }
+      return NULL;
+      }
 
     void Commit ()
       {
@@ -565,6 +592,8 @@ class CMXPStartTransaction
 
     CMUSHclientDoc * m_pDoc;
     __int64 m_iStateOwner;
+    __int64 m_iOpeningOutputGeneration;
+    __int64 m_iFirstResultLineCreationNumber;
     bool m_bOpeningInParagraph;
     bool m_bOpeningPreMode;
     bool m_bOpeningMXPScript;
@@ -950,12 +979,12 @@ CString strTagVariable;
     if (pAtomicElement)
       pTag->closeActions.push_back (pAtomicElement->iAction);
     else
-      for (POSITION closepos = pElement->ElementItemList.GetHeadPosition ();
-           closepos; )
-        {
-        CElementItem * pCloseItem = pElement->ElementItemList.GetNext (closepos);
-        pTag->closeActions.push_back (pCloseItem->pAtomicElement->iAction);
-        }
+      for (size_t iExpandedItem = 0;
+           iExpandedItem < expandedItems.size ();
+           iExpandedItem++)
+        if (expandedItemsWanted [iExpandedItem])
+          pTag->closeActions.push_back (
+            expandedItems [iExpandedItem]->pAtomicElement->iAction);
     m_ActiveTagList.AddTail (pTag.get ());  // add to outstanding tag list
     pPublishedTag = pTag.release ();
     transaction.SetActiveTag (pPublishedTag);

--- a/mxp/mxpStart.cpp
+++ b/mxp/mxpStart.cpp
@@ -122,8 +122,10 @@ static CString BuildAtomicCallbackArguments (CArgumentList & arguments)
   }
 
 static bool ExpandAtomicArgumentEntities (CMUSHclientDoc * pDoc,
-                                          CArgumentList & arguments)
+                                          CArgumentList & arguments,
+                                          bool & bExpandedEntities)
   {
+  bExpandedEntities = false;
   for (POSITION pos = arguments.GetHeadPosition (); pos; )
     {
     CArgument * pArgument = arguments.GetNext (pos);
@@ -159,7 +161,11 @@ static bool ExpandAtomicArgumentEntities (CMUSHclientDoc * pDoc,
         if (strEntity == "text")
           strFixedValue += "&text;";
         else
+          {
+          // Entity diagnostics can call scripts even if expansion fails.
+          bExpandedEntities = true;
           strFixedValue += pDoc->MXP_GetEntity (strEntity);
+          }
         pStart = p + 1;
         }
 
@@ -750,8 +756,9 @@ CString strTagVariable;
   const __int64 iOpeningMXPGeneration = m_iMXPGeneration;
   vector<__int64> activeTagsBeforePreparation;
   SnapshotActiveTags (m_ActiveTagList, activeTagsBeforePreparation);
-  const bool bExpandedAtomicArguments = pAtomicElement != NULL;
-  if (pAtomicElement && !ExpandAtomicArgumentEntities (this, ArgumentList))
+  bool bExpandedAtomicArguments = false;
+  if (pAtomicElement &&
+      !ExpandAtomicArgumentEntities (this, ArgumentList, bExpandedAtomicArguments))
     return;
 
   // Run the open callback before publishing this tag. A callback-created tag

--- a/mxp/mxpStart.cpp
+++ b/mxp/mxpStart.cpp
@@ -23,6 +23,596 @@ static char BASED_CODE THIS_FILE[] = __FILE__;
 
 #define SECURE_ELEMENT_CHECK true
 
+class CArgumentListGuard
+  {
+  public:
+    CArgumentListGuard (CArgumentList & list) : m_list (list) { }
+    ~CArgumentListGuard () { DELETE_LIST (m_list); }
+
+  private:
+    CArgumentList & m_list;
+  };
+
+static std::unique_ptr<CElement> CloneCustomElement (const CElement * pSource)
+  {
+  std::unique_ptr<CElement> pClone (new CElement);
+  pClone->strName = pSource->strName;
+  pClone->iTag = pSource->iTag;
+  pClone->strFlag = pSource->strFlag;
+  pClone->bOpen = pSource->bOpen;
+  pClone->bCommand = pSource->bCommand;
+
+  for (POSITION pos = pSource->AttributeList.GetHeadPosition (); pos; )
+    {
+    CArgument * pSourceArgument = pSource->AttributeList.GetNext (pos);
+    std::unique_ptr<CArgument> pArgument
+      (new CArgument (pSourceArgument->strName,
+                      pSourceArgument->strValue,
+                      pSourceArgument->iPosition));
+    pArgument->bKeyword = pSourceArgument->bKeyword;
+    pArgument->bUsed = pSourceArgument->bUsed;
+    pClone->AttributeList.AddTail (pArgument.get ());
+    pArgument.release ();
+    }
+
+  for (POSITION itempos = pSource->ElementItemList.GetHeadPosition (); itempos; )
+    {
+    CElementItem * pSourceItem = pSource->ElementItemList.GetNext (itempos);
+    std::unique_ptr<CElementItem> pItem (new CElementItem);
+    pItem->pAtomicElement = pSourceItem->pAtomicElement;
+
+    for (POSITION argpos = pSourceItem->ArgumentList.GetHeadPosition (); argpos; )
+      {
+      CArgument * pSourceArgument = pSourceItem->ArgumentList.GetNext (argpos);
+      std::unique_ptr<CArgument> pArgument
+        (new CArgument (pSourceArgument->strName,
+                        pSourceArgument->strValue,
+                        pSourceArgument->iPosition));
+      pArgument->bKeyword = pSourceArgument->bKeyword;
+      pArgument->bUsed = pSourceArgument->bUsed;
+      pItem->ArgumentList.AddTail (pArgument.get ());
+      pArgument.release ();
+      }
+
+    pClone->ElementItemList.AddTail (pItem.get ());
+    pItem.release ();
+    }
+
+  return pClone;
+  }
+
+static void SnapshotActiveTags (CActiveTagList & activeTags,
+                                vector<__int64> & identities)
+  {
+  identities.clear ();
+  for (POSITION pos = activeTags.GetHeadPosition (); pos; )
+    identities.push_back (activeTags.GetNext (pos)->nCreationNumber);
+  }
+
+static bool ActiveTagsMatch (CActiveTagList & activeTags,
+                             const vector<__int64> & identities)
+  {
+  if (activeTags.GetCount () != identities.size ())
+    return false;
+
+  vector<__int64>::const_iterator it = identities.begin ();
+  for (POSITION pos = activeTags.GetHeadPosition (); pos; ++it)
+    if (activeTags.GetNext (pos)->nCreationNumber != *it)
+      return false;
+
+  return true;
+  }
+
+static CString BuildAtomicCallbackArguments (CArgumentList & arguments)
+  {
+  CString result;
+  for (POSITION pos = arguments.GetHeadPosition (); pos; )
+    {
+    CArgument * pArgument = arguments.GetNext (pos);
+    if (pArgument->strName.IsEmpty ())
+      result += CFormat ("'%s'", (LPCTSTR) pArgument->strValue);
+    else
+      result += CFormat ("%s='%s'",
+                         (LPCTSTR) pArgument->strName,
+                         (LPCTSTR) pArgument->strValue);
+    if (pos)
+      result += " ";
+    }
+  return result;
+  }
+
+static bool ExpandAtomicArgumentEntities (CMUSHclientDoc * pDoc,
+                                          CArgumentList & arguments)
+  {
+  for (POSITION pos = arguments.GetHeadPosition (); pos; )
+    {
+    CArgument * pArgument = arguments.GetNext (pos);
+    if (pArgument->strValue.Find ('&') == -1)
+      continue;
+
+    const char * p = pArgument->strValue;
+    const char * pStart = pArgument->strValue;
+    CString strFixedValue;
+
+    for ( ; *p; p++)
+      if (*p == '&')
+        {
+        const long length = p - pStart;
+        if (length > 0)
+          strFixedValue += CString (pStart, length);
+
+        p++;
+        pStart = p;
+        for ( ; *p && *p != ';'; p++)
+          ;
+        if (*p != ';')
+          {
+          pDoc->MXP_error (
+            DBG_ERROR,
+            errMXP_NoClosingSemicolonInArgument,
+            TFormat ("No closing \";\" in MXP element argument \"%s\"",
+                     (LPCTSTR) pArgument->strValue));
+          return false;
+          }
+
+        CString strEntity (pStart, p - pStart);
+        if (strEntity == "text")
+          strFixedValue += "&text;";
+        else
+          strFixedValue += pDoc->MXP_GetEntity (strEntity);
+        pStart = p + 1;
+        }
+
+    strFixedValue += pStart;
+    pArgument->strValue = strFixedValue;
+    }
+
+  return true;
+  }
+
+static bool BuildCustomAtomicArguments (CMUSHclientDoc * pDoc,
+                                        const CString & strElementName,
+                                        CElement * pElement,
+                                        CElementItem * pElementItem,
+                                        CArgumentList & suppliedArguments,
+                                        CArgumentList & builtArguments)
+  {
+  int iArgumentNumber = 0;
+  for (POSITION atompos = pElementItem->ArgumentList.GetHeadPosition ();
+       atompos; )
+    {
+    CArgument * pArgument = pElementItem->ArgumentList.GetNext (atompos);
+    const char * p = pArgument->strValue;
+    const char * pStart = pArgument->strValue;
+    CString strFixedValue;
+
+    for ( ; *p; p++)
+      if (*p == '&')
+        {
+        const long length = p - pStart;
+        if (length > 0)
+          strFixedValue += CString (pStart, length);
+
+        p++;
+        pStart = p;
+        for ( ; *p && *p != ';'; p++)
+          ;
+        if (*p != ';')
+          {
+          pDoc->MXP_error (
+            DBG_ERROR,
+            errMXP_NoClosingSemicolonInArgument,
+            TFormat ("No closing \";\" in MXP element argument \"%s\"",
+                     (LPCTSTR) pArgument->strValue));
+          return false;
+          }
+
+        CString strEntity (pStart, p - pStart);
+        CString strReplacement = "&text;";
+        if (strEntity != "text")
+          {
+          CString strDefault;
+          CArgument * pAttribute = NULL;
+          int iSequence = 1;
+          for (POSITION attpos = pElement->AttributeList.GetHeadPosition ();
+               attpos; iSequence++)
+            {
+            pAttribute = pElement->AttributeList.GetNext (attpos);
+            if (pAttribute->strName.IsEmpty ())
+              {
+              if (pAttribute->strValue.CompareNoCase (strEntity) == 0)
+                break;
+              }
+            else if (pAttribute->strName.CompareNoCase (strEntity) == 0)
+              {
+              strDefault = pAttribute->strValue;
+              break;
+              }
+            pAttribute = NULL;
+            }
+
+          if (pAttribute)
+            {
+            strReplacement = GetArgument (suppliedArguments,
+                                          strEntity,
+                                          iSequence,
+                                          false);
+            if (strReplacement.IsEmpty ())
+              {
+              strReplacement = strDefault;
+              if (strReplacement.IsEmpty ())
+                pDoc->MXP_error (
+                  DBG_WARNING,
+                  wrnMXP_ArgumentNotSupplied,
+                  TFormat ("Non-default argument \"%s\" not supplied to <%s>",
+                           (LPCTSTR) strEntity,
+                           (LPCTSTR) strElementName));
+              }
+            }
+          else
+            strReplacement = pDoc->MXP_GetEntity (strEntity);
+          }
+
+        strFixedValue += strReplacement;
+        pStart = p + 1;
+        }
+
+    strFixedValue += pStart;
+    std::unique_ptr<CArgument> pNewArgument;
+    if (pArgument->strName.IsEmpty ())
+      pNewArgument.reset (
+        new CArgument ("", strFixedValue, ++iArgumentNumber));
+    else
+      pNewArgument.reset (
+        new CArgument (pArgument->strName, strFixedValue, 0));
+    builtArguments.AddTail (pNewArgument.get ());
+    pNewArgument.release ();
+    }
+
+  return true;
+  }
+
+static void ReportDeferredMXPMessages (
+  CMUSHclientDoc * pDoc,
+  vector<CDeferredMXPMessage> & messages)
+  {
+  for (vector<CDeferredMXPMessage>::const_iterator it = messages.begin ();
+       it != messages.end (); ++it)
+    pDoc->MXP_error (it->iLevel, it->iMessageNumber, it->strMessage);
+  messages.clear ();
+  }
+
+class CMXPStartTransaction
+  {
+  public:
+    CMXPStartTransaction (CMUSHclientDoc * pDoc,
+                          const __int64 iStateOwner) :
+      m_pDoc (pDoc),
+      m_iStateOwner (iStateOwner),
+      m_bOpeningInParagraph (pDoc->m_bInParagraph),
+      m_bOpeningPreMode (pDoc->m_bPreMode),
+      m_bOpeningMXPScript (pDoc->m_bMXP_script),
+      m_iOpeningListMode (pDoc->m_iListMode),
+      m_iOpeningListCount (pDoc->m_iListCount),
+      m_iOpeningParagraphOwner (pDoc->m_iMXPParagraphOwner),
+      m_iOpeningPreOwner (pDoc->m_iMXPPreOwner),
+      m_iOpeningScriptOwner (pDoc->m_iMXPScriptOwner),
+      m_iOpeningListOwner (pDoc->m_iMXPListOwner),
+      m_iActiveTagCreationNumber (0),
+      m_iMarkerCreationNumber (0),
+      m_iStyleCreationNumber (0),
+      m_iPreservedStyleCreationNumber (0),
+      m_iPreservedRangeCreationNumber (0),
+      m_iPreservedOutputAppendCreationNumber (0),
+      m_iPreservedLength (0),
+      m_iPreservedFlags (0),
+      m_iPreservedForeColour (0),
+      m_iPreservedBackColour (0),
+      m_pPreservedAction (NULL),
+      m_bCommitted (false) { }
+
+    ~CMXPStartTransaction ()
+      { Rollback (); }
+
+    void Rollback ()
+      {
+      if (m_bCommitted)
+        return;
+      m_bCommitted = true;
+
+      if (m_pOutputTransaction)
+        m_pOutputTransaction->Rollback ();
+
+      // A callback can publish a newer tag before this opening transaction
+      // fails. Replace every saved reference to this failed owner so that a
+      // later close cannot restore state owned by a tag that no longer exists.
+      for (POSITION pos = m_pDoc->m_ActiveTagList.GetHeadPosition (); pos; )
+        {
+        CActiveTag * pTag = m_pDoc->m_ActiveTagList.GetNext (pos);
+        if (pTag->iOpeningParagraphOwner == m_iStateOwner)
+          {
+          pTag->bOpeningInParagraph = m_bOpeningInParagraph;
+          pTag->iOpeningParagraphOwner = m_iOpeningParagraphOwner;
+          }
+        if (pTag->iOpeningPreOwner == m_iStateOwner)
+          {
+          pTag->bOpeningPreMode = m_bOpeningPreMode;
+          pTag->iOpeningPreOwner = m_iOpeningPreOwner;
+          }
+        if (pTag->iOpeningScriptOwner == m_iStateOwner)
+          {
+          pTag->bOpeningMXPScript = m_bOpeningMXPScript;
+          pTag->iOpeningScriptOwner = m_iOpeningScriptOwner;
+          }
+        if (pTag->iOpeningListOwner == m_iStateOwner)
+          {
+          pTag->iOpeningListMode = m_iOpeningListMode;
+          pTag->iOpeningListCount = m_iOpeningListCount;
+          pTag->iOpeningListOwner = m_iOpeningListOwner;
+          }
+        }
+
+      if (m_pDoc->m_iMXPParagraphOwner == m_iStateOwner)
+        {
+        m_pDoc->m_bInParagraph = m_bOpeningInParagraph;
+        m_pDoc->m_iMXPParagraphOwner = m_iOpeningParagraphOwner;
+        }
+      if (m_pDoc->m_iMXPPreOwner == m_iStateOwner)
+        {
+        m_pDoc->m_bPreMode = m_bOpeningPreMode;
+        m_pDoc->m_iMXPPreOwner = m_iOpeningPreOwner;
+        }
+      if (m_pDoc->m_iMXPScriptOwner == m_iStateOwner)
+        {
+        m_pDoc->m_bMXP_script = m_bOpeningMXPScript;
+        m_pDoc->m_iMXPScriptOwner = m_iOpeningScriptOwner;
+        }
+      if (m_pDoc->m_iMXPListOwner == m_iStateOwner)
+        {
+        m_pDoc->m_iListMode = m_iOpeningListMode;
+        m_pDoc->m_iListCount = m_iOpeningListCount;
+        m_pDoc->m_iMXPListOwner = m_iOpeningListOwner;
+        }
+
+      CStyle * pMarkerStyle = FindStyle (m_iMarkerCreationNumber);
+      CStyle * pNewStyle = FindStyle (m_iStyleCreationNumber);
+      const bool bMarkerWasRepurposed =
+        pMarkerStyle &&
+        ((pMarkerStyle->iFlags & START_TAG) == 0 ||
+         pMarkerStyle->iLength != 0);
+      const bool bOriginalStyleMissing =
+        m_iPreservedStyleCreationNumber &&
+        !HasStyle (m_iPreservedStyleCreationNumber);
+
+      if (bMarkerWasRepurposed)
+        {
+        if (pNewStyle && pNewStyle->iLength == 0)
+          RemoveStyle (m_iStyleCreationNumber);
+        if (pMarkerStyle->pAction)
+          pMarkerStyle->pAction->Release ();
+        pMarkerStyle->iFlags = m_iPreservedFlags;
+        pMarkerStyle->iForeColour = m_iPreservedForeColour;
+        pMarkerStyle->iBackColour = m_iPreservedBackColour;
+        pMarkerStyle->pAction = m_pPreservedAction;
+        pMarkerStyle->nRangeCreationNumber =
+          m_iPreservedRangeCreationNumber;
+        pMarkerStyle->nOutputAppendCreationNumber =
+          m_iPreservedOutputAppendCreationNumber;
+        if (bOriginalStyleMissing)
+          pMarkerStyle->nCreationNumber = m_iPreservedStyleCreationNumber;
+        m_pPreservedAction = NULL;
+        }
+      else if (bOriginalStyleMissing &&
+          (pMarkerStyle || (pNewStyle && pNewStyle->iLength == 0)))
+        {
+        CStyle * pRestoreStyle = pMarkerStyle ? pMarkerStyle : pNewStyle;
+        if (pRestoreStyle != pNewStyle && pNewStyle && pNewStyle->iLength == 0)
+          RemoveStyle (m_iStyleCreationNumber);
+        if (pRestoreStyle != pMarkerStyle)
+          RemoveStyle (m_iMarkerCreationNumber);
+        if (pRestoreStyle->pAction)
+          pRestoreStyle->pAction->Release ();
+        pRestoreStyle->iLength = m_iPreservedLength;
+        pRestoreStyle->iFlags = m_iPreservedFlags;
+        pRestoreStyle->iForeColour = m_iPreservedForeColour;
+        pRestoreStyle->iBackColour = m_iPreservedBackColour;
+        pRestoreStyle->pAction = m_pPreservedAction;
+        pRestoreStyle->nCreationNumber = m_iPreservedStyleCreationNumber;
+        pRestoreStyle->nRangeCreationNumber =
+          m_iPreservedRangeCreationNumber;
+        pRestoreStyle->nOutputAppendCreationNumber =
+          m_iPreservedOutputAppendCreationNumber;
+        m_pPreservedAction = NULL;
+        }
+      else
+        {
+        if (pNewStyle && pNewStyle->iLength == 0)
+          RemoveStyle (m_iStyleCreationNumber);
+        if (pMarkerStyle && !bMarkerWasRepurposed)
+          RemoveStyle (m_iMarkerCreationNumber);
+        }
+
+      if (m_iActiveTagCreationNumber)
+        for (POSITION pos = m_pDoc->m_ActiveTagList.GetHeadPosition (); pos; )
+          {
+          POSITION current = pos;
+          CActiveTag * pTag = m_pDoc->m_ActiveTagList.GetNext (pos);
+          if (pTag->nCreationNumber == m_iActiveTagCreationNumber)
+            {
+            m_pDoc->m_ActiveTagList.RemoveAt (current);
+            delete pTag;
+            break;
+            }
+          }
+
+      if (m_pPreservedAction)
+        m_pPreservedAction->Release ();
+      }
+
+    void PreserveStyle (const CStyle * pStyle)
+      {
+      m_iPreservedStyleCreationNumber = pStyle->nCreationNumber;
+      m_iPreservedRangeCreationNumber = pStyle->nRangeCreationNumber;
+      m_iPreservedOutputAppendCreationNumber =
+        pStyle->nOutputAppendCreationNumber;
+      m_iPreservedLength = pStyle->iLength;
+      m_iPreservedFlags = pStyle->iFlags;
+      m_iPreservedForeColour = pStyle->iForeColour;
+      m_iPreservedBackColour = pStyle->iBackColour;
+      m_pPreservedAction = pStyle->pAction;
+      if (m_pPreservedAction)
+        m_pPreservedAction->AddRef ();
+      }
+
+    void SetActiveTag (const CActiveTag * pTag)
+      { m_iActiveTagCreationNumber = pTag->nCreationNumber; }
+
+    void SetMarker (const CStyle * pStyle)
+      { m_iMarkerCreationNumber = pStyle->nCreationNumber; }
+
+    void SetStyle (const CStyle * pStyle)
+      { m_iStyleCreationNumber = pStyle->nCreationNumber; }
+
+    COutputAppendTransaction * OutputTransaction ()
+      {
+      if (!m_pOutputTransaction)
+        m_pOutputTransaction.reset (
+          new COutputAppendTransaction (m_pDoc, 0));
+      return m_pOutputTransaction.get ();
+      }
+
+    bool IsPublishedStatePresent () const
+      {
+      return (!m_iActiveTagCreationNumber ||
+              HasActiveTag (m_iActiveTagCreationNumber)) &&
+             (!m_iMarkerCreationNumber || HasStyle (m_iMarkerCreationNumber));
+      }
+
+    CStyle * ResolveStyle (const __int64 iCreationNumber) const
+      { return FindStyle (iCreationNumber); }
+
+    void Commit ()
+      {
+      if (m_pOutputTransaction)
+        m_pOutputTransaction->Commit ();
+      m_bCommitted = true;
+      if (m_pPreservedAction)
+        {
+        m_pPreservedAction->Release ();
+        m_pPreservedAction = NULL;
+        }
+      }
+
+  private:
+    bool HasActiveTag (const __int64 iCreationNumber) const
+      {
+      for (POSITION pos = m_pDoc->m_ActiveTagList.GetHeadPosition (); pos; )
+        if (m_pDoc->m_ActiveTagList.GetNext (pos)->nCreationNumber == iCreationNumber)
+          return true;
+      return false;
+      }
+
+    bool HasStyle (const __int64 iCreationNumber) const
+      { return FindStyle (iCreationNumber) != NULL; }
+
+    CStyle * FindStyle (const __int64 iCreationNumber) const
+      {
+      if (!iCreationNumber)
+        return NULL;
+
+      // Opening markers and action results are normally at the output tail.
+      // Still search all lines when rollback needs an older style.
+      for (POSITION linepos = m_pDoc->m_LineList.GetTailPosition (); linepos; )
+        {
+        CLine * pLine = m_pDoc->m_LineList.GetPrev (linepos);
+        for (POSITION stylepos = pLine->styleList.GetTailPosition (); stylepos; )
+          {
+          CStyle * pStyle = pLine->styleList.GetPrev (stylepos);
+          if (pStyle->nCreationNumber == iCreationNumber)
+            return pStyle;
+          }
+        }
+      return NULL;
+      }
+
+    void RemoveStyle (const __int64 iCreationNumber)
+      {
+      if (!iCreationNumber)
+        return;
+
+      for (POSITION linepos = m_pDoc->m_LineList.GetHeadPosition (); linepos; )
+        {
+        CLine * pLine = m_pDoc->m_LineList.GetNext (linepos);
+        for (POSITION stylepos = pLine->styleList.GetHeadPosition (); stylepos; )
+          {
+          POSITION current = stylepos;
+          CStyle * pStyle = pLine->styleList.GetNext (stylepos);
+          if (pStyle->nCreationNumber == iCreationNumber)
+            {
+            pLine->styleList.RemoveAt (current);
+            DELETESTYLE (pStyle);
+            return;
+            }
+          }
+        }
+      }
+
+    CMUSHclientDoc * m_pDoc;
+    __int64 m_iStateOwner;
+    bool m_bOpeningInParagraph;
+    bool m_bOpeningPreMode;
+    bool m_bOpeningMXPScript;
+    int m_iOpeningListMode;
+    int m_iOpeningListCount;
+    __int64 m_iOpeningParagraphOwner;
+    __int64 m_iOpeningPreOwner;
+    __int64 m_iOpeningScriptOwner;
+    __int64 m_iOpeningListOwner;
+    __int64 m_iActiveTagCreationNumber;
+    __int64 m_iMarkerCreationNumber;
+    __int64 m_iStyleCreationNumber;
+    __int64 m_iPreservedStyleCreationNumber;
+    __int64 m_iPreservedRangeCreationNumber;
+    __int64 m_iPreservedOutputAppendCreationNumber;
+    unsigned short m_iPreservedLength;
+    unsigned short m_iPreservedFlags;
+    COLORREF m_iPreservedForeColour;
+    COLORREF m_iPreservedBackColour;
+    CAction * m_pPreservedAction;
+    std::unique_ptr<COutputAppendTransaction> m_pOutputTransaction;
+    bool m_bCommitted;
+  };
+
+class CActionReferenceGuard
+  {
+  public:
+    CActionReferenceGuard (CAction * pAction) : m_pAction (pAction)
+      {
+      if (m_pAction)
+        m_pAction->AddRef ();
+      }
+
+    ~CActionReferenceGuard ()
+      {
+      if (m_pAction)
+        m_pAction->Release ();
+      }
+
+    CAction * Get () const { return m_pAction; }
+
+    void Reset (CAction * pAction)
+      {
+      if (pAction)
+        pAction->AddRef ();
+      if (m_pAction)
+        m_pAction->Release ();
+      m_pAction = pAction;
+      }
+
+  private:
+    CAction * m_pAction;
+  };
+
 
 // here for start tag, eg. <bold> <underline> <usertag>
 void CMUSHclientDoc::MXP_StartTag (CString strTag)
@@ -33,7 +623,8 @@ bool bNoReset = false;
 
   MXP_Restore_Mode ();  // cancel secure-once mode
 
-static CArgumentList ArgumentList;
+CArgumentList ArgumentList;
+CArgumentListGuard argumentListGuard (ArgumentList);
 
 CString strName;
 
@@ -57,9 +648,9 @@ CString strName;
 
 CAtomicElement * pAtomicElement = NULL;
 CElement * pElement = NULL;
+std::unique_ptr<CElement> pElementSnapshot;
 bool bOpen;
 bool bCommand;
-POSITION atompos;
 
 // find existing styles
 
@@ -68,11 +659,13 @@ CStyle * pStyle = m_pCurrentLine->styleList.GetTail ();
 unsigned short iFlags = pStyle->iFlags;      
 COLORREF       iForeColour = pStyle->iForeColour; 
 COLORREF       iBackColour = pStyle->iBackColour; 
-CAction *      pAction = pStyle->pAction;
+CActionReferenceGuard openingActionGuard (pStyle->pAction);
+CAction *      pAction = openingActionGuard.Get ();
 
 CString strAction;    
 CString strHint;      
 CString strVariable;  
+CString strTagVariable;
 
   // get old action, hint etc. so that something like:
   // <send href="nick"> <b> blah </b> </send> will work
@@ -132,7 +725,7 @@ CString strVariable;
     bOpen    = pElement->bOpen;
     bCommand = pElement->bCommand;
     if (!pElement->strFlag.IsEmpty ())
-      strVariable = pElement->strFlag;  // might have a variable to set
+      strTagVariable = pElement->strFlag;  // variable set when this tag closes
     } // end of not atomic
 
 
@@ -154,70 +747,230 @@ CString strVariable;
     return;
     }
 
-  // call script if required for user-defined elements
-  // atomic elements have their script called in MXP_OpenAtomicTag
+  const __int64 iOpeningMXPGeneration = m_iMXPGeneration;
+  vector<__int64> activeTagsBeforePreparation;
+  SnapshotActiveTags (m_ActiveTagList, activeTagsBeforePreparation);
+  const bool bExpandedAtomicArguments = pAtomicElement != NULL;
+  if (pAtomicElement && !ExpandAtomicArgumentEntities (this, ArgumentList))
+    return;
 
-  if ((m_dispidOnMXP_OpenTag != DISPID_UNKNOWN || m_bPluginProcessesOpenTag)
-        && pAtomicElement == NULL)
+  // Run the open callback before publishing this tag. A callback-created tag
+  // then has a stable outer position and cannot be overwritten by this open.
+  bool bRanOpenCallback = false;
+  bool bNotWanted = false;
+  if (m_dispidOnMXP_OpenTag != DISPID_UNKNOWN || m_bPluginProcessesOpenTag)
     {
-    bool bNotWanted = MXP_StartTagScript (strName, strTag, ArgumentList);
+    bRanOpenCallback = true;
+    const CString strCallbackArguments = pAtomicElement ?
+      BuildAtomicCallbackArguments (ArgumentList) : strTag;
+    bNotWanted =
+      MXP_StartTagScript (strName, strCallbackArguments, ArgumentList);
+    }
 
-    // re-get current style in case the script did a world.note
-    pStyle = m_pCurrentLine->styleList.GetTail ();
+  if (m_iMXPGeneration != iOpeningMXPGeneration || !m_bMXP)
+    return;
 
-    // put things backt to how they were
-    pStyle->iFlags      = iFlags;      
-    pStyle->iForeColour = iForeColour; 
-    pStyle->iBackColour = iBackColour; 
+  if (bExpandedAtomicArguments || bRanOpenCallback)
+    {
+    if (ActiveTagsMatch (m_ActiveTagList, activeTagsBeforePreparation))
+      {
+      // A note can change the current output style. Publish a new boundary
+      // for the requested tag instead of rewriting the callback's style.
+      pStyle = AddStyle (iFlags & STYLE_BITS,
+                         iForeColour,
+                         iBackColour,
+                         0,
+                         pAction);
+      }
+    else
+      {
+      // A callback-created tag is now outside the requested tag. Inherit its
+      // current style so that the two tags remain correctly nested.
+      pStyle = m_pCurrentLine->styleList.GetTail ();
+      }
+
+    iFlags = pStyle->iFlags;
+    iForeColour = pStyle->iForeColour;
+    iBackColour = pStyle->iBackColour;
+    openingActionGuard.Reset (pStyle->pAction);
+    pAction = openingActionGuard.Get ();
+    strAction.Empty ();
+    strHint.Empty ();
+    strVariable.Empty ();
+    if (pAction)
+      {
+      strAction = pAction->m_strAction;
+      strHint = pAction->m_strHint;
+      strVariable = pAction->m_strVariable;
+      }
 
     if (bNotWanted)
       return;   // they didn't want to go ahead with this tag
 
+    if (bRanOpenCallback && !pAtomicElement)
+      {
+      // The callback can redefine or delete this custom element.
+      pElement = NULL;
+      if (!m_CustomElementMap.Lookup (strName, pElement))
+        {
+        MXP_error (DBG_ERROR, errMXP_UnknownElement,
+                   TFormat ("Unknown MXP element after open-tag callback: <%s>",
+                            (LPCTSTR) strName));
+        return;
+        }
+      bOpen = pElement->bOpen;
+      bCommand = pElement->bCommand;
+      bNoReset = false;
+      strTagVariable.Empty ();
+      if (!pElement->strFlag.IsEmpty ())
+        strTagVariable = pElement->strFlag;
+
+      if (!bOpen && !bSecure && SECURE_ELEMENT_CHECK)
+        {
+        MXP_error (DBG_ERROR, errMXP_ElementWhenNotSecure,
+                   TFormat ("Secure MXP tag ignored when not in secure mode: <%s>",
+                            (LPCTSTR) strName));
+        return;
+        }
+      }
     }
 
-// If existing run is zero length, get rid of it, unless it
-// is a tag marker
-
-  if (pStyle->iLength == 0 && (pStyle->iFlags & START_TAG) == 0)
+  vector<std::unique_ptr<CElementItem> > expandedItems;
+  vector<bool> expandedItemsWanted;
+  if (!pAtomicElement)
     {
-    DELETESTYLE (pStyle);
-    m_pCurrentLine->styleList.RemoveTail ();
+    pElementSnapshot = CloneCustomElement (pElement);
+    pElement = pElementSnapshot.get ();
+
+    vector<__int64> activeTagsBeforeExpandedCallbacks;
+    SnapshotActiveTags (m_ActiveTagList, activeTagsBeforeExpandedCallbacks);
+    bool bPreparedExpandedItems = false;
+    for (POSITION itempos = pElement->ElementItemList.GetHeadPosition ();
+         itempos; )
+      {
+      CElementItem * pSourceItem = pElement->ElementItemList.GetNext (itempos);
+      std::unique_ptr<CElementItem> pExpandedItem (new CElementItem);
+      pExpandedItem->pAtomicElement = pSourceItem->pAtomicElement;
+      if (!BuildCustomAtomicArguments (this,
+                                       strName,
+                                       pElement,
+                                       pSourceItem,
+                                       ArgumentList,
+                                       pExpandedItem->ArgumentList))
+        return;
+
+      bool bWanted = true;
+      if (m_dispidOnMXP_OpenTag != DISPID_UNKNOWN ||
+          m_bPluginProcessesOpenTag)
+        {
+        bPreparedExpandedItems = true;
+        bWanted = !MXP_StartTagScript (
+          pExpandedItem->pAtomicElement->strName,
+          BuildAtomicCallbackArguments (pExpandedItem->ArgumentList),
+          pExpandedItem->ArgumentList);
+        }
+      expandedItemsWanted.push_back (bWanted);
+      expandedItems.push_back (std::move (pExpandedItem));
+      }
+
+    if (m_iMXPGeneration != iOpeningMXPGeneration || !m_bMXP)
+      return;
+
+    if (bPreparedExpandedItems)
+      {
+      if (ActiveTagsMatch (m_ActiveTagList,
+                           activeTagsBeforeExpandedCallbacks))
+        pStyle = AddStyle (iFlags & STYLE_BITS,
+                           iForeColour,
+                           iBackColour,
+                           0,
+                           pAction);
+      else
+        pStyle = m_pCurrentLine->styleList.GetTail ();
+
+      iFlags = pStyle->iFlags;
+      iForeColour = pStyle->iForeColour;
+      iBackColour = pStyle->iBackColour;
+      openingActionGuard.Reset (pStyle->pAction);
+      pAction = openingActionGuard.Get ();
+      strAction.Empty ();
+      strHint.Empty ();
+      strVariable.Empty ();
+      if (pAction)
+        {
+        strAction = pAction->m_strAction;
+        strHint = pAction->m_strHint;
+        strVariable = pAction->m_strVariable;
+        }
+      }
     }
+
+  vector<CDeferredMXPMessage> deferredMessages;
+  const __int64 iStateOwner = App.GetUniqueNumber ();
+  CMXPStartTransaction transaction (this, iStateOwner);
+  transaction.PreserveStyle (pStyle);
+  bool bWarnOutstandingTags = false;
+  CActiveTag * pPublishedTag = NULL;
 
   // command tags are not popped from the stack, and thus don't need a record
 
   if (!bCommand)
     {
-  // add a marker to the current line for the tag itself
-  // this is a record of what the text style was at this point
-
-    AddStyle (iFlags | START_TAG, 
-              iForeColour, 
-              iBackColour, 
-              0, 
-              strName,
-              "",
-              strVariable);
-
     // remember what is outstanding
 
-    CActiveTag * pTag = new CActiveTag;
+    std::unique_ptr<CActiveTag> pTag (new CActiveTag);
 
     pTag->strName = strName;
     pTag->bSecure = bSecure;
     pTag->bNoReset = bNoReset;
-    m_ActiveTagList.AddTail (pTag);  // add to outstanding tag list
+    pTag->nCreationNumber = iStateOwner;
+    pTag->iOpeningFlags = iFlags & STYLE_BITS;
+    pTag->iOpeningForeColour = iForeColour;
+    pTag->iOpeningBackColour = iBackColour;
+    pTag->pOpeningAction = pAction;
+    if (pTag->pOpeningAction)
+      pTag->pOpeningAction->AddRef ();
+    pTag->strVariable = strTagVariable;
+    pTag->bOpeningInParagraph = m_bInParagraph;
+    pTag->bOpeningPreMode = m_bPreMode;
+    pTag->bOpeningMXPScript = m_bMXP_script;
+    pTag->iOpeningListMode = m_iListMode;
+    pTag->iOpeningListCount = m_iListCount;
+    pTag->iOpeningParagraphOwner = m_iMXPParagraphOwner;
+    pTag->iOpeningPreOwner = m_iMXPPreOwner;
+    pTag->iOpeningScriptOwner = m_iMXPScriptOwner;
+    pTag->iOpeningListOwner = m_iMXPListOwner;
+    if (pAtomicElement)
+      pTag->closeActions.push_back (pAtomicElement->iAction);
+    else
+      for (POSITION closepos = pElement->ElementItemList.GetHeadPosition ();
+           closepos; )
+        {
+        CElementItem * pCloseItem = pElement->ElementItemList.GetNext (closepos);
+        pTag->closeActions.push_back (pCloseItem->pAtomicElement->iAction);
+        }
+    m_ActiveTagList.AddTail (pTag.get ());  // add to outstanding tag list
+    pPublishedTag = pTag.release ();
+    transaction.SetActiveTag (pPublishedTag);
+
+    // add a marker to the current line for the tag itself
+    // this is a record of what the text style was at this point
+    CStyle * pMarkerStyle = AddStyle (iFlags | START_TAG,
+                                      iForeColour,
+                                      iBackColour,
+                                      0,
+                                      strName,
+                                      "",
+                                      strTagVariable);
+    transaction.SetMarker (pMarkerStyle);
+    pPublishedTag->nOpeningStyleCreationNumber = pMarkerStyle->nCreationNumber;
+    pPublishedTag->nOpeningLineCreationNumber =
+      m_pCurrentLine->nCreationNumber;
 
     // warn if they are overdoing the outstanding tags
     if (m_ActiveTagList.GetCount () % OUTSTANDING_TAG_WARNING == 0 &&
         m_ActiveTagList.GetCount () != m_iLastOutstandingTagCount)
-      {
-      MXP_error (DBG_WARNING, wrnMXP_ManyOutstandingTags,
-                  TFormat (
-                          "Now have %i outstanding MXP tags" ,
-                          m_ActiveTagList.GetCount ()));
-      m_iLastOutstandingTagCount = m_ActiveTagList.GetCount ();
-      }
+      bWarnOutstandingTags = true;
 
 
     } // end of not command tag
@@ -241,299 +994,227 @@ CStyle * pNewStyle = AddStyle (iFlags & STYLE_BITS,
                                iForeColour, 
                                iBackColour, 
                                0, 
-                               NULL);  // we will add the action later
+                               strAction,
+                               strHint,
+                               strVariable);
+transaction.SetStyle (pNewStyle);
 
   
   // atomic element?  (looked-up earlier)
   if (pAtomicElement)
     {
-    CArgument * pArgument;
-
-    for (atompos = ArgumentList.GetHeadPosition (); atompos; )
+    try
       {
-      pArgument = ArgumentList.GetNext (atompos);
-
-      // Walk the value for &xxx; entries
-
-      if (pArgument->strValue.Find ('&') != -1)
-        {
-
-        const char * p = pArgument->strValue;
-        const char * pStart = pArgument->strValue;
-        CString strEntity;
-        CString strFixedValue;
-        strFixedValue.Empty ();
-        long length;
-
-        for ( ; *p; p++)
-          {
-          if (*p == '&')
-            {
-
-            // copy up to ampersand
-            length = p - pStart;
-      
-            if (length > 0)
-              strFixedValue += CString (pStart, length);
-
-            p++;    // skip ampersand
-            pStart = p; // where entity starts
-            for ( ; *p && *p != ';'; p++) // look for closing semicolon
-              ; // just keep looking
-            if (*p != ';')
-              {
-              MXP_error (DBG_ERROR, errMXP_NoClosingSemicolonInArgument,
-                        TFormat ("No closing \";\" in MXP element argument \"%s\"", 
-                        (LPCTSTR) pArgument->strValue)); 
-              return;
-              }
-
-            strEntity = CString (pStart, p - pStart);   // build entity, excluding & and ;
-
-            // b. i. Look up entity in attribute list by name (eg. "col")
-
-            CString strReplacement = "&text;";
-
-            if (strEntity != "text")
-              strReplacement = MXP_GetEntity (strEntity);
-            strFixedValue += strReplacement;    // add to list
-
-            pStart = p + 1;   // move on past the entity
-            
-            } // end of having an ampersand 
-
-          } // end of processing the value
-
-        strFixedValue += pStart;
-
-        pArgument->strValue = strFixedValue;
-        } // end of subsitution needed
-      } // end of processing each argument in the atomic list
-
-    MXP_OpenAtomicTag (strName,
-                       pAtomicElement->iAction, 
-                       pNewStyle,
-                       strAction,
-                       strHint,
-                       strVariable,
-                       ArgumentList);
-
-    // new style might have changed if they started a new line
-    // (eg. BR)
-    if (!m_pCurrentLine->styleList.IsEmpty ())
+    if (!transaction.IsPublishedStatePresent ())
       {
-      pNewStyle = m_pCurrentLine->styleList.GetTail ();
-      RememberStyle (pNewStyle);
-      if (pNewStyle->pAction)
-        {
-        strAction = pNewStyle->pAction->m_strAction;
-        strHint =  pNewStyle->pAction->m_strHint;
-        strVariable = pNewStyle->pAction->m_strVariable;
-        }
+      transaction.Rollback ();
+      ReportDeferredMXPMessages (this, deferredMessages);
+      return;
+      }
+    if (!pNewStyle)
+      {
+      transaction.Rollback ();
+      ReportDeferredMXPMessages (this, deferredMessages);
+      return;
       }
 
-    pNewStyle->pAction = GetAction (strAction, strHint, strVariable);
+    __int64 iAtomicResultStyleCreationNumber = pNewStyle->nCreationNumber;
+    COutputAppendTransaction * pOutputTransaction =
+      (pAtomicElement->iAction == MXP_ACTION_BR ||
+       pAtomicElement->iAction == MXP_ACTION_HR ||
+       pAtomicElement->iAction == MXP_ACTION_LI ||
+       pAtomicElement->iAction == MXP_ACTION_IMG ||
+       pAtomicElement->iAction == MXP_ACTION_IMAGE) ?
+        transaction.OutputTransaction () : NULL;
+    if (!MXP_OpenAtomicTag (strName,
+                            pAtomicElement->iAction,
+                            pNewStyle,
+                            iAtomicResultStyleCreationNumber,
+                            strAction,
+                            strHint,
+                            strVariable,
+                            ArgumentList,
+                            iStateOwner,
+                            pOutputTransaction,
+                            deferredMessages))
+      {
+      transaction.Rollback ();
+      ReportDeferredMXPMessages (this, deferredMessages);
+      return;
+      }
 
+    if (m_iMXPGeneration != iOpeningMXPGeneration || !m_bMXP)
+      {
+      transaction.Rollback ();
+      ReportDeferredMXPMessages (this, deferredMessages);
+      return;
+      }
+
+    if (!transaction.IsPublishedStatePresent ())
+      {
+      transaction.Rollback ();
+      ReportDeferredMXPMessages (this, deferredMessages);
+      return;
+      }
+
+    if (pPublishedTag && pAtomicElement->iAction == MXP_ACTION_VAR)
+      pPublishedTag->strVariable = strVariable;
+
+    // Finalize only the style that the atomic action published. A callback can
+    // create a newer nested tag, whose tail style must stay unchanged.
+    // If it deleted the result, keep its valid output boundary unchanged too.
+    pNewStyle = transaction.ResolveStyle (iAtomicResultStyleCreationNumber);
+    if (pNewStyle)
+      {
+      RememberStyle (pNewStyle);
+      }
+
+    if (pNewStyle)
+      {
+      CAction * pReplacementAction =
+        GetAction (strAction, strHint, strVariable);
+      CAction * pOldAction = pNewStyle->pAction;
+      pNewStyle->pAction = pReplacementAction;
+      if (pOldAction)
+        pOldAction->Release ();
+      }
+
+    transaction.Commit ();
+    ReportDeferredMXPMessages (this, deferredMessages);
+    CheckArgumentsUsed (strName, ArgumentList);
     DELETE_LIST (ArgumentList);  // clean up memory
+    if (bWarnOutstandingTags)
+      {
+      MXP_error (DBG_WARNING, wrnMXP_ManyOutstandingTags,
+                 TFormat ("Now have %i outstanding MXP tags",
+                          m_ActiveTagList.GetCount ()));
+      m_iLastOutstandingTagCount = m_ActiveTagList.GetCount ();
+      }
     return;
+      }
+    catch (...)
+      {
+      transaction.Rollback ();
+      throw;
+      }
     }
 
 // --------- end of processing for ATOMIC element ------------
 
 // must be a user-defined element
 
-CElementItem * pElementItem;
-
-  for (POSITION pos = pElement->ElementItemList.GetHeadPosition (); pos; )
+  try
     {
-    pElementItem = pElement->ElementItemList.GetNext (pos);
+  for (size_t iExpandedItem = 0;
+       iExpandedItem < expandedItems.size ();
+       iExpandedItem++)
+    {
+    if (!expandedItemsWanted [iExpandedItem])
+      continue;
+    CElementItem * pElementItem = expandedItems [iExpandedItem].get ();
+    CArgumentList & BuiltArgumentList = pElementItem->ArgumentList;
 
-    CArgumentList BuiltArgumentList;
-    BuiltArgumentList.RemoveAll ();
-
-    /* we need to build up the arguments to the atomic element from 3 places:
-
-    1. The atom itself needs an argument list (eg. <COLOR &col;> )
-    2. The user-defined element has an attribute list that lists possible arguments
-       possibly with defaults, eg. col=red
-    3. The tag itself may supply values, eg. col=blue
-
-    These are:
-       1.  pElementItem->ArgumentList     - what the atomic element wants
-       2.  pElement->AttributeList        - what it can get, including defaults
-       3.  ArgumentList                   - what is specified on *this* tag
-
-    So, I think we need to:
-     
-       a. Walk the atomic item's argument list
-       b. For any entries in the form &xxx; ...
-           0. The special case &text; is left alone (for processing later)
-           i. Look up the entity in the attribute list (2) above. 
-          ii. If found, go to (c).
-         iii. Look up entity in entities map (could be &lt; for instance)
-          iv. If found, just replace it and continue
-           v. If not found still, error
-       c. If entity is found in attribute list (2) above, then:
-       d. Look up value in supplied arguments (3) by name and position.
-       e. If found, take supplied value.
-       f. If not found, take default from (2) including <nothing> if applicable.
-
-     Each entry gets built into BuiltArgumentList and passed down to the atomic element
-     processing routine.
-
-    */
-
-    // a. Walk the atom's list
-    CArgument * pArgument;
-    int iArgumentNumber = 0;
-
-    for (atompos = pElementItem->ArgumentList.GetHeadPosition (); atompos; )
+    if (!transaction.IsPublishedStatePresent ())
       {
-      pArgument = pElementItem->ArgumentList.GetNext (atompos);
+      transaction.Rollback ();
+      ReportDeferredMXPMessages (this, deferredMessages);
+      return;
+      }
+    __int64 iAtomicResultStyleCreationNumber = pNewStyle->nCreationNumber;
+    COutputAppendTransaction * pOutputTransaction =
+      (pElementItem->pAtomicElement->iAction == MXP_ACTION_BR ||
+       pElementItem->pAtomicElement->iAction == MXP_ACTION_HR ||
+       pElementItem->pAtomicElement->iAction == MXP_ACTION_LI ||
+       pElementItem->pAtomicElement->iAction == MXP_ACTION_IMG ||
+       pElementItem->pAtomicElement->iAction == MXP_ACTION_IMAGE) ?
+        transaction.OutputTransaction () : NULL;
+    if (!MXP_OpenAtomicTag (pElementItem->pAtomicElement->strName,
+                            pElementItem->pAtomicElement->iAction,
+                            pNewStyle,
+                            iAtomicResultStyleCreationNumber,
+                            strAction,
+                            strHint,
+                            strVariable,
+                            BuiltArgumentList,
+                            iStateOwner,
+                            pOutputTransaction,
+                            deferredMessages))
+      {
+      transaction.Rollback ();
+      ReportDeferredMXPMessages (this, deferredMessages);
+      return;
+      }
 
-      // b. Walk the value for &xxx; entries
+    if (m_iMXPGeneration != iOpeningMXPGeneration || !m_bMXP)
+      {
+      transaction.Rollback ();
+      ReportDeferredMXPMessages (this, deferredMessages);
+      return;
+      }
 
-      const char * p = pArgument->strValue;
-      const char * pStart = pArgument->strValue;
-      CString strEntity;
-      CString strFixedValue;
-      long length;
+    if (!transaction.IsPublishedStatePresent ())
+      {
+      transaction.Rollback ();
+      ReportDeferredMXPMessages (this, deferredMessages);
+      return;
+      }
 
-      strFixedValue.Empty ();
+    if (pPublishedTag &&
+        pElementItem->pAtomicElement->iAction == MXP_ACTION_VAR)
+      pPublishedTag->strVariable = strVariable;
 
-      for ( ; *p; p++)
-        {
-        if (*p == '&')
-          {
+    pNewStyle = transaction.ResolveStyle (iAtomicResultStyleCreationNumber);
+    if (!pNewStyle)
+      {
+      COutputAppendTransaction * pBoundaryTransaction =
+        transaction.OutputTransaction ();
+      pBoundaryTransaction->Reserve (1);
+      pBoundaryTransaction->MarkCurrentLineStyles ();
+      pNewStyle = pBoundaryTransaction->PrepareAppendStyle ();
+      }
 
-          // copy up to ampersand
-          length = p - pStart;
-    
-          if (length > 0)
-            strFixedValue += CString (pStart, length);
-
-          p++;    // skip ampersand
-          pStart = p; // where entity starts
-          for ( ; *p && *p != ';'; p++) // look for closing semicolon
-            ; // just keep looking
-          if (*p != ';')
-            {
-            MXP_error (DBG_ERROR, errMXP_NoClosingSemicolonInArgument,
-                      TFormat ("No closing \";\" in MXP element argument \"%s\"", 
-                      (LPCTSTR) pArgument->strValue)); 
-            return;
-            }
-
-          strEntity = CString (pStart, p - pStart);   // build entity, excluding & and ;
-
-          // b. i. Look up entity in attribute list by name (eg. "col")
-
-          CString strReplacement = "&text;";
-
-          if (strEntity != "text")
-            {
-
-            CString strDefault;
-
-            CArgument * pAttribute = NULL;
-            int iSequence = 1;
-
-            for (POSITION attpos = pElement->AttributeList.GetHeadPosition (); 
-                 attpos; 
-                 iSequence++)
-              {
-              pAttribute = pElement->AttributeList.GetNext (attpos);
-              if (pAttribute->strName.IsEmpty ())  // no name, value is name (ie. no default)
-                {
-                if (pAttribute->strValue.CompareNoCase (strEntity) == 0)
-                  break;
-                }
-              else
-                if (pAttribute->strName.CompareNoCase (strEntity) == 0)
-                  {
-                  strDefault = pAttribute->strValue;
-                  break;
-                  }
-              pAttribute = NULL;   // indicates it wasn't found
-              }  // end of looking for the attribute
-
-            if (pAttribute)
-              {
-
-              // we now have a default and a position - look it up in the supplied arguments
-
-              strReplacement = GetArgument (ArgumentList, strEntity, iSequence, false); 
-              if (strReplacement.IsEmpty ())   // empty? take default
-                {
-                strReplacement = strDefault; 
-
-                // stil empty? Warn them.
-                if (strReplacement.IsEmpty ())
-                  MXP_error (DBG_WARNING, wrnMXP_ArgumentNotSupplied,
-                             TFormat ("Non-default argument \"%s\" not supplied to <%s>", 
-                            (LPCTSTR) strEntity,
-                            (LPCTSTR) strName
-                            ));     
-                }
-
-              } // end of attribute found
-            else
-              strReplacement = MXP_GetEntity (strEntity);
-            } // end of not being the entity &text;
-          strFixedValue += strReplacement;    // add to list
-
-          pStart = p + 1;   // move on past the entity
-          
-          } // end of having an ampersand 
-
-        } // end of processing the value
-
-      strFixedValue += pStart;
-
-      // add fixed argument to the built argument list
-      CArgument * pNewArgument;
-
-      if (pArgument->strName.IsEmpty ())  // just a positional argument
-        {
-        pNewArgument = new CArgument ("", strFixedValue, ++iArgumentNumber);
-        BuiltArgumentList.AddTail (pNewArgument);
-        }
-      else
-        {
-        pNewArgument = new CArgument (pArgument->strName, strFixedValue, 0);
-        BuiltArgumentList.AddTail (pNewArgument);
-        }
-
-
-      } // end of processing each argument in the atomic list
-
-    MXP_OpenAtomicTag (pElementItem->pAtomicElement->strName,
-                       pElementItem->pAtomicElement->iAction, 
-                       pNewStyle,
-                       strAction,
-                       strHint,
-                       strVariable,
-                       BuiltArgumentList); 
-
-    DELETE_LIST (BuiltArgumentList);  // just a temporary list
     } // end of doing each atomic element
 
-  // new style might have changed if they started a new line
-  // (eg. BR)
-  if (!m_pCurrentLine->styleList.IsEmpty ())
+  if (pNewStyle)
     {
-    pNewStyle = m_pCurrentLine->styleList.GetTail ();
     RememberStyle (pNewStyle);
     }
 
   // make an action for the built-up action/hint/variable
-  pNewStyle->pAction = GetAction (strAction, strHint, strVariable);
+  if (pNewStyle)
+    {
+    CAction * pReplacementAction = GetAction (strAction, strHint, strVariable);
+    CAction * pOldAction = pNewStyle->pAction;
+    pNewStyle->pAction = pReplacementAction;
+    if (pOldAction)
+      pOldAction->Release ();
+    }
 
-// check all arguments used
+  transaction.Commit ();
+  ReportDeferredMXPMessages (this, deferredMessages);
 
+  for (size_t iExpandedItem = 0;
+       iExpandedItem < expandedItems.size ();
+       iExpandedItem++)
+    if (expandedItemsWanted [iExpandedItem])
+      CheckArgumentsUsed (
+        expandedItems [iExpandedItem]->pAtomicElement->strName,
+        expandedItems [iExpandedItem]->ArgumentList);
   CheckArgumentsUsed (strName, ArgumentList);
-
   DELETE_LIST (ArgumentList);  // clean up memory
+  if (bWarnOutstandingTags)
+    {
+    MXP_error (DBG_WARNING, wrnMXP_ManyOutstandingTags,
+               TFormat ("Now have %i outstanding MXP tags",
+                        m_ActiveTagList.GetCount ()));
+    m_iLastOutstandingTagCount = m_ActiveTagList.GetCount ();
+    }
+    }
+  catch (...)
+    {
+    transaction.Rollback ();
+    throw;
+    }
 
   } // end of CMUSHclientDoc::MXP_StartTag
 

--- a/mxp/mxpinit.cpp
+++ b/mxp/mxpinit.cpp
@@ -316,14 +316,14 @@ char * character_entities [] =
 void CMUSHclientApp::MXP_LoadColours (void)
   {
 
-CColours * colour_item;
 CString strName;
 
   for (int i = 0; i < NUMITEMS (MXP_colours); i++)
     {
     strName = MXP_colours [i].pName;
     strName.MakeLower ();     // ensure lower case
-    m_ColoursMap.SetAt (strName, colour_item = new CColours);
+    std::unique_ptr<CColours> newColour (new CColours);
+    CColours * colour_item = newColour.get ();
     colour_item->strName = strName;
     // colours seem to be inverted in my table above
     colour_item->iColour = RGB (
@@ -331,6 +331,12 @@ CString strName;
                       GetGValue (MXP_colours [i].iColour),
                       GetRValue (MXP_colours [i].iColour)
                       );    
+
+    CColours * oldColour = NULL;
+    m_ColoursMap.Lookup (strName, oldColour);
+    m_ColoursMap.SetAt (strName, colour_item);
+    newColour.release ();
+    delete oldColour;
 
 // temporary, for displaying colours
 /*
@@ -429,15 +435,19 @@ CString strReplacement;
 void CMUSHclientApp::MXP_LoadElements (void)
   {
 
-CAtomicElement * element_item;
-
   for (int i = 0; i < NUMITEMS (MXP_elements); i++)
     {
-    m_ElementMap.SetAt (MXP_elements [i].pName, element_item = new CAtomicElement);
+    std::unique_ptr<CAtomicElement> newElement (new CAtomicElement);
+    CAtomicElement * element_item = newElement.get ();
     element_item->strName = MXP_elements [i].pName;
     element_item->strArgs = MXP_elements [i].pArgs;
     element_item->iFlags = MXP_elements [i].iFlags;
     element_item->iAction = MXP_elements [i].iAction;
+    CAtomicElement * oldElement = NULL;
+    m_ElementMap.Lookup (MXP_elements [i].pName, oldElement);
+    m_ElementMap.SetAt (MXP_elements [i].pName, element_item);
+    newElement.release ();
+    delete oldElement;
     }   // end of doing each one
 
   } // end of CMUSHclientApp::LoadAtomicElements 

--- a/mxp/mxputils.cpp
+++ b/mxp/mxputils.cpp
@@ -111,6 +111,22 @@ bool GetWord (CString & strResult, CString & str)
 bool CMUSHclientDoc::BuildArgumentList (CArgumentList & ArgumentList, 
                                         CString strTag) 
   {
+class CArgumentBuildGuard
+  {
+  public:
+    CArgumentBuildGuard (CArgumentList & list) : m_list (list), m_bRelease (false) { }
+    ~CArgumentBuildGuard ()
+      {
+      if (!m_bRelease)
+        DELETE_LIST (m_list);
+      }
+    void Release () { m_bRelease = true; }
+
+  private:
+    CArgumentList & m_list;
+    bool m_bRelease;
+  } argumentBuildGuard (ArgumentList);
+
 CArgument * pArgument;
 int iArgumentNumber = 0;
 bool bEnd;
@@ -145,6 +161,7 @@ CString strArgumentValue;
       // NB - not implemented yet - we have detected an empty tag.
       //      eg.  <sound blah blah />
 
+      argumentBuildGuard.Release ();
       return false;   // OK return
 
       } // end of / at end of list
@@ -174,19 +191,24 @@ CString strArgumentValue;
 
       strArgumentName.MakeLower ();
       // named arguments don't have a numbered position
-      pArgument = new CArgument (strArgumentName, strArgumentValue, 0);
-      ArgumentList.AddTail (pArgument);
+      std::unique_ptr<CArgument> pNewArgument
+        (new CArgument (strArgumentName, strArgumentValue, 0));
+      ArgumentList.AddTail (pNewArgument.get ());
+      pArgument = pNewArgument.release ();
       bEnd = GetWord (strArgumentName, strTag); // get next argument
       }   // end of name=value
     else
       { // positional argument, no name=value
       // thus, name is value
-      pArgument = new CArgument ("", strArgumentName, ++iArgumentNumber);
-      ArgumentList.AddTail (pArgument);
+      std::unique_ptr<CArgument> pNewArgument
+        (new CArgument ("", strArgumentName, ++iArgumentNumber));
+      ArgumentList.AddTail (pNewArgument.get ());
+      pArgument = pNewArgument.release ();
       strArgumentName = strEquals;    // and strEquals is next argument, if any      
       }   // end of value alone
     }  // end of processing each argument                             
 
+  argumentBuildGuard.Release ();
   return false; // all OK
   } // end of CMUSHclientDoc::BuildArgumentList 
 
@@ -455,12 +477,13 @@ unsigned long iHash = MakeActionHash (strAction, strHint, strVariable);
 
   // here when action not found
 
-  CAction * pAction = new CAction (strAction, strHint, strVariable, this);
+  std::unique_ptr<CAction> pAction
+    (new CAction (strAction, strHint, strVariable, this));
 
+  m_ActionList.AddTail (pAction.get ());
   pAction->AddRef ();
-  m_ActionList.AddTail (pAction);   
   
-  return pAction;
+  return pAction.release ();
   } // end of CMUSHclientDoc::GetAction
 
 

--- a/output_line_buffer.h
+++ b/output_line_buffer.h
@@ -1,0 +1,43 @@
+// Reserve line storage before callbacks so restoration does not allocate.
+#pragma once
+
+class COutputLineBuffer
+  {
+  public:
+    explicit COutputLineBuffer (const int iCapacity) :
+      m_pText (NULL), m_iCapacity (iCapacity)
+      {
+#ifdef USE_REALLOC
+      m_pText = static_cast<char *> (malloc (iCapacity));
+#else
+      m_pText = new char [iCapacity];
+#endif
+      if (!m_pText)
+        AfxThrowMemoryException ();
+      }
+
+    ~COutputLineBuffer ()
+      {
+#ifdef USE_REALLOC
+      free (m_pText);
+#else
+      delete [] m_pText;
+#endif
+      }
+
+    void RestoreCapacity (CLine * pLine)
+      {
+      if (pLine->iMemoryAllocated >= m_iCapacity)
+        return;
+      // Keep any callback changes to the retained prefix.
+      memcpy (m_pText, pLine->text, pLine->len);
+      std::swap (m_pText, pLine->text);
+      std::swap (m_iCapacity, pLine->iMemoryAllocated);
+      }
+
+  private:
+    COutputLineBuffer (const COutputLineBuffer &);
+    COutputLineBuffer & operator= (const COutputLineBuffer &);
+    char * m_pText;
+    int m_iCapacity;
+  };

--- a/paneline.cpp
+++ b/paneline.cpp
@@ -22,7 +22,11 @@ void CPaneLine::AddStyle (const CPaneStyle style)
 
     // if first style for line, must be a new style
     if (m_vStyles.empty ())
-      m_vStyles.push_back (new CPaneStyle (style));  // must add it
+      {
+      std::unique_ptr<CPaneStyle> pNewStyle (new CPaneStyle (style));
+      m_vStyles.push_back (pNewStyle.get ());  // must add it
+      pNewStyle.release ();
+      }
     else
       {
       CPaneStyle * oldstyle = m_vStyles.back ();        // last style
@@ -32,7 +36,11 @@ void CPaneLine::AddStyle (const CPaneStyle style)
         oldstyle->m_sText += style.m_sText;       // yep - just append text
       else
         // different style, add to list
-        m_vStyles.push_back (new CPaneStyle (style));   // need new style
+        {
+        std::unique_ptr<CPaneStyle> pNewStyle (new CPaneStyle (style));
+        m_vStyles.push_back (pNewStyle.get ());   // need new style
+        pNewStyle.release ();
+        }
       } // end of style list not empty
     };
 

--- a/scripting/methods/methods_noting.cpp
+++ b/scripting/methods/methods_noting.cpp
@@ -696,20 +696,39 @@ void CMUSHclientDoc::Hyperlink_Helper (LPCTSTR Action,
   SetColour (BackColour, backcolour);
 
   // change to underlined hyperlink
-  AddStyle (COLOUR_RGB | 
-            (URL ? ACTION_HYPERLINK : ACTION_SEND) | 
-            (NoUnderline ? 0 : UNDERLINE), 
-            forecolour, 
-            backcolour, 0, 
-            GetAction (Action, 
-                        Hint [0] == 0 ? Action : Hint, 
-                        ""));
+  CAction * pLinkAction = GetAction (Action,
+                                     Hint [0] == 0 ? Action : Hint,
+                                     "");
+  try
+    {
+    AddStyle (COLOUR_RGB |
+              (URL ? ACTION_HYPERLINK : ACTION_SEND) |
+              (NoUnderline ? 0 : UNDERLINE),
+              forecolour,
+              backcolour, 0,
+              pLinkAction);
+    }
+  catch (...)
+    {
+    pLinkAction->Release ();
+    throw;
+    }
+  pLinkAction->Release ();
 
-  // output the link text
-  if (strlen (Text) > 0)
-    AddToLine (Text, COMMENT);
-  else
-    AddToLine (Action, COMMENT);
+  // Output the link text. Always publish the finishing note style, including
+  // when line wrapping reports a failure or throws after partial output.
+  exception_ptr pendingException;
+  try
+    {
+    if (strlen (Text) > 0)
+      AddToLine (Text, COMMENT);
+    else
+      AddToLine (Action, COMMENT);
+    }
+  catch (...)
+    {
+    pendingException = current_exception ();
+    }
 
   // add another style to finish the hyperlink
 
@@ -727,6 +746,9 @@ void CMUSHclientDoc::Hyperlink_Helper (LPCTSTR Action,
     else
       AddStyle (COLOUR_CUSTOM, m_iNoteTextColour, BLACK, 0, NULL);
     } // not RGB
+
+  if (pendingException)
+    rethrow_exception (pendingException);
 
 }   // end of CMUSHclientDoc::Hyperlink_Helper
 
@@ -778,12 +800,14 @@ void CMUSHclientDoc::NoteHr()
 {
   // wrap up previous line if necessary
   if (m_pCurrentLine->len > 0)
-     StartNewLine (true, 0);
+    if (!StartNewLine (true, 0))
+      return;
 
   // mark line as HR line
   m_pCurrentLine->flags = HORIZ_RULE;
   
-  StartNewLine (true, 0); // now finish this line
+  if (!StartNewLine (true, 0)) // now finish this line
+    return;
 
   // refresh views
 

--- a/scripting/methods/methods_output.cpp
+++ b/scripting/methods/methods_output.cpp
@@ -244,48 +244,66 @@ POSITION pos;
   if (m_pCurrentLine && m_pCurrentLine->len == 0)
     Count++;
 
-// delete all lines in this set
-  for (pos = m_LineList.GetTailPosition (); Count > 0 && pos; Count--)
-   {
-   // if this particular line was added to the line positions array, then make it null
-    if (m_LineList.GetCount () % JUMP_SIZE == 1)
-          m_pLinePositions [m_LineList.GetCount () / JUMP_SIZE] = NULL;
-
-    delete m_LineList.GetTail (); // delete contents of tail iten -- version 3.85
-    m_LineList.RemoveTail ();   // get rid of the line
-    m_total_lines--;            // don't count as received
-
-   if (m_LineList.IsEmpty ())  // give up if buffer is empty
-     break;
-
-   m_LineList.GetPrev (pos);
-   }
-
-  // try to allow world.tells to span omitted lines
-  if (!m_LineList.IsEmpty ())
+  vector<POSITION> linesToDelete;
+  POSITION scan = m_LineList.GetTailPosition ();
+  for (long i = 0; i < Count && scan; i++)
     {
-    m_pCurrentLine = m_LineList.GetTail ();
-    if (((m_pCurrentLine->flags & COMMENT) == 0) ||
-        m_pCurrentLine->hard_return)
-        m_pCurrentLine = NULL;
+    POSITION current = scan;
+    m_LineList.GetPrev (scan);
+    linesToDelete.push_back (current);
     }
+
+  CLine * pSurvivingCurrentLine = scan ? m_LineList.GetAt (scan) : NULL;
+  if (pSurvivingCurrentLine &&
+      (((pSurvivingCurrentLine->flags & COMMENT) == 0) ||
+       pSurvivingCurrentLine->hard_return))
+    pSurvivingCurrentLine = NULL;
+
+  std::unique_ptr<CLine> pNewLine;
+  if (!pSurvivingCurrentLine)
+    {
+    pNewLine.reset (new CLine (m_total_lines -
+                               static_cast<long> (linesToDelete.size ()) + 1,
+                               m_nWrapColumn,
+                               m_iFlags,
+                               m_iForeColour,
+                               m_iBackColour,
+                               m_bUTF_8));
+    m_LineList.AddTail (pNewLine.get ());
+    }
+
+  if (!linesToDelete.empty ())
+    m_iOutputGeneration++;
+
+  for (vector<POSITION>::const_iterator it = linesToDelete.begin ();
+       it != linesToDelete.end (); ++it)
+    {
+    CLine * pLine = m_LineList.GetAt (*it);
+    m_LineList.RemoveAt (*it);
+    delete pLine;
+    m_total_lines--;
+    }
+
+  if (pSurvivingCurrentLine)
+    m_pCurrentLine = pSurvivingCurrentLine;
   else
-    m_pCurrentLine = NULL;
-
-  if (!m_pCurrentLine)
     {
-    // restart with a blank line at the end of the list
-    m_pCurrentLine = new CLine (++m_total_lines, 
-                                m_nWrapColumn,
-                                m_iFlags,
-                                m_iForeColour,
-                                m_iBackColour,
-                                m_bUTF_8);
-    pos = m_LineList.AddTail (m_pCurrentLine);
-
-    if (m_LineList.GetCount () % JUMP_SIZE == 1)
-      m_pLinePositions [m_LineList.GetCount () / JUMP_SIZE] = pos;
+    m_pCurrentLine = pNewLine.release ();
+    m_total_lines++;
     }
+
+  for (int i = 0; i <= m_maxlines / JUMP_SIZE; i++)
+    m_pLinePositions [i] = NULL;
+  int iLine = 0;
+  for (pos = m_LineList.GetHeadPosition (); pos; iLine++)
+    {
+    POSITION current = pos;
+    m_LineList.GetNext (pos);
+    if (iLine % JUMP_SIZE == 0)
+      m_pLinePositions [iLine / JUMP_SIZE] = current;
+    }
+
+  RefreshMXPMissingTagAnchors ();
 
 // notify view that we have "added" stuff (deleted, really)
 // this is so that scroll bar positions are recalculated, and the

--- a/scriptingoptions.cpp
+++ b/scriptingoptions.cpp
@@ -501,6 +501,17 @@ long CMUSHclientDoc::SetOptionItem (const int iItem,
   {
 bool bChanged;
 
+  // Prepare the current line before enabling UTF-8. A failed allocation must
+  // leave the option unchanged.
+  if (bDoSpecial && iItem >= 0 && iItem < NUMITEMS (OptionsTable) &&
+      OptionsTable [iItem].iOffset == offsetof (CMUSHclientDoc, m_bUTF_8) &&
+      Value == 1 && !m_bUTF_8 && m_pCurrentLine)
+    {
+    const int iMemoryAllocated = MAX (m_pCurrentLine->len, m_nWrapColumn * 4);
+    if (m_pCurrentLine->iMemoryAllocated < iMemoryAllocated)
+      m_pCurrentLine->ResizeText (iMemoryAllocated);
+    }
+
 long iResult = SetBaseOptionItem (iItem, 
                                   OptionsTable, 
                                   NUMITEMS (OptionsTable),
@@ -537,22 +548,10 @@ long iResult = SetBaseOptionItem (iItem,
     {
     if (m_pCurrentLine)     // a new world might not have a line yet
       {
-      // save current line text
-      CString strLine = CString (m_pCurrentLine->text, m_pCurrentLine->len);
-
-#ifdef USE_REALLOC
-      m_pCurrentLine->text  = (char *) 
-            realloc (m_pCurrentLine->text, 
-                     MAX (m_pCurrentLine->len, Value) 
-                     * sizeof (char));  
-#else
-      delete [] m_pCurrentLine->text;
-      m_pCurrentLine->text = new char [MAX (m_pCurrentLine->len, Value)];
-#endif
-
-      // put text back
-      memcpy (m_pCurrentLine->text, (LPCTSTR) strLine, m_pCurrentLine->len);
-      ASSERT (m_pCurrentLine->text);
+      int iMemoryAllocated = MAX (m_pCurrentLine->len, Value);
+      if (m_bUTF_8)
+        iMemoryAllocated *= 4;
+      m_pCurrentLine->ResizeText (iMemoryAllocated);
       }   // end of having a current line
     SendWindowSizes (Value);
     }

--- a/stdafx.h
+++ b/stdafx.h
@@ -93,6 +93,7 @@
 #include <iterator>
 #include <sstream>
 #include <memory>
+#include <exception>
 #pragma warning (pop)
 
 #ifdef LUA_52
@@ -676,16 +677,15 @@ enum
               _CrtSetDbgFlag((a) | _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG))
   #define  CLEAR_CRT_DEBUG_FIELD(a) \
               _CrtSetDbgFlag(~(a) & _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG))
-//  #define NEWSTYLE GetNewStyle (__FILE__, __LINE__)
 //  #define DELETESTYLE(arg) DeleteStyle (arg, __FILE__, __LINE__)
-  #define NEWSTYLE new CStyle
+  #define NEWSTYLE GetNewStyle (__FILE__, __LINE__)
   #define DELETESTYLE(arg) delete arg
 
 #else
   #define  SET_CRT_DEBUG_FIELD(a)   ((void) 0)
   #define  CLEAR_CRT_DEBUG_FIELD(a) ((void) 0)
 
-  #define NEWSTYLE new CStyle
+  #define NEWSTYLE GetNewStyle (__FILE__, __LINE__)
   #define DELETESTYLE(arg) delete arg
 #endif
 

--- a/telnet_phases.cpp
+++ b/telnet_phases.cpp
@@ -908,7 +908,11 @@ void CMUSHclientDoc::OutputBadUTF8characters (void)
     char sOutput [5];
     memset (sOutput, 0, sizeof sOutput);  // ensure trailing null
     WideCharToMultiByte (CP_UTF8, 0, sUnicode, 1, sOutput, sizeof sOutput, NULL, NULL);
-    AddToLine (sOutput, 0); 
+    if (!AddToLine (sOutput, 0))
+      {
+      m_phase = NONE;
+      return;
+      }
     m_cLastChar = m_UTF8Sequence [i];
     }
 
@@ -952,7 +956,11 @@ void CMUSHclientDoc::Phase_UTF8 (const unsigned char c)
     }
 
   // valid UTF8 sequence, add to line
-  AddToLine ((const char *) m_UTF8Sequence, 0);
+  if (!AddToLine ((const char *) m_UTF8Sequence, 0))
+    {
+    m_phase = NONE;
+    return;
+    }
   m_phase = NONE;
 
   }  // end of CMUSHclientDoc::Phase_UTF8

--- a/tests/check_mxp_anchor_refresh.cpp.in
+++ b/tests/check_mxp_anchor_refresh.cpp.in
@@ -1,0 +1,435 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <new>
+#include <random>
+#include <type_traits>
+#include <vector>
+
+using __int64 = long long;
+static bool failAllocations = false;
+void* operator new(std::size_t size) {
+  if (failAllocations) throw std::bad_alloc();
+  if (void* result = std::malloc(size ? size : 1)) return result;
+  throw std::bad_alloc();
+}
+void* operator new[](std::size_t size) { return ::operator new(size); }
+void operator delete(void* value) noexcept { std::free(value); }
+void operator delete[](void* value) noexcept { std::free(value); }
+void operator delete(void* value, std::size_t) noexcept { std::free(value); }
+void operator delete[](void* value, std::size_t) noexcept { std::free(value); }
+
+struct CLine;
+struct CStyle;
+struct Counts { long long lines = 0, styles = 0, index = 0; };
+static Counts reads;
+struct Position {};
+using POSITION = Position*;
+template<class T> struct List {
+  struct Node : Position { Node* prev; Node* next; T value; };
+  Node* head = nullptr;
+  Node* tail = nullptr;
+  int count = 0;
+  List() = default;
+  List(const List&) = delete;
+  List& operator=(const List&) = delete;
+  ~List() { while (count) delete RemoveTail(); }
+  bool IsEmpty() const { return count == 0; }
+  int GetCount() const { return count; }
+  POSITION GetHeadPosition() const { return head; }
+  POSITION GetTailPosition() const { return tail; }
+  T GetTail() const { assert(tail); return tail->value; }
+  T GetHead() const { assert(head); return head->value; }
+  T GetAt(POSITION pos) const {
+    assert(pos);
+    if constexpr (std::is_same<T, CLine*>::value) ++reads.index;
+    return static_cast<Node*>(pos)->value;
+  }
+  T GetNext(POSITION& pos) const {
+    assert(pos);
+    if constexpr (std::is_same<T, CLine*>::value) ++reads.lines;
+    if constexpr (std::is_same<T, CStyle*>::value) ++reads.styles;
+    Node* node = static_cast<Node*>(pos);
+    pos = node->next;
+    return node->value;
+  }
+  POSITION AddTail(T value) {
+    Node* node = new Node{{}, tail, nullptr, value};
+    if (tail) tail->next = node; else head = node;
+    tail = node;
+    ++count;
+    return node;
+  }
+  T RemoveTail() {
+    assert(tail);
+    Node* node = tail;
+    T value = node->value;
+    tail = node->prev;
+    if (tail) tail->next = nullptr; else head = nullptr;
+    delete node;
+    --count;
+    return value;
+  }
+  T RemoveHead() {
+    assert(head);
+    Node* node = head;
+    T value = node->value;
+    head = node->next;
+    if (head) head->prev = nullptr; else tail = nullptr;
+    delete node;
+    --count;
+    return value;
+  }
+};
+
+static __int64 sequence = 0;
+static const int JUMP_SIZE = 100;
+static const int START_TAG = 1;
+struct CStyle {
+  __int64 nCreationNumber = ++sequence;
+  __int64 nRangeCreationNumber = nCreationNumber;
+  int iFlags = 0;
+};
+struct CLine {
+  __int64 nCreationNumber = ++sequence;
+  List<CStyle*> styleList;
+  CLine() { styleList.AddTail(new CStyle); }
+};
+struct CActiveTag {
+  __int64 nOpeningStyleCreationNumber = 0;
+  __int64 nOpeningLineCreationNumber = 0;
+  __int64 nFallbackStyleRangeNumber = 0;
+  __int64 nFallbackLineCreationNumber = 0;
+  bool operator==(const CActiveTag& other) const {
+    return nOpeningStyleCreationNumber == other.nOpeningStyleCreationNumber &&
+      nOpeningLineCreationNumber == other.nOpeningLineCreationNumber &&
+      nFallbackStyleRangeNumber == other.nFallbackStyleRangeNumber &&
+      nFallbackLineCreationNumber == other.nFallbackLineCreationNumber;
+  }
+};
+struct CMUSHclientDoc {
+  List<CLine*> m_LineList;
+  List<CActiveTag*> m_ActiveTagList;
+  CLine* m_pCurrentLine = nullptr;
+  std::vector<POSITION> positions;
+  POSITION* m_pLinePositions = nullptr;
+  void RefreshMXPMissingTagAnchors();
+  void BaselineRefresh();
+  CLine* append() {
+    m_pCurrentLine = new CLine;
+    m_LineList.AddTail(m_pCurrentLine);
+    return m_pCurrentLine;
+  }
+  void history(int count) { while (m_LineList.GetCount() < count) append(); }
+  void index() {
+    positions.assign(m_LineList.GetCount() / JUMP_SIZE + 1, nullptr);
+    int number = 0;
+    for (POSITION pos = m_LineList.GetHeadPosition(); pos; ++number) {
+      if (number % JUMP_SIZE == 0) positions[number / JUMP_SIZE] = pos;
+      m_LineList.GetNext(pos);
+    }
+    m_pLinePositions = positions.data();
+  }
+  void deleteTail() {
+    delete m_LineList.RemoveTail();
+    m_pCurrentLine = m_LineList.IsEmpty() ? nullptr : m_LineList.GetTail();
+  }
+  CActiveTag* open() {
+    CStyle* marker = new CStyle;
+    marker->iFlags = START_TAG;
+    m_pCurrentLine->styleList.AddTail(marker);
+    CActiveTag* tag = new CActiveTag;
+    tag->nOpeningLineCreationNumber = m_pCurrentLine->nCreationNumber;
+    tag->nOpeningStyleCreationNumber = marker->nCreationNumber;
+    // A live marker must leave these fields unchanged.
+    tag->nFallbackLineCreationNumber = -11;
+    m_ActiveTagList.AddTail(tag);
+    return tag;
+  }
+  void clearTailStyles() {
+    auto& styles = m_pCurrentLine->styleList;
+    while (!styles.IsEmpty()) delete styles.RemoveTail();
+    styles.AddTail(new CStyle);
+  }
+};
+
+@REFRESH@
+
+// Frozen reference rules: search the entire history for a marker, then take
+// the first fallback range OR post-opening style in line and style order.
+static void reference(CMUSHclientDoc& doc) {
+  if (!doc.m_pCurrentLine || doc.m_ActiveTagList.IsEmpty()) return;
+  for (POSITION tags = doc.m_ActiveTagList.GetHeadPosition(); tags;) {
+    CActiveTag* tag = doc.m_ActiveTagList.GetNext(tags);
+    bool marker = false;
+    for (POSITION lines = doc.m_LineList.GetHeadPosition(); lines && !marker;) {
+      CLine* line = doc.m_LineList.GetNext(lines);
+      for (POSITION styles = line->styleList.GetHeadPosition(); styles;) {
+        CStyle* style = line->styleList.GetNext(styles);
+        if ((style->iFlags & START_TAG) &&
+            style->nCreationNumber == tag->nOpeningStyleCreationNumber) {
+          marker = true;
+          break;
+        }
+      }
+    }
+    if (marker) continue;
+    CLine* boundaryLine = nullptr;
+    CStyle* boundary = nullptr;
+    for (POSITION lines = doc.m_LineList.GetHeadPosition(); lines && !boundary;) {
+      CLine* line = doc.m_LineList.GetNext(lines);
+      for (POSITION styles = line->styleList.GetHeadPosition(); styles;) {
+        CStyle* style = line->styleList.GetNext(styles);
+        if ((tag->nFallbackStyleRangeNumber &&
+             style->nRangeCreationNumber == tag->nFallbackStyleRangeNumber) ||
+            line->nCreationNumber > tag->nOpeningLineCreationNumber ||
+            (line->nCreationNumber == tag->nOpeningLineCreationNumber &&
+             style->nCreationNumber > tag->nOpeningStyleCreationNumber)) {
+          boundaryLine = line;
+          boundary = style;
+          break;
+        }
+      }
+    }
+    if (!boundary) {
+      boundaryLine = doc.m_pCurrentLine;
+      boundary = boundaryLine->styleList.GetTail();
+    }
+    tag->nFallbackLineCreationNumber = boundaryLine->nCreationNumber;
+    tag->nFallbackStyleRangeNumber = boundary->nRangeCreationNumber;
+  }
+}
+
+@BASELINE@
+
+static std::vector<CActiveTag> tags(CMUSHclientDoc& doc) {
+  std::vector<CActiveTag> result;
+  for (POSITION pos = doc.m_ActiveTagList.GetHeadPosition(); pos;)
+    result.push_back(*doc.m_ActiveTagList.GetNext(pos));
+  return result;
+}
+static int differentialChecks = 0;
+static Counts compare(CMUSHclientDoc& doc, const char* name = nullptr,
+                      int history = 0, bool bounded = true) {
+  auto before = tags(doc);
+  reads = {};
+  reference(doc);
+  auto expected = tags(doc);
+  int number = 0;
+  for (POSITION pos = doc.m_ActiveTagList.GetHeadPosition(); pos;)
+    *doc.m_ActiveTagList.GetNext(pos) = before.at(number++);
+  reads = {};
+  doc.BaselineRefresh();
+  Counts old = reads;
+  assert(tags(doc) == expected);
+  number = 0;
+  for (POSITION pos = doc.m_ActiveTagList.GetHeadPosition(); pos;)
+    *doc.m_ActiveTagList.GetNext(pos) = before.at(number++);
+  reads = {};
+  failAllocations = true;
+  doc.RefreshMXPMissingTagAnchors();
+  failAllocations = false;
+  Counts current = reads;
+  if (tags(doc) != expected) {
+    std::cerr << "Differential failure: " << (name ? name : "random") << '\n';
+    std::abort();
+  }
+  ++differentialChecks;
+  if (name) {
+    std::cout << "{\"case\":\"" << name << "\",\"history\":" << history
+      << ",\"tags\":" << before.size() << ",\"old_lines\":" << old.lines
+      << ",\"old_styles\":" << old.styles << ",\"new_lines\":" << current.lines
+      << ",\"new_styles\":" << current.styles << ",\"index_reads\":" << current.index << "}\n";
+    if (bounded) {
+      assert(current.lines <= 650 * static_cast<long long>(before.size()) + 1);
+      assert(current.styles <= 700 * static_cast<long long>(before.size()) + 1);
+      assert(current.index <= 40 * static_cast<long long>(before.size()) + 1);
+    }
+  }
+  return current;
+}
+
+static void copyMarker(CMUSHclientDoc& doc, CActiveTag* tag) {
+  CStyle* marker = new CStyle;
+  marker->nCreationNumber = tag->nOpeningStyleCreationNumber;
+  marker->nRangeCreationNumber = tag->nOpeningStyleCreationNumber;
+  marker->iFlags = START_TAG;
+  doc.m_pCurrentLine->styleList.AddTail(marker);
+  tag->nOpeningLineCreationNumber = doc.m_pCurrentLine->nCreationNumber;
+}
+static void cases(int count) {
+  for (int active : {1, 8, 65}) {
+    CMUSHclientDoc doc;
+    doc.history(count);
+    for (int i = 0; i < active; ++i) doc.open();
+    doc.index();
+    compare(doc, "live_recent_markers", count);
+    doc.clearTailStyles();
+    compare(doc, "carriage_return", count);
+    doc.clearTailStyles();
+    compare(doc, "repeated_carriage_return", count);
+  }
+  {
+    CMUSHclientDoc doc;
+    doc.history(count - 200);
+    CActiveTag* tag = doc.open();
+    __int64 origin = tag->nOpeningLineCreationNumber;
+    doc.history(count);
+    copyMarker(doc, tag);
+    doc.index();
+    compare(doc, "moved_marker", count);
+    doc.deleteTail();
+    doc.index();
+    compare(doc, "retained_marker_after_tail_deletion", count);
+    assert(tag->nFallbackLineCreationNumber == -11);
+    tag->nOpeningLineCreationNumber = origin;
+    compare(doc, "restored_marker", count);
+  }
+  for (bool moved : {false, true}) {
+    CMUSHclientDoc doc;
+    doc.append();
+    CActiveTag* tag = doc.open();
+    doc.history(count + JUMP_SIZE);
+    if (moved) copyMarker(doc, tag);
+    for (int i = 0; i < JUMP_SIZE; ++i) delete doc.m_LineList.RemoveHead();
+    doc.index();
+    compare(doc, moved ? "pruned_origin_moved_marker" : "pruned_marker", count);
+    if (!moved)
+      assert(tag->nFallbackLineCreationNumber == doc.m_LineList.GetHead()->nCreationNumber);
+  }
+  {
+    CMUSHclientDoc doc;
+    doc.history(count - 200);
+    CLine* origin = doc.m_pCurrentLine;
+    __int64 range = origin->styleList.GetTail()->nRangeCreationNumber;
+    // Split fragments retain the range but have later instance identities.
+    while (doc.m_LineList.GetCount() < count) {
+      doc.append();
+      doc.m_pCurrentLine->styleList.GetTail()->nRangeCreationNumber = range;
+    }
+    doc.append();
+    CActiveTag* tag = doc.open();
+    doc.deleteTail();
+    doc.index();
+    compare(doc, "older_tail_without_fallback", count);
+    assert(tag->nFallbackLineCreationNumber == doc.m_pCurrentLine->nCreationNumber);
+    compare(doc, "earliest_older_range_fragment", count);
+    assert(tag->nFallbackLineCreationNumber == origin->nCreationNumber);
+    // A split on the origin line can have an instance ID newer than the tag.
+    origin->styleList.GetHead()->nCreationNumber = ++sequence;
+    compare(doc, "split_range_instance_order", count);
+  }
+  {
+    CMUSHclientDoc doc;
+    doc.history(count);
+    doc.append();
+    CActiveTag* tag = doc.open();
+    doc.deleteTail();
+    doc.clearTailStyles();
+    doc.index();
+    compare(doc, "new_range_on_reused_older_line", count);
+    compare(doc, "retained_range_on_reused_older_line", count);
+    assert(tag->nFallbackLineCreationNumber < tag->nOpeningLineCreationNumber);
+  }
+  {
+    CMUSHclientDoc doc;
+    doc.history(count - 10);
+    CActiveTag* tag = doc.open();
+    doc.clearTailStyles();
+    __int64 firstRange = doc.m_pCurrentLine->styleList.GetTail()->nRangeCreationNumber;
+    doc.history(count);
+    tag->nFallbackStyleRangeNumber = doc.m_pCurrentLine->styleList.GetTail()->nRangeCreationNumber;
+    doc.index();
+    compare(doc, "post_opening_precedes_existing_fallback", count);
+    assert(tag->nFallbackStyleRangeNumber == firstRange);
+    doc.m_pLinePositions = nullptr;
+    compare(doc, "absent_index", count, false);
+    doc.index();
+    for (auto& pos : doc.positions) pos = nullptr;
+    compare(doc, "empty_index_slots", count, false);
+  }
+}
+
+static void randomCases() {
+  std::mt19937 random(1605);
+  for (int trial = 0; trial < 150; ++trial) {
+    CMUSHclientDoc doc;
+    doc.history(1000);
+    for (int step = 0; step < 60; ++step) {
+      switch (random() % 7) {
+        case 0: doc.history(doc.m_LineList.GetCount() + 1 + random() % 130); break;
+        case 1: doc.open(); break;
+        case 2: doc.clearTailStyles(); break;
+        case 3:
+          for (int i = 0, limit = 1 + random() % 40;
+               i < limit && doc.m_LineList.GetCount() > 1; ++i) doc.deleteTail();
+          break;
+        case 4:
+          if (doc.m_LineList.GetCount() > JUMP_SIZE)
+            for (int i = 0; i < JUMP_SIZE; ++i) delete doc.m_LineList.RemoveHead();
+          break;
+        case 5: {
+          // Preserve copies only of markers that actually occupy the source.
+          CLine* source = doc.m_pCurrentLine;
+          doc.append();
+          for (POSITION pos = source->styleList.GetHeadPosition(); pos;) {
+            CStyle* style = source->styleList.GetNext(pos);
+            if (!(style->iFlags & START_TAG)) continue;
+            for (POSITION tags = doc.m_ActiveTagList.GetHeadPosition(); tags;) {
+              CActiveTag* tag = doc.m_ActiveTagList.GetNext(tags);
+              if (tag->nOpeningStyleCreationNumber == style->nCreationNumber)
+                copyMarker(doc, tag);
+            }
+          }
+          break;
+        }
+        case 6: {
+          __int64 range = doc.m_pCurrentLine->styleList.GetTail()->nRangeCreationNumber;
+          doc.append()->styleList.GetTail()->nRangeCreationNumber = range;
+          break;
+        }
+      }
+      doc.index();
+      compare(doc);
+    }
+  }
+}
+
+int main() {
+  {
+    CMUSHclientDoc doc;
+    compare(doc, "no_current_line");
+    doc.history(1000);
+    doc.index();
+    compare(doc, "no_active_tags", 1000);
+  }
+  for (int count : {1000, 10000, 100000}) cases(count);
+  randomCases();
+  {
+    CMUSHclientDoc doc;
+    doc.history(1000);
+    doc.open();
+    doc.clearTailStyles();
+    doc.index();
+    struct Guard {
+      CMUSHclientDoc& doc;
+      ~Guard() { doc.RefreshMXPMissingTagAnchors(); }
+    };
+    bool unwound = false;
+    try {
+      Guard guard{doc};
+      failAllocations = true;
+      throw 16;
+    } catch (int value) {
+      assert(value == 16);
+      failAllocations = false;
+      unwound = true;
+    }
+    assert(unwound);
+    assert(doc.m_ActiveTagList.GetHead()->nFallbackLineCreationNumber ==
+           doc.m_pCurrentLine->nCreationNumber);
+  }
+  std::cout << "{\"differential_checks\":" << differentialChecks
+    << ",\"allocation_failure_and_destructor_unwind\":\"passed\"}\n";
+}

--- a/tests/check_mxp_anchor_refresh.py
+++ b/tests/check_mxp_anchor_refresh.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Check MXP anchor results, list visits, and allocation failure during refresh.
+
+Compile the current production function with portable list substitutes and a
+full-history reference. This does not run native MFC callbacks or the UI.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+
+
+def extract(doc, label):
+    first = 'void CMUSHclientDoc::RefreshMXPMissingTagAnchors (void)'
+    last = '  } // end of CMUSHclientDoc::RefreshMXPMissingTagAnchors'
+    start = doc.find(first)
+    if start < 0:
+        raise ValueError(f'{label}: missing {first!r}')
+    end = doc.find(last, start)
+    if end < 0:
+        raise ValueError(f'{label}: missing {last!r}')
+    return doc[start:end + len(last)]
+
+
+def run(source, output, baseline_ref):
+    doc = (source / 'doc.cpp').read_text()
+    body = extract(doc, source / 'doc.cpp')
+    if baseline_ref:
+        original = subprocess.check_output(
+            ['git', '-C', str(source), 'show', baseline_ref + ':doc.cpp'], text=True)
+        baseline = extract(original, baseline_ref + ':doc.cpp').replace(
+            'CMUSHclientDoc::RefreshMXPMissingTagAnchors',
+            'CMUSHclientDoc::BaselineRefresh')
+    else:
+        baseline = 'void CMUSHclientDoc::BaselineRefresh() { reference(*this); }'
+    template = Path(__file__).with_suffix('.cpp.in').read_text()
+    if template.count('@REFRESH@') != 1:
+        raise ValueError('check_mxp_anchor_refresh.cpp.in: expected one @REFRESH@')
+    cpp = output / 'mxp_anchor_refresh.cpp'
+    if template.count('@BASELINE@') != 1:
+        raise ValueError('check_mxp_anchor_refresh.cpp.in: expected one @BASELINE@')
+    cpp.write_text(template.replace('@REFRESH@', body).replace('@BASELINE@', baseline))
+    binary = output / 'mxp_anchor_refresh'
+    command = shlex.split(os.environ.get('CXX', 'clang++')) + [
+        '-std=c++17', '-Wall', '-Wextra', '-Werror', '-g', '-O1',
+        '-fsanitize=address,undefined', '-fno-sanitize-recover=all',
+        '-fno-omit-frame-pointer', str(cpp), '-o', str(binary)]
+    subprocess.run(command, check=True)
+    result = subprocess.run([str(binary)], text=True, capture_output=True)
+    (output / 'run.log').write_text(result.stdout + result.stderr)
+    print(result.stdout + result.stderr, end='')
+    result.check_returncode()
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
+    (output / 'result.json').write_text(json.dumps({
+        'command': command, 'baseline_ref': baseline_ref, 'results': rows,
+        'method': 'Extracted production refresh, full-history reference, counted linked-list reads, failing operator new, ASan and UBSan.',
+        'limits': 'Portable list substitutes. No native MFC timing or callback integration claim.'
+    }, indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source', type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--output', type=Path)
+    parser.add_argument('--baseline-ref', help='Also compare the exact refresh function at this Git revision')
+    args = parser.parse_args()
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=True)
+        run(args.source, args.output, args.baseline_ref)
+    else:
+        with tempfile.TemporaryDirectory(prefix='mxp-anchor-refresh-') as directory:
+            run(args.source, Path(directory), args.baseline_ref)

--- a/tests/check_mxp_atomic_preparation.cpp.in
+++ b/tests/check_mxp_atomic_preparation.cpp.in
@@ -1,0 +1,225 @@
+// Production excerpts use portable strings, lists, actions, and callbacks.
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+#include <cstdio>
+#include <functional>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+using namespace std;
+using __int64 = long long;
+using POSITION = void *;
+using COLORREF = unsigned;
+using LPCTSTR = const char *;
+constexpr int START_TAG = 0x1000, STYLE_BITS = 0xfff, DBG_ERROR = 1;
+constexpr int DISPID_UNKNOWN = -1;
+#define NEWSTYLE new CStyle
+#define DELETESTYLE(p) delete (p)
+@ENUMS@
+struct CString : string {
+  using string::string;
+  CString(const string &s) : string(s) {}
+  operator const char *() const { return c_str(); }
+  bool IsEmpty() const { return empty(); }
+  void Empty() { clear(); }
+  int GetLength() const { return size(); }
+  int Find(char c) const { auto pos = find(c); return pos == npos ? -1 : int(pos); }
+  void MakeLower() { transform(begin(), end(), begin(), [](unsigned char c){return tolower(c);}); }
+};
+template<class... T> CString CFormat(const char *fmt, T... args) {
+  char buffer[256]; snprintf(buffer, sizeof(buffer), fmt, args...); return buffer;
+}
+template<class... T> CString TFormat(const char *fmt, T... args) { return CFormat(fmt, args...); }
+template<class T> class List {
+  struct Node { T *value; Node *prev; Node *next; };
+  Node *head = nullptr, *tail = nullptr;
+  size_t count = 0;
+public:
+  ~List() { assert(IsEmpty()); }
+  POSITION GetHeadPosition() { return head; }
+  POSITION GetTailPosition() { return tail; }
+  T *GetNext(POSITION &pos) { auto n = static_cast<Node *>(pos); pos = n->next; return n->value; }
+  T *GetTail() { assert(tail); return tail->value; }
+  bool IsEmpty() const { return !head; }
+  size_t GetCount() const { return count; }
+  void AddTail(T *value) {
+    auto n = new Node{value, tail, nullptr};
+    if (tail) tail->next = n; else head = n;
+    tail = n; ++count;
+  }
+  void RemoveAt(POSITION pos) {
+    auto n = static_cast<Node *>(pos);
+    if (n->prev) n->prev->next = n->next; else head = n->next;
+    if (n->next) n->next->prev = n->prev; else tail = n->prev;
+    delete n; --count;
+  }
+  T *RemoveTail() { auto value = GetTail(); RemoveAt(tail); return value; }
+  void DeleteAll() { while (!IsEmpty()) delete RemoveTail(); }
+};
+static int actionCount = 0, styleCount = 0, styleAllocations = 0;
+struct CAction {
+  int refs = 1;
+  CString m_strAction, m_strHint, m_strVariable;
+  CAction(CString a, CString h, CString v) : m_strAction(a), m_strHint(h), m_strVariable(v) { ++actionCount; }
+  ~CAction() { --actionCount; }
+  void AddRef() { ++refs; }
+  void Release() { assert(refs > 0); if (!--refs) delete this; }
+};
+struct CStyle {
+  unsigned short iFlags = 0, iLength = 0;
+  COLORREF iForeColour = 7, iBackColour = 0;
+  CAction *pAction = nullptr;
+  CStyle() { ++styleCount; ++styleAllocations; }
+  ~CStyle() { if (pAction) pAction->Release(); --styleCount; }
+};
+struct CLine {
+  List<CStyle> styleList;
+  ~CLine() { styleList.DeleteAll(); }
+};
+struct CArgument { CString strName, strValue; };
+using CArgumentList = List<CArgument>;
+struct Arguments : CArgumentList {
+  Arguments(initializer_list<CString> values) { for (auto &value : values) AddTail(new CArgument{"", value}); }
+  ~Arguments() { DeleteAll(); }
+};
+struct CActiveTag { __int64 nCreationNumber; };
+using CActiveTagList = List<CActiveTag>;
+struct StringMap {
+  map<CString, CString> values;
+  bool Lookup(CString name, CString &value) {
+    auto found = values.find(name);
+    if (found == values.end()) return false;
+    value = found->second; return true;
+  }
+};
+struct { StringMap m_EntityMap; } App;
+struct CMUSHclientDoc {
+  CLine *m_pCurrentLine = new CLine;
+  CActiveTagList m_ActiveTagList;
+  StringMap m_CustomEntityMap;
+  __int64 m_iMXPGeneration = 1;
+  bool m_bMXP = true, m_bPluginProcessesOpenTag = false;
+  int m_dispidOnMXP_OpenTag = DISPID_UNKNOWN;
+  int errors = 0, openCalls = 0, resets = 0;
+  bool prepared = false;
+  CString callbackArguments;
+  function<void()> errorHook;
+  function<bool()> openHook;
+  CMUSHclientDoc() { AddStyle(2, 7, 0, 0, "outer", "hint", "var"); }
+  ~CMUSHclientDoc() { delete m_pCurrentLine; m_ActiveTagList.DeleteAll(); }
+  CStyle *tail() { return m_pCurrentLine->styleList.GetTail(); }
+  CAction *GetAction(CString a, CString h, CString v) {
+    if (a.IsEmpty() && h.IsEmpty() && v.IsEmpty()) return nullptr;
+    return new CAction(a, h, v);
+  }
+  CStyle *AddStyle(unsigned short, COLORREF, COLORREF, int, CString, CString, CString, CLine * = nullptr);
+  CStyle *AddStyle(unsigned short, COLORREF, COLORREF, int, CAction *, CLine * = nullptr);
+  CString MXP_GetEntity(CString &);
+  void MXP_Restore_Mode() { ++resets; }
+  void MXP_error(int, int, CString) { ++errors; MXP_Restore_Mode(); if (errorHook) errorHook(); }
+  bool MXP_StartTagScript(CString, CString arguments, CArgumentList &) {
+    ++openCalls; callbackArguments = arguments; return openHook ? openHook() : false;
+  }
+  void Run(CArgumentList &, bool paired);
+};
+@ADD_STYLE@
+@GET_ENTITY@
+@HELPERS@
+@ACTION_GUARD@
+void CMUSHclientDoc::Run(CArgumentList &ArgumentList, bool paired) {
+  int atomicElement = 0;
+  const int *pAtomicElement = &atomicElement;
+  CString strName = "test", strTag;
+  @OPENING@
+  @PREPARATION@
+  prepared = true;
+  // Model the two subsequent publication calls; preparation and AddStyle above
+  // use exact source excerpts. Tag transactions are checked by their own runner.
+  if (paired) AddStyle(iFlags | START_TAG, iForeColour, iBackColour, 0, strName, "", strTagVariable);
+  AddStyle(iFlags & STYLE_BITS, iForeColour, iBackColour, 0, strAction, strHint, strVariable);
+}
+static void plainChecks(bool baseline) {
+  for (bool paired : {false, true}) for (int length : {0, 4})
+    for (auto value : {"", "plain", "&text;", "before &text; after"}) {
+      CMUSHclientDoc d; d.tail()->iLength = length;
+      Arguments arguments{value};
+      int before = styleAllocations;
+      d.Run(arguments, paired);
+      assert(d.prepared && !d.errors && !d.openCalls);
+      assert(arguments.GetTail()->strValue == value);
+      assert(styleAllocations - before == 1 + int(paired) + int(baseline));
+      assert(d.m_pCurrentLine->styleList.GetCount() == 1 + size_t(paired) + size_t(length != 0));
+      assert(d.tail()->iFlags == 2 && d.tail()->pAction->m_strAction == "outer");
+    }
+  // Empty argument lists and repeated command tags must also remain bounded.
+  CMUSHclientDoc d; Arguments empty{}; int before = styleAllocations;
+  for (int i = 0; i < 1000; ++i) d.Run(empty, false);
+  assert(styleAllocations - before == 1000 * (baseline ? 2 : 1));
+  assert(d.m_pCurrentLine->styleList.GetCount() == 1);
+  printf("plain atomic tags: %d allocations per 1000 command tags; one retained style\n", styleAllocations - before);
+}
+static void expansionChecks() {
+  App.m_EntityMap.values["amp"] = "&";
+  for (auto entry : {pair<CString,CString>{"&amp;", "&"}, {"&#65;", "A"},
+                     {"&#x42;", "B"}, {"&same;", "&same;"},
+                     {"&amp;:&text;:&#65;", "&:&text;:A"}}) {
+    CMUSHclientDoc d; d.m_CustomEntityMap.values["same"] = "&same;";
+    Arguments args{entry.first}; int before = styleAllocations;
+    d.Run(args, false);
+    assert(d.prepared && !d.errors && args.GetTail()->strValue == entry.second);
+    assert(styleAllocations - before == 2);
+  }
+  // Error callbacks remain possible even without an open-tag callback.
+  for (auto value : {"&unknown;", "&#999;", "&#xZZ;"}) {
+    CMUSHclientDoc d; Arguments args{value}; CStyle *callbackStyle = nullptr;
+    d.errorHook = [&]{ callbackStyle = d.AddStyle(8, 3, 4, 8, "callback", "", ""); };
+    d.Run(args, true);
+    assert(d.errors == 1 && d.prepared && args.GetTail()->strValue.empty());
+    assert(callbackStyle->iFlags == 8 && callbackStyle->iLength == 8);
+    assert(callbackStyle->pAction->m_strAction == "callback");
+    assert(d.tail()->iFlags == 2 && d.tail()->pAction->m_strAction == "outer");
+  }
+  // Missing semicolons stop preparation after its diagnostic.
+  CMUSHclientDoc d; Arguments args{"&missing"}; int before = styleAllocations;
+  d.Run(args, false);
+  assert(!d.prepared && d.errors == 1 && styleAllocations == before);
+  puts("entity expansion: numeric, named, unchanged, text placeholder, and errors passed");
+}
+static void callbackChecks() {
+  for (bool entity : {false, true}) for (int mode = 0; mode < 6; ++mode) {
+    CMUSHclientDoc d; Arguments args{entity ? "&unknown;" : "plain"};
+    CStyle *callbackStyle = nullptr;
+    auto callback = [&] {
+      if (mode == 1) { delete d.m_pCurrentLine; d.m_pCurrentLine = new CLine; }
+      callbackStyle = d.AddStyle(8, 3, 4, 8, "callback", "", "");
+      if (mode == 2) d.m_ActiveTagList.AddTail(new CActiveTag{42});
+      if (mode == 3) d.m_bMXP = false;
+      if (mode == 4) ++d.m_iMXPGeneration;
+      if (mode == 5) throw runtime_error("callback failure");
+    };
+    if (entity) d.errorHook = callback;
+    else { d.m_bPluginProcessesOpenTag = true; d.openHook = [&]{ callback(); return false; }; }
+    bool threw = false;
+    try { d.Run(args, true); }
+    catch (const runtime_error &e) { threw = string(e.what()) == "callback failure"; }
+    assert(threw == (mode == 5));
+    assert(d.prepared == (mode < 3));
+    assert(callbackStyle->iFlags == 8 && callbackStyle->iLength == 8);
+    assert(callbackStyle->pAction->m_strAction == "callback");
+    if (mode < 3) assert(d.tail()->iFlags == (mode == 2 ? 8 : 2));
+    if (!entity) assert(d.openCalls == 1 && d.callbackArguments == "'plain'");
+  }
+  CMUSHclientDoc d; Arguments args{"&amp;"};
+  d.m_dispidOnMXP_OpenTag = 1; d.openHook = []{return true;};
+  d.Run(args, true);
+  assert(!d.prepared && d.openCalls == 1 && d.callbackArguments == "'&'");
+  puts("callback boundaries: output, replaced line, nested tag, disabled MXP, generation, rejection, and exceptions passed");
+}
+int main(int argc, char **argv) {
+  assert(argc == 2);
+  plainChecks(string(argv[1]) == "baseline"); expansionChecks(); callbackChecks();
+  assert(actionCount == 0 && styleCount == 0);
+}

--- a/tests/check_mxp_atomic_preparation.py
+++ b/tests/check_mxp_atomic_preparation.py
@@ -56,7 +56,7 @@ def main():
     cpp.write_text(template)
     executable = cpp.with_suffix('')
     subprocess.run(['clang++', '-std=c++17', '-Wall', '-Wextra', '-Werror',
-                    '-O1', '-g', '-fsanitize=address,undefined',
+                    '-O1', '-g', '-fsanitize=address,undefined', '-fno-sanitize-recover=all',
                     '-fno-omit-frame-pointer', str(cpp), '-o', str(executable)], check=True)
     subprocess.run([str(executable), 'baseline' if args.baseline_ref else 'fixed'], check=True)
 

--- a/tests/check_mxp_atomic_preparation.py
+++ b/tests/check_mxp_atomic_preparation.py
@@ -1,0 +1,65 @@
+"""Check atomic MXP preparation with production source excerpts.
+
+Requires clang++. Portable substitutes do not validate native MFC callbacks.
+"""
+import argparse
+from pathlib import Path
+import re
+import subprocess
+
+
+from output_callbacks import section as between
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--baseline-ref')
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    def source(path):
+        if args.baseline_ref:
+            return subprocess.check_output(
+                ['git', 'show', args.baseline_ref + ':' + path], cwd=root, text=True)
+        return (root / path).read_text()
+
+    start = source('mxp/mxpStart.cpp')
+    # The preparation excerpt ends before the custom-element-only branch.
+    # The added brace closes the enclosing callback-boundary block.
+    preparation = between(start, '  const __int64 iOpeningMXPGeneration =',
+                          '    if (bRanOpenCallback && !pAtomicElement)') + '    }\n'
+    pieces = {
+        'HELPERS': between(start, 'static void SnapshotActiveTags',
+                           'static bool BuildCustomAtomicArguments'),
+        'ACTION_GUARD': between(start, 'class CActionReferenceGuard',
+                                '// here for start tag'),
+        'OPENING': between(start, 'CStyle * pStyle = m_pCurrentLine',
+                           '  if (App.m_ElementMap.Lookup'),
+        'PREPARATION': preparation,
+        'ADD_STYLE': between(source('doc.cpp'), '// adds a new style to the current line',
+                             'void CMUSHclientDoc::RefreshMXPMissingTagAnchors'),
+        'GET_ENTITY': between(source('mxp/mxpEntities.cpp'),
+                              'CString CMUSHclientDoc::MXP_GetEntity',
+                              '// end of CMUSHclientDoc::MXP_GetEntity',
+                              'mxp/mxpEntities.cpp') + '\n',
+    }
+    template = Path(__file__).with_suffix('.cpp.in').read_text()
+    for name, code in pieces.items():
+        token = '@' + name + '@'
+        assert template.count(token) == 1, token
+        template = template.replace(token, code)
+    names = sorted(set(re.findall(r'\berrMXP_\w+\b', template)))
+    template = template.replace('@ENUMS@', 'enum { ' + ', '.join(names) + ' };')
+    cpp = args.output / 'mxp_atomic_preparation.cpp'
+    cpp.write_text(template)
+    executable = cpp.with_suffix('')
+    subprocess.run(['clang++', '-std=c++17', '-Wall', '-Wextra', '-Werror',
+                    '-O1', '-g', '-fsanitize=address,undefined',
+                    '-fno-omit-frame-pointer', str(cpp), '-o', str(executable)], check=True)
+    subprocess.run([str(executable), 'baseline' if args.baseline_ref else 'fixed'], check=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_mxp_cleanup.cpp.in
+++ b/tests/check_mxp_cleanup.cpp.in
@@ -108,7 +108,11 @@ struct CMUSHclientDoc {
   CElement element;
   struct Map {
     CElement *element;
-    bool Lookup(const CString &, CElement *&result) { result = element; return result != nullptr; }
+    CString name = "custom";
+    bool Lookup(const CString &key, CElement *&result) {
+      if (key != name) return false;
+      result = element; return result != nullptr;
+    }
   } m_CustomElementMap{&element};
   vector<string> events;
   vector<long> warnings;
@@ -117,7 +121,7 @@ struct CMUSHclientDoc {
   function<void()> finishHook;
   string prepareFailure, reject, finishFailure;
   bool warningFailure = false, formatFailure = false;
-  int buildMode = 0;
+  int buildMode = 0, buildCalls = 0;
   CMUSHclientDoc() {
     formatHook = [this] {
       events.push_back("format");
@@ -153,6 +157,7 @@ struct CMUSHclientDoc {
     if (warningFailure) throw runtime_error("warning failure");
   }
   bool BuildArgumentList(CArgumentList &list, const CString &) {
+    ++buildCalls;
     list.AddTail(new CArgument(1)); list.AddTail(new CArgument(2));
     if (buildMode == 2) throw runtime_error("build failure");
     return buildMode == 1;
@@ -239,6 +244,22 @@ void discardChecks() {
   cout << "PASS discard predicates, missing or reused markers and action ownership\n";
 }
 void attlistChecks() {
+  for (bool format : {false, true}) for (bool warning : {false, true}) {
+    {
+      CMUSHclientDoc d;
+      auto old = new CArgument(0); d.element.AttributeList.AddTail(old);
+      d.formatFailure = format; d.warningFailure = warning;
+      string error;
+      try { d.MXP_Attlist("Unknown", "a=1 b=2"); } catch (const runtime_error &e) { error = e.what(); }
+      assert(error == (format ? "format failure" : warning ? "warning failure" : ""));
+      assert(d.buildCalls == 0 && argumentsAlive == 1);
+      assert(d.element.AttributeList.GetHead() == old && d.element.AttributeList.GetTail() == old);
+      assert((d.events == (format ? vector<string>{"format"} : vector<string>{"format", "warning"})));
+      assert((d.warnings == (format ? vector<long>{} : vector<long>{errMXP_UnknownElementInAttlist})));
+      if (!format) assert(d.messages.front() == "Cannot add attributes to undefined MXP element: <unknown>");
+    }
+    assert(argumentsAlive == 0);
+  }
   for (int build : {0,1,2}) for (int failAt : {0,1,2}) {
     CMUSHclientDoc d;
     auto old = new CArgument(0); d.element.AttributeList.AddTail(old);
@@ -250,11 +271,12 @@ void attlistChecks() {
     for (POSITION p = d.element.AttributeList.GetHeadPosition(); p;) values.push_back(d.element.AttributeList.GetNext(p)->value);
     vector<int> expected{0};
     if (!build) for (int n = 1; n <= 2 && (!failAt || n < failAt); ++n) expected.push_back(n);
+    assert(d.buildCalls == 1);
     assert(values == expected && d.element.AttributeList.GetHead() == old);
     assert(argumentsAlive == static_cast<int>(values.size()));
   }
   assert(argumentsAlive == 0);
-  cout << "PASS attribute ownership, parse rejection, build exceptions and each insertion failure\n";
+  cout << "PASS undefined elements, diagnostic failures, attribute ownership, parse rejection, build exceptions and each insertion failure\n";
 }
 int main(int argc, char **argv) {
   string check = argc > 1 ? argv[1] : "all";

--- a/tests/check_mxp_cleanup.cpp.in
+++ b/tests/check_mxp_cleanup.cpp.in
@@ -1,0 +1,264 @@
+// Compile the production helpers with portable MFC and callback substitutes.
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+using namespace std;
+using __int64 = long long;
+using COLORREF = unsigned;
+using POSITION = void *;
+using LPCTSTR = const char *;
+constexpr int START_TAG = 0x1000, DBG_WARNING = 2, DBG_ERROR = 1;
+constexpr long wrnMXP_OpenTagClosedAtEndOfLine = 20, wrnMXP_TagClosedAtReset = 21;
+constexpr long errMXP_UnknownElementInAttlist = 30;
+struct CString : string {
+  using string::string;
+  CString(const string &s) : string(s) {}
+  operator const char *() const { return c_str(); }
+  void MakeLower() { transform(begin(), end(), begin(), [](unsigned char c){return tolower(c);}); }
+};
+std::function<void()> formatHook;
+CString TFormat(const char *format, const char *value) {
+  if (formatHook) formatHook();
+  char buffer[200]; snprintf(buffer, sizeof(buffer), format, value); return buffer;
+}
+template<class T> class List {
+  struct Node { T *value; Node *prev; Node *next; };
+  Node *head = nullptr, *tail = nullptr;
+public:
+  int failAt = 0, calls = 0;
+  ~List() { while (!IsEmpty()) RemoveHead(); }
+  bool IsEmpty() const { return !head; }
+  POSITION GetHeadPosition() { return head; }
+  POSITION GetTailPosition() { return tail; }
+  T *GetHead() { assert(head); return head->value; }
+  T *GetTail() { assert(tail); return tail->value; }
+  T *GetNext(POSITION &pos) { auto n = static_cast<Node *>(pos); pos = n->next; return n->value; }
+  T *GetPrev(POSITION &pos) { auto n = static_cast<Node *>(pos); pos = n->prev; return n->value; }
+  void AddTail(T *value) {
+    if (++calls == failAt) throw runtime_error("insertion failure");
+    auto n = new Node{value, tail, nullptr};
+    if (tail) tail->next = n; else head = n;
+    tail = n;
+  }
+  void AddTail(List *source) {
+    for (POSITION pos = source->GetHeadPosition(); pos;) AddTail(source->GetNext(pos));
+  }
+  void RemoveAt(POSITION pos) {
+    auto n = static_cast<Node *>(pos);
+    if (n->prev) n->prev->next = n->next; else head = n->next;
+    if (n->next) n->next->prev = n->prev; else tail = n->prev;
+    delete n;
+  }
+  T *RemoveHead() { auto value = GetHead(); RemoveAt(head); return value; }
+};
+#define DELETE_LIST(list) do { while (!(list).IsEmpty()) delete (list).RemoveHead(); } while(false)
+int actionsAlive = 0, tagsAlive = 0, argumentsAlive = 0;
+struct CAction {
+  int refs = 1;
+  CAction() { ++actionsAlive; }
+  ~CAction() { --actionsAlive; }
+  void AddRef() { ++refs; }
+  void Release() { assert(refs > 0); if (!--refs) delete this; }
+};
+struct CStyle {
+  __int64 nCreationNumber = 0;
+  unsigned short iFlags = START_TAG;
+  COLORREF iForeColour = 1, iBackColour = 2;
+  CAction *pAction = nullptr;
+  ~CStyle() { if (pAction) pAction->Release(); }
+};
+struct CLine {
+  List<CStyle> styleList;
+  ~CLine() { DELETE_LIST(styleList); }
+};
+using CLineList = List<CLine>;
+struct CActiveTag {
+  __int64 nCreationNumber = 0, nOpeningStyleCreationNumber = 0;
+  bool bSecure = false, bNoReset = false;
+  CString strName;
+  vector<int> closeActions;
+  CAction *pOpeningAction = nullptr;
+  unsigned short iOpeningFlags = 8;
+  COLORREF iOpeningForeColour = 3, iOpeningBackColour = 4;
+  CActiveTag() { ++tagsAlive; }
+  ~CActiveTag() { if (pOpeningAction) pOpeningAction->Release(); --tagsAlive; }
+};
+struct CArgument {
+  int value;
+  explicit CArgument(int n) : value(n) { ++argumentsAlive; }
+  ~CArgument() { --argumentsAlive; }
+};
+using CArgumentList = List<CArgument>;
+struct CElement {
+  CArgumentList AttributeList;
+  ~CElement() { DELETE_LIST(AttributeList); }
+};
+struct CPreparedMXPClose { CString strTag; };
+struct CMUSHclientDoc {
+  List<CActiveTag> m_ActiveTagList;
+  CLineList m_LineList;
+  CElement element;
+  struct Map {
+    CElement *element;
+    bool Lookup(const CString &, CElement *&result) { result = element; return result != nullptr; }
+  } m_CustomElementMap{&element};
+  vector<string> events;
+  vector<long> warnings;
+  vector<string> messages;
+  function<void(CActiveTag *)> prepareHook;
+  function<void()> finishHook;
+  string prepareFailure, reject, finishFailure;
+  bool warningFailure = false, formatFailure = false;
+  int buildMode = 0;
+  CMUSHclientDoc() {
+    formatHook = [this] {
+      events.push_back("format");
+      if (formatFailure) throw runtime_error("format failure");
+    };
+  }
+  ~CMUSHclientDoc() { formatHook = nullptr; DELETE_LIST(m_ActiveTagList); DELETE_LIST(m_LineList); }
+  CActiveTag *tag(int id) {
+    auto p = new CActiveTag; p->nCreationNumber = id; p->strName = to_string(id);
+    p->nOpeningStyleCreationNumber = id * 100; p->closeActions = {id};
+    m_ActiveTagList.AddTail(p); return p;
+  }
+  CStyle *marker(CActiveTag *tag) {
+    if (m_LineList.IsEmpty()) m_LineList.AddTail(new CLine);
+    auto p = new CStyle; p->nCreationNumber = tag->nOpeningStyleCreationNumber;
+    m_LineList.GetTail()->styleList.AddTail(p); return p;
+  }
+  bool MXP_PrepareCloseTag(CString name, bool open, __int64 marker,
+                          const vector<int> &actions, CActiveTag *tag, CPreparedMXPClose &close) {
+    assert(!open && marker == tag->nOpeningStyleCreationNumber && actions == tag->closeActions);
+    events.push_back("prepare" + name);
+    if (prepareFailure == name) throw runtime_error("prepare failure");
+    if (prepareHook) prepareHook(tag);
+    close.strTag = name; return reject != name;
+  }
+  void MXP_FinishCloseTag(const CPreparedMXPClose &close) {
+    events.push_back("finish" + close.strTag);
+    if (finishHook) finishHook();
+    if (finishFailure == close.strTag) throw runtime_error("finish failure");
+  }
+  void MXP_error(int, long number, CString message) {
+    warnings.push_back(number); messages.push_back(message); events.push_back("warning");
+    if (warningFailure) throw runtime_error("warning failure");
+  }
+  bool BuildArgumentList(CArgumentList &list, const CString &) {
+    list.AddTail(new CArgument(1)); list.AddTail(new CArgument(2));
+    if (buildMode == 2) throw runtime_error("build failure");
+    return buildMode == 1;
+  }
+  void MXP_CloseOpenTags();
+  void MXP_CloseAllTags();
+  void MXP_Attlist(CString name, CString arguments);
+};
+@CLOSE@
+@DISCARD@
+@GUARD@
+@ATTLIST@
+vector<int> tags(CMUSHclientDoc &doc) {
+  vector<int> ids;
+  for (POSITION p = doc.m_ActiveTagList.GetHeadPosition(); p;) ids.push_back(doc.m_ActiveTagList.GetNext(p)->nCreationNumber);
+  return ids;
+}
+void closeChecks() {
+  for (bool reset : {false, true}) {
+    auto close = [reset](CMUSHclientDoc &d) { if (reset) d.MXP_CloseAllTags(); else d.MXP_CloseOpenTags(); };
+    {
+      CMUSHclientDoc d; auto a = d.tag(1); d.tag(2); auto c = d.tag(3);
+      if (reset) { a->bNoReset = true; c->bSecure = true; }
+      else { a->bSecure = true; c->bNoReset = true; }
+      d.finishHook = [&]{if (tags(d) == vector<int>{1}) d.tag(4);};
+      close(d);
+      assert((tags(d) == vector<int>{1,4}));
+      assert((d.events == vector<string>{"prepare3","prepare2","format","warning","finish3","format","warning","finish2"}));
+      assert((d.warnings == vector<long>(2, reset ? wrnMXP_TagClosedAtReset : wrnMXP_OpenTagClosedAtEndOfLine)));
+      assert(d.messages.front() == (reset ? "<reset> closure of MXP tag: <3>" : "End-of-line closure of open MXP tag: <3>"));
+    }
+    {
+      CMUSHclientDoc d; d.tag(1); d.tag(2); d.tag(3); d.reject = "2";
+      close(d); assert((tags(d) == vector<int>{2}));
+      assert((d.events == vector<string>{"prepare3","prepare2","prepare1","format","warning","finish3","format","warning","finish1"}));
+    }
+    {
+      CMUSHclientDoc d; d.tag(1); d.tag(2); d.tag(3);
+      d.prepareHook = [&](CActiveTag *tag) {
+        if (tag->nCreationNumber != 3) return;
+        POSITION p = d.m_ActiveTagList.GetHeadPosition(); d.m_ActiveTagList.GetNext(p);
+        POSITION remove = p; auto removed = d.m_ActiveTagList.GetNext(p);
+        d.m_ActiveTagList.RemoveAt(remove); delete removed; d.tag(4);
+      };
+      close(d); assert((tags(d) == vector<int>{4}));
+      assert((d.events == vector<string>{"prepare3","prepare1","format","warning","finish3","format","warning","finish1"}));
+    }
+    for (bool prepare : {false, true}) for (bool warning : {false, true}) for (bool format : {false, true}) {
+      CMUSHclientDoc d; d.tag(1); d.tag(2); d.tag(3);
+      d.prepareFailure = prepare ? "2" : ""; d.warningFailure = warning; d.finishFailure = "3"; d.formatFailure = format;
+      string error;
+      try { close(d); } catch (const runtime_error &e) { error = e.what(); }
+      assert(error == (prepare ? "prepare failure" : format ? "format failure" : warning ? "warning failure" : "finish failure"));
+      assert(count(d.events.begin(), d.events.end(), "format") == (prepare ? 1 : 3));
+      assert(count(d.events.begin(), d.events.end(), "finish3") == 1);
+      assert(count(d.events.begin(), d.events.end(), "finish1") == (prepare ? 0 : 1));
+      assert(tags(d).size() == (prepare ? 2 : 0));
+    }
+  }
+  assert(tagsAlive == 0);
+  cout << "PASS close stop flags, warning text, identity lookup, callback exclusion, format timing and exception order\n";
+}
+void discardChecks() {
+  for (bool boundary : {false, true}) for (int action : {0,1,2}) for (int markerMode : {0,1,2}) {
+    CMUSHclientDoc d; d.tag(1); auto b = d.tag(2); auto c = d.tag(3);
+    CStyle *s = markerMode == 2 ? nullptr : d.marker(b);
+    if (s) {
+      if (markerMode == 1) s->iFlags = 32;
+      s->pAction = new CAction;
+      if (action) { b->pOpeningAction = action == 1 ? s->pAction : new CAction; if (action == 1) b->pOpeningAction->AddRef(); }
+    }
+    auto openingAction = b->pOpeningAction;
+    auto untouched = d.marker(c);
+    if (boundary) DiscardMXPTagsCreatedAfter(&d, 1); else DiscardMXPTags(&d, set<__int64>{2});
+    assert((tags(d) == (boundary ? vector<int>{1} : vector<int>{1,3})));
+    if (s && markerMode == 0) {
+      assert(s->iFlags == 8 && s->iForeColour == 3 && s->iBackColour == 4);
+      assert(s->pAction == openingAction); if (openingAction) assert(openingAction->refs == 1);
+    }
+    if (s && markerMode == 1) assert(s->iFlags == 32 && s->pAction);
+    assert(untouched->iFlags == (boundary ? 8 : START_TAG));
+  }
+  assert(actionsAlive == 0 && tagsAlive == 0);
+  cout << "PASS discard predicates, missing or reused markers and action ownership\n";
+}
+void attlistChecks() {
+  for (int build : {0,1,2}) for (int failAt : {0,1,2}) {
+    CMUSHclientDoc d;
+    auto old = new CArgument(0); d.element.AttributeList.AddTail(old);
+    d.element.AttributeList.calls = 0; d.element.AttributeList.failAt = failAt; d.buildMode = build;
+    string error;
+    try { d.MXP_Attlist("Custom", "a=1 b=2"); } catch (const runtime_error &e) { error = e.what(); }
+    assert(error == (build == 2 ? "build failure" : build == 0 && failAt ? "insertion failure" : ""));
+    vector<int> values;
+    for (POSITION p = d.element.AttributeList.GetHeadPosition(); p;) values.push_back(d.element.AttributeList.GetNext(p)->value);
+    vector<int> expected{0};
+    if (!build) for (int n = 1; n <= 2 && (!failAt || n < failAt); ++n) expected.push_back(n);
+    assert(values == expected && d.element.AttributeList.GetHead() == old);
+    assert(argumentsAlive == static_cast<int>(values.size()));
+  }
+  assert(argumentsAlive == 0);
+  cout << "PASS attribute ownership, parse rejection, build exceptions and each insertion failure\n";
+}
+int main(int argc, char **argv) {
+  string check = argc > 1 ? argv[1] : "all";
+  if (check == "all" || check == "close") closeChecks();
+  if (check == "all" || check == "discard") discardChecks();
+  if (check == "all" || check == "attlist") attlistChecks();
+}

--- a/tests/check_mxp_cleanup.py
+++ b/tests/check_mxp_cleanup.py
@@ -45,7 +45,7 @@ def main():
     cpp.write_text(template)
     executable = args.output / 'mxp_cleanup'
     subprocess.run(['clang++', '-std=c++17', '-Wall', '-Wextra', '-Werror', '-O1', '-g',
-                    '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                    '-fsanitize=address,undefined', '-fno-sanitize-recover=all', '-fno-omit-frame-pointer',
                     str(cpp), '-o', str(executable)], check=True)
     result = subprocess.run([str(executable), args.check], text=True, capture_output=True)
     (args.output / 'run.log').write_text(result.stdout + result.stderr)

--- a/tests/check_mxp_cleanup.py
+++ b/tests/check_mxp_cleanup.py
@@ -26,11 +26,12 @@ def main():
 
     close = source('mxp/mxpClose.cpp')
     close_start = 'struct CTagToClose' if '\nstruct CTagToClose' in close else 'void CMUSHclientDoc::MXP_CloseOpenTags'
+    close_end = '// end of CMUSHclientDoc::MXP_CloseAllTags'
     discard = source('mxp/mxpOnOff.cpp')
     definitions = source('mxp/mxpDefs.cpp')
     guard_end = '  };' if '\nclass CElementArgumentListGuard' in definitions[:definitions.index('void CMUSHclientDoc::MXP_Definition')] else '  } argumentListGuard (ArgumentList);'
     pieces = {
-        'CLOSE': close[close.index(close_start):],
+        'CLOSE': between(close, close_start, close_end, 'mxp/mxpClose.cpp') + close_end + '\n',
         'DISCARD': between(discard, 'static CStyle * FindMXPStyle', 'static void RebaseMXPResetState', 'mxp/mxpOnOff.cpp'),
         'GUARD': between(definitions, 'class CElementArgumentListGuard', guard_end, 'mxp/mxpDefs.cpp') + '  };\n',
         'ATTLIST': between(definitions, 'void CMUSHclientDoc::MXP_Attlist', '// here for <!ENTITY', 'mxp/mxpDefs.cpp'),

--- a/tests/check_mxp_cleanup.py
+++ b/tests/check_mxp_cleanup.py
@@ -1,0 +1,56 @@
+"""Check MXP close, discard, and argument ownership with source excerpts.
+
+Requires clang++. Portable substitutes do not validate native MFC behavior.
+"""
+import argparse
+from pathlib import Path
+import subprocess
+
+from check_mxp_start_identities import between
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--baseline-ref')
+    parser.add_argument('--check', choices=['all', 'close', 'discard', 'attlist'], default='all')
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    def source(path):
+        if args.baseline_ref:
+            return subprocess.check_output(
+                ['git', 'show', args.baseline_ref + ':' + path], cwd=root, text=True)
+        return (root / path).read_text()
+
+    close = source('mxp/mxpClose.cpp')
+    close_start = 'struct CTagToClose' if '\nstruct CTagToClose' in close else 'void CMUSHclientDoc::MXP_CloseOpenTags'
+    discard = source('mxp/mxpOnOff.cpp')
+    definitions = source('mxp/mxpDefs.cpp')
+    guard_end = '  };' if '\nclass CElementArgumentListGuard' in definitions[:definitions.index('void CMUSHclientDoc::MXP_Definition')] else '  } argumentListGuard (ArgumentList);'
+    pieces = {
+        'CLOSE': close[close.index(close_start):],
+        'DISCARD': between(discard, 'static CStyle * FindMXPStyle', 'static void RebaseMXPResetState', 'mxp/mxpOnOff.cpp'),
+        'GUARD': between(definitions, 'class CElementArgumentListGuard', guard_end, 'mxp/mxpDefs.cpp') + '  };\n',
+        'ATTLIST': between(definitions, 'void CMUSHclientDoc::MXP_Attlist', '// here for <!ENTITY', 'mxp/mxpDefs.cpp'),
+    }
+    template = Path(__file__).with_suffix('.cpp.in').read_text()
+    for name, code in pieces.items():
+        marker = '@' + name + '@'
+        assert template.count(marker) == 1, marker
+        template = template.replace(marker, code)
+    cpp = args.output / 'mxp_cleanup.cpp'
+    cpp.write_text(template)
+    executable = args.output / 'mxp_cleanup'
+    subprocess.run(['clang++', '-std=c++17', '-Wall', '-Wextra', '-Werror', '-O1', '-g',
+                    '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                    str(cpp), '-o', str(executable)], check=True)
+    result = subprocess.run([str(executable), args.check], text=True, capture_output=True)
+    (args.output / 'run.log').write_text(result.stdout + result.stderr)
+    print(result.stdout + result.stderr, end='')
+    result.check_returncode()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_mxp_close_ranges.py
+++ b/tests/check_mxp_close_ranges.py
@@ -120,9 +120,15 @@ cout<<"PASS close range capture, split/move, pruning, callback exclusion, staged
 def main():
  p=argparse.ArgumentParser(description=__doc__);p.add_argument('--output',type=Path);p.add_argument('--baseline-ref');a=p.parse_args()
  out=a.output or Path(tempfile.mkdtemp(prefix='mxp-close-'));out.mkdir(parents=True,exist_ok=True)
- source=(subprocess.check_output(['git','show',a.baseline_ref+':mxp/mxpCloseAtomic.cpp'],cwd=ROOT,text=True) if a.baseline_ref else (ROOT/'mxp/mxpCloseAtomic.cpp').read_text())
- prepare=(ROOT/'mxp/mxpClose.cpp').read_text();header=(ROOT/'OtherTypes.h').read_text()
- assert 'iFirstContentLineCreationNumber (0)' in header and 'preparedClose = CPreparedMXPClose ();' in prepare
+ def read(path):
+  if a.baseline_ref:
+   return subprocess.check_output(['git','show',a.baseline_ref+':'+path],cwd=ROOT,text=True)
+  return (ROOT/path).read_text()
+ source=read('mxp/mxpCloseAtomic.cpp')
+ prepare=read('mxp/mxpClose.cpp');header=read('OtherTypes.h')
+ for path,text,marker in [('OtherTypes.h',header,'iFirstContentLineCreationNumber (0)'),('mxp/mxpClose.cpp',prepare,'preparedClose = CPreparedMXPClose ();')]:
+  if marker not in text:
+   raise ValueError(f'{a.baseline_ref or "working tree"}:{path}: required close-range marker not found: {marker!r}')
  start=prepare.index('        if (contentStyleRangeNumbers.empty ())')
  end=prepare.index('contentStyleRangeNumbers.insert (pStyle2->nRangeCreationNumber);',start)+len('contentStyleRangeNumbers.insert (pStyle2->nRangeCreationNumber);')
  capture=prepare[start:end]

--- a/tests/check_mxp_close_ranges.py
+++ b/tests/check_mxp_close_ranges.py
@@ -1,0 +1,135 @@
+"""Check saved MXP close ranges, action publication, and traversal cost.
+Uses production close-action and capture statements with portable MFC substitutes.
+"""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+ROOT=Path(__file__).resolve().parents[1]
+PREFIX = r'''
+#include <cassert>
+#include <stdexcept>
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+using namespace std;
+using __int64=long long; using COLORREF=unsigned; using POSITION=size_t;
+inline constexpr int ACTIONTYPE=3, START_TAG=4, COLOURTYPE=24, COLOUR_RGB=16, UNDERLINE=32;
+struct CString: string { using string::string; CString(const string &s):string(s){} CString()=default;
+bool IsEmpty()const{return empty();} void Replace(const char *from,const CString &to){size_t pos=0;while((pos=find(from,pos))!=npos){replace(pos,string(from).size(),to);pos+=to.size();}} };
+int actionsAlive=0;
+struct CAction { CAction(){++actionsAlive;} ~CAction(){--actionsAlive;} CString m_strAction,m_strHint,m_strVariable; int refs=1;
+void AddRef(){++refs;} void Release(){if(!--refs) delete this;} };
+struct CStyle { __int64 nRangeCreationNumber=0; unsigned short iFlags=0; COLORREF iForeColour=0,iBackColour=0;CAction *pAction=nullptr;~CStyle(){if(pAction)pAction->Release();} };
+template<class T>struct List { vector<T*> items; size_t visits=0; POSITION GetHeadPosition(){return items.empty()?0:1;} POSITION GetTailPosition(){return items.size();} T*GetPrev(POSITION &p){++visits;return items.at(--p);} T*GetNext(POSITION &p){++visits;auto v=items.at(p-1);p=p<items.size()?p+1:0;return v;} };
+struct CLine { __int64 nCreationNumber=0; List<CStyle> styleList; };
+struct CPreparedMXPClose { __int64 iFirstContentLineCreationNumber=0; CString strText;set<__int64> contentStyleRangeNumbers; };
+'''
+COMMON = r'''
+struct Fixture {
+int actionCalls=0,failActionAt=0;vector<CString> actionOrder;
+List<CLine> m_LineList;
+bool m_bUseCustomLinkColour=false,m_bMudCanChangeLinkColour=false,m_bUnderlineHyperlinks=false,m_bMudCanRemoveUnderline=false;
+COLORREF m_iHyperlinkColour=0;
+void GetStyleRGB(CStyle *s,COLORREF &a,COLORREF &b){a=s->iForeColour;b=s->iBackColour;}
+CAction *GetAction(const CString&a,const CString&b,const CString&c){if(++actionCalls==failActionAt)throw runtime_error("action allocation");actionOrder.push_back(a);auto*p=new CAction;p->m_strAction=a;p->m_strHint=b;p->m_strVariable=c;return p;}
+void close(const CPreparedMXPClose &preparedClose){
+POSITION linepos,stylepos;
+const CString &strText=preparedClose.strText;
+'''
+MAIN = r'''
+}};
+struct World:Fixture {
+vector<unique_ptr<CLine>> lines;vector<unique_ptr<CStyle>> styles;
+CLine* line(long long id){auto l=make_unique<CLine>();l->nCreationNumber=id;auto*p=l.get();m_LineList.items.push_back(p);lines.push_back(std::move(l));return p;}
+CStyle* style(CLine*l,long long range,bool active=true){auto s=make_unique<CStyle>();s->nRangeCreationNumber=range;s->iFlags=active?ACTIONTYPE:0;auto*p=s.get();l->styleList.items.push_back(p);styles.push_back(std::move(s));return p;}
+void resetCounts(){m_LineList.visits=0;for(auto&l:lines)l->styleList.visits=0;}
+size_t styleVisits(){size_t n=0;for(auto&l:lines)n+=l->styleList.visits;return n;}
+};
+void capture(CPreparedMXPClose& preparedClose,CLine*pLine2,CStyle*pStyle2){
+auto&contentStyleRangeNumbers=preparedClose.contentStyleRangeNumbers;
+@CAPTURE@
+}
+int main(){
+for(int n:{1000,10000,100000}){
+ World w;CStyle*target=nullptr;
+ for(int i=1;i<=n;++i)target=w.style(w.line(i),i,i==n);
+ CPreparedMXPClose p;p.strText="north";capture(p,w.lines.back().get(),target);
+ w.resetCounts();w.close(p);
+ assert(target->pAction&&target->pAction->m_strAction=="north");
+ assert(w.styleVisits()==(EXPECT_HISTORY_SCAN?size_t(n):size_t(1)));
+ for(int i=0;i<n-1;++i)assert(w.styles[i]->pAction==nullptr);
+ cout<<"history="<<n<<" line_visits="<<w.m_LineList.visits<<" style_visits="<<w.styleVisits()<<'\n';
+}
+assert(actionsAlive==0);
+{
+ World w;auto*first=w.line(0);auto*a=w.style(first,5);auto*next=w.line(10);auto*b=w.style(next,6);
+ CPreparedMXPClose p;p.strText="zero";capture(p,first,a);capture(p,next,b);
+ assert(p.iFirstContentLineCreationNumber==0);w.close(p);assert(a->pAction&&b->pAction);
+}
+assert(actionsAlive==0);
+for(bool prune:{false,true}){
+ World w;auto*history=w.line(10);auto*unrelated=w.style(history,90);
+ auto*first=w.line(20);auto*a=w.style(first,100);
+ auto*second=w.line(30);auto*b=w.style(second,101);
+ CPreparedMXPClose p;p.strText="text";capture(p,first,a);capture(p,second,b);assert(p.iFirstContentLineCreationNumber==20);
+ // Split a saved logical range onto a later line. New callback ranges stay out.
+ auto*later=w.line(40);auto*split=w.style(later,101);auto*callback=w.style(later,102);
+ if(prune){w.m_LineList.items.erase(w.m_LineList.items.begin()+1);}
+ // Move a saved style forward without changing its logical range.
+ second->styleList.items.clear();later->styleList.items.push_back(b);
+ w.close(p);
+ assert(!unrelated->pAction&&!callback->pAction);
+ assert(b->pAction&&split->pAction);
+ assert(bool(a->pAction)==!prune);
+ assert(w.actionCalls==(prune?2:3));
+}
+assert(actionsAlive==0);
+for(int fail:{1,2}){
+ World w;auto*l=w.line(10);auto*a=w.style(l,1);auto*b=w.style(l,2);
+ a->pAction=w.GetAction("a &text;","hint &text;","var");b->pAction=w.GetAction("b &text;","hint &text;","var");
+ CAction*oldA=a->pAction;CAction*oldB=b->pAction;
+ CPreparedMXPClose p;p.strText="ok";capture(p,l,a);capture(p,l,b);
+ w.m_bUseCustomLinkColour=true;w.m_bUnderlineHyperlinks=true;w.m_iHyperlinkColour=99;
+ w.actionCalls=0;w.actionOrder.clear();w.failActionAt=fail;bool caught=false;
+ try{w.close(p);}catch(const runtime_error&){caught=true;}
+ assert(caught&&a->pAction==oldA&&b->pAction==oldB&&actionsAlive==2);
+ assert(a->iFlags==ACTIONTYPE&&b->iFlags==ACTIONTYPE);
+ w.failActionAt=0;w.actionCalls=0;w.actionOrder.clear();w.close(p);
+ assert(w.actionOrder.size()==2&&w.actionOrder[0]=="a ok"&&w.actionOrder[1]=="b ok");
+ assert(a->pAction->m_strHint=="hint ok"&&a->pAction->m_strVariable=="var");
+ assert((a->iFlags&UNDERLINE)&&a->iForeColour==99);
+}
+assert(actionsAlive==0);
+{
+ World w;auto*l=w.line(10);auto*s=w.style(l,1);CPreparedMXPClose p;p.strText="none";
+ w.close(p);assert(!s->pAction&&w.styleVisits()==(EXPECT_HISTORY_SCAN?1:0));
+ // A removed first identity must not prevent a surviving newer range.
+ auto*next=w.line(20);auto*survives=w.style(next,2);capture(p,l,s);capture(p,next,survives);
+ w.m_LineList.items.erase(w.m_LineList.items.begin());w.close(p);assert(survives->pAction&&!s->pAction);
+}
+assert(actionsAlive==0);
+cout<<"PASS close range capture, split/move, pruning, callback exclusion, staged failure and action order\n";
+}
+'''
+
+def main():
+ p=argparse.ArgumentParser(description=__doc__);p.add_argument('--output',type=Path);p.add_argument('--baseline-ref');a=p.parse_args()
+ out=a.output or Path(tempfile.mkdtemp(prefix='mxp-close-'));out.mkdir(parents=True,exist_ok=True)
+ source=(subprocess.check_output(['git','show',a.baseline_ref+':mxp/mxpCloseAtomic.cpp'],cwd=ROOT,text=True) if a.baseline_ref else (ROOT/'mxp/mxpCloseAtomic.cpp').read_text())
+ prepare=(ROOT/'mxp/mxpClose.cpp').read_text();header=(ROOT/'OtherTypes.h').read_text()
+ assert 'iFirstContentLineCreationNumber (0)' in header and 'preparedClose = CPreparedMXPClose ();' in prepare
+ start=prepare.index('        if (contentStyleRangeNumbers.empty ())')
+ end=prepare.index('contentStyleRangeNumbers.insert (pStyle2->nRangeCreationNumber);',start)+len('contentStyleRangeNumbers.insert (pStyle2->nRangeCreationNumber);')
+ capture=prepare[start:end]
+ start=source.index('    case MXP_ACTION_HYPERLINK:')+len('    case MXP_ACTION_HYPERLINK:');end=source.index('      break;  // end of MXP_ACTION_SEND',start)
+ block=source[start:end];staged=source[source.index('struct CStagedMXPActionStyle'):source.index('// do the action required')]
+ cpp=out/'mxp_close.cpp';cpp.write_text('#define EXPECT_HISTORY_SCAN '+str(int(bool(a.baseline_ref)))+'\n'+PREFIX+staged+COMMON+'const set<__int64> &contentStyleRangeNumbers=preparedClose.contentStyleRangeNumbers;\n'+block+MAIN.replace('@CAPTURE@',capture))
+ exe=out/'mxp_close';subprocess.run(['clang++','-std=c++17','-Wall','-Wextra','-Werror','-O1','-g','-fsanitize=address,undefined',str(cpp),'-o',str(exe)],check=True)
+ result=subprocess.run([str(exe)],text=True,capture_output=True);(out/'run.log').write_text(result.stdout+result.stderr);print(result.stdout+result.stderr,end='');result.check_returncode()
+ (out/'result.json').write_text(json.dumps({'source':a.baseline_ref or 'working tree','output':result.stdout,'passed':True,'limitation':'Extracted close/capture code with MFC/action substitutes. No native timing claim.'},indent=2)+'\n')
+if __name__=='__main__':main()

--- a/tests/check_mxp_locale.py
+++ b/tests/check_mxp_locale.py
@@ -1,0 +1,30 @@
+"""Check that xgettext extracts both shared MXP close warning formats."""
+import argparse
+from pathlib import Path
+import subprocess
+
+
+FORMATS = (
+    'End-of-line closure of open MXP tag: <%s>',
+    '<reset> closure of MXP tag: <%s>',
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--source', type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--xgettext', default='xgettext')
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    catalog = args.output / 'mxp_close.po'
+    subprocess.run([args.xgettext, '--language=C++', '--keyword=TFormat',
+                    '--output', str(catalog), str(args.source / 'mxp/mxpClose.cpp')], check=True)
+    extracted = catalog.read_text()
+    for message in FORMATS:
+        assert 'msgid "' + message + '"' in extracted, f'{catalog}: missing format: {message!r}'
+    print('PASS xgettext extracts both MXP close warning formats')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_mxp_start_identities.py
+++ b/tests/check_mxp_start_identities.py
@@ -38,7 +38,8 @@ def main():
     packet_names = ['VERSION', 'AFK', 'SUPPORT', 'OPTION', 'USER', 'PASSWORD']
     packet_cases = []
     for name in packet_names:
-        case = between(atomic, '    case MXP_ACTION_' + name + ':', '          break;', 'mxp/mxpOpenAtomic.cpp') if name in ['VERSION', 'AFK', 'SUPPORT'] else atomic[atomic.index('    case MXP_ACTION_' + name + ':'):]
+        case = between(atomic, '    case MXP_ACTION_' + name + ':',
+                       '          break;', 'mxp/mxpOpenAtomic.cpp: ' + name)
         # Keep the exact packet call and its deferred diagnostic. Packet building
         # and option/credential gates are outside this lifetime reproduction.
         match = re.search(r'            SendPacket \((\w+),.*?\);[^\n]*\n(.*?);', case, re.S)

--- a/tests/check_mxp_start_identities.py
+++ b/tests/check_mxp_start_identities.py
@@ -1,0 +1,80 @@
+"""Compile MXP source excerpts with portable callback and MFC substitutes.
+
+Run: python3 tests/check_mxp_start_identities.py --output /path/to/results
+Requires clang++ with AddressSanitizer. This is not a native MFC build.
+"""
+import argparse
+import os
+from pathlib import Path
+import re
+import subprocess
+
+
+def between(text, first, last, label):
+    start = text.find(first)
+    if start < 0:
+        raise ValueError(f'{label}: start marker not found: {first!r}')
+    stop = text.find(last, start)
+    if stop < 0:
+        raise ValueError(f'{label}: end marker not found: {last!r}')
+    return text[start:stop]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--source', type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    start = (args.source / 'mxp/mxpStart.cpp').read_text()
+    atomic = (args.source / 'mxp/mxpOpenAtomic.cpp').read_text()
+    doc = (args.source / 'doc.cpp').read_text()
+    header = (args.source / 'doc.h').read_text()
+    declaration = between(header, '  bool MXP_OpenAtomicTag', '  void MXP_CloseAtomicTag', 'doc.h')
+    assert '__int64 & iResultStyleCreationNumber' in declaration
+    assert start.count('transaction.ResolveStyle (iAtomicResultStyleCreationNumber)') == 2
+    assert start.count('                            iAtomicResultStyleCreationNumber,') == 2
+    assert 'CStyle * & pResultStyle' not in atomic
+    packet_names = ['VERSION', 'AFK', 'SUPPORT', 'OPTION', 'USER', 'PASSWORD']
+    packet_cases = []
+    for name in packet_names:
+        case = between(atomic, '    case MXP_ACTION_' + name + ':', '          break;', 'mxp/mxpOpenAtomic.cpp') if name in ['VERSION', 'AFK', 'SUPPORT'] else atomic[atomic.index('    case MXP_ACTION_' + name + ':'):]
+        # Keep the exact packet call and its deferred diagnostic. Packet building
+        # and option/credential gates are outside this lifetime reproduction.
+        match = re.search(r'            SendPacket \((\w+),.*?\);[^\n]*\n(.*?);', case, re.S)
+        assert match, name
+        call = match.group(0)
+        variable = match.group(1)
+        packet_cases.append('case MXP_ACTION_' + name + ': {\nCString ' + variable + ' = "response-' + name + '\\r\\n";\n' + call + '\nbreak; }')
+    pieces = {
+        'TRANSACTION': between(start, 'class CMXPStartTransaction', 'class CActionReferenceGuard', 'mxp/mxpStart.cpp'),
+        'FINALIZATION': between(start, '  // atomic element?  (looked-up earlier)', '  } // end of CMUSHclientDoc::MXP_StartTag', 'mxp/mxpStart.cpp'),
+        'SEND_PACKET': between(doc, 'void  CMUSHclientDoc::SendPacket (const char *', 'void  CMUSHclientDoc::SendPacket (const unsigned char *', 'doc.cpp'),
+        'REMEMBER_STYLE': between(doc, 'void CMUSHclientDoc::RememberStyle (', 'void CMUSHclientDoc::OnDebugWorldInput', 'doc.cpp'),
+        'PREPARE_STYLE': between(doc, 'void COutputAppendTransaction::TrackLine (', 'void COutputAppendTransaction::RecordCreatedLine ()', 'doc.cpp'),
+        'RESULT_INIT': between(atomic, 'unsigned short iFlags', '// find current foreground', 'mxp/mxpOpenAtomic.cpp'),
+        'PACKET_CASES': '\n'.join(packet_cases),
+        'BR_CASE': between(atomic, '    case MXP_ACTION_BR:', '          // reset', 'mxp/mxpOpenAtomic.cpp'),
+        'HR_CASE': between(atomic, '    case MXP_ACTION_HR:', '    case MXP_ACTION_PRE:', 'mxp/mxpOpenAtomic.cpp'),
+        'LI_CASE': between(atomic, '     case MXP_ACTION_LI:', '    // pueblo tags', 'mxp/mxpOpenAtomic.cpp'),
+        'IMAGE_RESULT': between(atomic, '            CStyle * pResultStyle = AddStyle', '            strAction = strOldAction;', 'mxp/mxpOpenAtomic.cpp'),
+    }
+    template = Path(__file__).with_name('mxp_start_identity_test.cpp.in').read_text()
+    for key, value in pieces.items():
+        token = '@' + key + '@'
+        assert template.count(token) == 1, token
+        template = template.replace(token, value)
+    names = sorted(set(re.findall(r'\b(?:MXP_ACTION_\w+|infoMXP_\w+|wrnMXP_\w+)\b', template)))
+    template = template.replace('@ENUMS@', 'enum { ' + ', '.join(names) + ' };')
+    cpp = args.output / 'mxp_start_identity_test.cpp'
+    cpp.write_text(template)
+    executable = args.output / 'mxp_start_identity_test'
+    command = ['clang++', '-std=c++17', '-g', '-O1', '-fsanitize=address,undefined', '-fno-omit-frame-pointer', str(cpp), '-o', str(executable)]
+    subprocess.run(command, check=True)
+    env = dict(os.environ)
+    # Keep diagnostics visible. A failed compile or check stops this runner.
+    subprocess.run([str(executable)], check=True, env=env)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/check_mxp_start_identities.py
+++ b/tests/check_mxp_start_identities.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import re
 import subprocess
 
+from output_callbacks import replace_once
+
 
 def between(text, first, last, label):
     start = text.find(first)
@@ -29,6 +31,9 @@ def main():
     start = (args.source / 'mxp/mxpStart.cpp').read_text()
     atomic = (args.source / 'mxp/mxpOpenAtomic.cpp').read_text()
     doc = (args.source / 'doc.cpp').read_text()
+    close = (args.source / 'mxp/mxpClose.cpp').read_text()
+    close_atomic = (args.source / 'mxp/mxpCloseAtomic.cpp').read_text()
+    close_atomic = close_atomic[close_atomic.index('void CMUSHclientDoc::MXP_CloseAtomicTag ('):]
     header = (args.source / 'doc.h').read_text()
     declaration = between(header, '  bool MXP_OpenAtomicTag', '  void MXP_CloseAtomicTag', 'doc.h')
     assert '__int64 & iResultStyleCreationNumber' in declaration
@@ -49,8 +54,26 @@ def main():
         packet_cases.append('case MXP_ACTION_' + name + ': {\nCString ' + variable + ' = "response-' + name + '\\r\\n";\n' + call + '\nbreak; }')
     pieces = {
         'TRANSACTION': between(start, 'class CMXPStartTransaction', 'class CActionReferenceGuard', 'mxp/mxpStart.cpp'),
+        'CUSTOM_PREPARATION': between(start,
+            '    for (POSITION itempos = pElement->ElementItemList.GetHeadPosition ();',
+            '    if (m_iMXPGeneration != iOpeningMXPGeneration || !m_bMXP)', 'mxp/mxpStart.cpp'),
+        'CLOSE_ACTIONS': between(start,
+            '    if (pAtomicElement)\n      pTag->closeActions.push_back',
+            '    m_ActiveTagList.AddTail', 'mxp/mxpStart.cpp'),
+        'PARAGRAPH_OPEN': between(atomic, '    case MXP_ACTION_P:',
+            '          // new line', 'mxp/mxpOpenAtomic.cpp'),
+        'LIST_OPEN': between(atomic, '    case MXP_ACTION_PRE:',
+            '     case MXP_ACTION_LI:', 'mxp/mxpOpenAtomic.cpp'),
+        'PARAGRAPH_LIST_CLOSE': between(close_atomic, '    case MXP_ACTION_P:',
+            '      case MXP_ACTION_VAR:', 'mxp/mxpCloseAtomic.cpp'),
+        'CLOSE_DISPATCH': between(close,
+            '  // Keep the original callback-before-close-action order.',
+            '  } // end of CMUSHclientDoc::MXP_FinishCloseTag', 'mxp/mxpClose.cpp'),
         'FINALIZATION': between(start, '  // atomic element?  (looked-up earlier)', '  } // end of CMUSHclientDoc::MXP_StartTag', 'mxp/mxpStart.cpp'),
         'SEND_PACKET': between(doc, 'void  CMUSHclientDoc::SendPacket (const char *', 'void  CMUSHclientDoc::SendPacket (const unsigned char *', 'doc.cpp'),
+        'NOTE_ADD_STYLE': replace_once(between(doc,
+            'CStyle * CMUSHclientDoc::AddStyle (', '// adds a new style to the current line', 'doc.cpp'),
+            'CStyle * CMUSHclientDoc::AddStyle (', 'CStyle * CMUSHclientDoc::NoteStyle (', 'doc.cpp'),
         'REMEMBER_STYLE': between(doc, 'void CMUSHclientDoc::RememberStyle (', 'void CMUSHclientDoc::OnDebugWorldInput', 'doc.cpp'),
         'PREPARE_STYLE': between(doc, 'void COutputAppendTransaction::TrackLine (', 'void COutputAppendTransaction::RecordCreatedLine ()', 'doc.cpp'),
         'RESULT_INIT': between(atomic, 'unsigned short iFlags', '// find current foreground', 'mxp/mxpOpenAtomic.cpp'),
@@ -70,7 +93,7 @@ def main():
     cpp = args.output / 'mxp_start_identity_test.cpp'
     cpp.write_text(template)
     executable = args.output / 'mxp_start_identity_test'
-    command = ['clang++', '-std=c++17', '-g', '-O1', '-fsanitize=address,undefined', '-fno-omit-frame-pointer', str(cpp), '-o', str(executable)]
+    command = ['clang++', '-std=c++17', '-g', '-O1', '-fsanitize=address,undefined', '-fno-sanitize-recover=all', '-fno-omit-frame-pointer', str(cpp), '-o', str(executable)]
     subprocess.run(command, check=True)
     env = dict(os.environ)
     # Keep diagnostics visible. A failed compile or check stops this runner.

--- a/tests/check_option_and_plugin_reload.py
+++ b/tests/check_option_and_plugin_reload.py
@@ -89,10 +89,14 @@ void AfxThrowMemoryException(){throw new CMemoryException;}
 '''
     # Inject only the allocator. Keep production ResizeText publication ordering.
     resize = block(read('Line.cpp'), 'void CLine::ResizeText (')
-    resize = resize.replace('new char [iNewSize]', 'allocateLineText(iNewSize)')
+    resize = replace_once(resize, 'new char [iNewSize]',
+                          'allocateLineText(iNewSize)', 'Line.cpp')
     base = block(source, 'long SetBaseOptionItem (')
     # Windows long has four bytes; the macOS/Linux host long can have eight.
-    base = base.replace('(long *)', '(int32_t *)')
+    base = replace_once(base, 'if (* (long *) p != Value)',
+                        'if (* (int32_t *) p != Value)', 'scriptingoptions.cpp')
+    base = replace_once(base, '* (long *) p = Value;',
+                        '* (int32_t *) p = Value;', 'scriptingoptions.cpp')
     body = base + block(source, 'long CMUSHclientDoc::SetOptionItem (')
     for start, end in [
         ('bool CMUSHclientDoc::StartNewLine_KeepPreviousStyle', 'COutputAppendTransaction::COutputAppendTransaction'),

--- a/tests/check_option_and_plugin_reload.py
+++ b/tests/check_option_and_plugin_reload.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Check UTF-8 option changes and plugin reloads with extracted production code.
+
+Requires Python 3 and clang++. MFC, plugin loading, and Windows text conversion
+use substitutes. This does not test a native Windows build.
+"""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def block(text, start):
+    begin = text.index(start)
+    brace = text.index('{', begin)
+    depth = 0
+    for end in range(brace, len(text)):
+        depth += (text[end] == '{') - (text[end] == '}')
+        if depth == 0:
+            return text[begin:end + 1]
+    raise ValueError(start)
+
+
+def section(text, start, end):
+    begin = text.index(start)
+    return text[begin:text.index(end, begin)]
+
+
+def utf8_program(read):
+    source = read('scriptingoptions.cpp')
+    doc = read('doc.cpp')
+    shim = read('tests/output_test_shim.h')
+    # Use the actual option field size and the Windows MAX macro semantics.
+    shim = shim.replace('#define MAX std::max', '#define MAX(a,b) ((a)>(b)?(a):(b))')
+    shim = shim.replace('bool m_bUTF_8=false,m_wrap=true,',
+                        'unsigned short m_bUTF_8=false;bool m_wrap=true,')
+    resize = block(shim, ' void ResizeText(int n)')
+    shim = shim.replace(resize, ' void ResizeText(int);')
+    shim = shim.replace('struct CMUSHView:CView {', '''
+struct CMUSHView:CView {
+ struct {bool m_hWnd=false;void SendMessage(int,int,int){assert(false);}} m_ToolTip;
+''')
+    declarations = r'''
+ unsigned short otherOption=0;
+ int modified=0,windowSizes=0,inputWraps=0;
+ struct Config {bool bInclude=false;long iValue=0;} config;
+ Config* m_NumericConfiguration[3]={&config,&config,&config};
+ void SetModifiedFlag(){++modified;}void SendWindowSizes(long){++windowSizes;}
+ void FixUpOutputBuffer(long){assert(false);}void FixInputWrap(){++inputWraps;}
+ void SetSpeedWalkDelay(short){assert(false);}
+ int m_iUseMXP=0;bool m_bMXP=false;
+ void MXP_Off(bool){assert(false);}void MXP_On(bool,bool){assert(false);}
+ int m_input_font_height=0,m_input_font_weight=0,m_input_font_charset=0;
+ bool m_input_font_italic=false;CString m_input_font_name;
+ int m_font_height=0,m_font_weight=0,m_font_charset=0,m_iLineSpacing=0;
+ CString m_font_name;bool m_bShowBold=false,m_bShowItalic=false,m_bShowUnderline=false;
+ template<class... T>void ChangeInputFont(T...){assert(false);}
+ template<class... T>void ChangeFont(T...){assert(false);}
+ void UpdateAllViews(void*){assert(false);}
+ long SetOptionItem(int,long,bool,bool);
+'''
+    shim = shim.replace(' struct CTriggerLineSnapshot', declarations + '\n struct CTriggerLineSnapshot')
+    header = read('doc.h')
+    flags = section(header, '#define OPT_CUSTOM_COLOUR', '// for debug.options')
+    options = r'''
+#define NUMITEMS(x) (sizeof(x)/sizeof((x)[0]))
+enum {eOK,eUnknownOption,eOptionOutOfRange};
+enum {eNoMXP,eUseMXP,TTM_SETDELAYTIME,TTDT_AUTOPOP,TTDT_INITIAL};
+struct tConfigurationNumericOption {
+ const char* pName;double iDefault;size_t iOffset,iLength;int iMinimum,iMaximum,iFlags;
+};
+#define O(arg) offsetof(CMUSHclientDoc,arg),sizeof(((CMUSHclientDoc*)0)->arg)
+tConfigurationNumericOption OptionsTable[]={
+ {"utf_8",false,O(m_bUTF_8),0,0,0},
+ {"other",false,O(otherOption),0,0,0},
+ {"wrap_column",80,O(m_nWrapColumn),20,500,OPT_FIX_WRAP_COLUMN|OPT_FIX_INPUT_WRAP}
+};
+bool failResize=false;int resizes=0;
+char* allocateLineText(int size) {
+ ++resizes;if(failResize)throw new CMemoryException;
+ return new char[size];
+}
+void AfxThrowMemoryException(){throw new CMemoryException;}
+'''
+    # Inject only the allocator. Keep production ResizeText publication ordering.
+    resize = block(read('Line.cpp'), 'void CLine::ResizeText (')
+    resize = resize.replace('new char [iNewSize]', 'allocateLineText(iNewSize)')
+    base = block(source, 'long SetBaseOptionItem (')
+    # Windows long has four bytes; the macOS/Linux host long can have eight.
+    base = base.replace('(long *)', '(int32_t *)')
+    body = base + block(source, 'long CMUSHclientDoc::SetOptionItem (')
+    for start, end in [
+        ('bool CMUSHclientDoc::StartNewLine_KeepPreviousStyle', 'COutputAppendTransaction::COutputAppendTransaction'),
+        ('bool CMUSHclientDoc::AddToLine (', '// called when starting a new line to get colours right'),
+        ('bool CMUSHclientDoc::StartNewLine (', 'const bool CMUSHclientDoc::CheckScriptingAvailable'),
+        (' void CMUSHclientDoc::RemoveChunk (void)', 'void CMUSHclientDoc::ShowStatusLine'),
+    ]:
+        body += section(doc, start, end)
+    main = r'''
+int main() {
+ // At byte 79, each multibyte character must stay on the first line.
+ for(const string& character:{string("\xc2\xa2"),string("\xe2\x82\xac"),string("\xf0\x9f\x98\x80")}) {
+  CMUSHclientDoc d;string prefix(79,'A');assert(d.AddToLine(prefix.c_str(),0));
+  CLine* first=d.m_pCurrentLine;
+  assert(d.SetOptionItem(0,1,true,false)==eOK);
+  assert(d.AddToLine(character.c_str(),0));
+  assert(d.m_pCurrentLine==first && d.m_LineList.GetCount()==1);
+  assert(string(first->text,first->len)==prefix+character);
+  assert(d.SetOptionItem(0,1,true,false)==eOK);
+  assert(d.AddToLine("Z",0));assert(d.m_LineList.GetCount()==2);
+  assert(string(first->text,first->len)==prefix+character);
+ }
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("saved",0));
+  char* original=d.m_pCurrentLine->text;int size=d.m_pCurrentLine->iMemoryAllocated;
+  failResize=true;bool caught=false;
+  try{d.SetOptionItem(0,1,true,true);}catch(CMemoryException* e){caught=true;e->Delete();}
+  failResize=false;assert(caught && !d.m_bUTF_8 && !d.modified && !d.config.bInclude);
+  assert(d.m_pCurrentLine->text==original && d.m_pCurrentLine->iMemoryAllocated==size);
+  assert(string(original,d.m_pCurrentLine->len)=="saved");
+  assert(d.SetOptionItem(0,1,true,true)==eOK && d.m_bUTF_8);
+  assert(d.config.bInclude && d.config.iValue==1);
+  int allocations=resizes;d.modified=0;
+  assert(d.SetOptionItem(0,1,true,false)==eOK && resizes==allocations && !d.modified);
+  assert(d.SetOptionItem(0,0,true,false)==eOK && resizes==allocations);
+  assert(d.m_pCurrentLine->iMemoryAllocated==320 && !d.m_bUTF_8);
+  assert(d.SetOptionItem(1,1,true,false)==eOK && resizes==allocations);
+  assert(d.SetOptionItem(-1,1,true,false)==eUnknownOption);
+  assert(d.SetOptionItem(3,1,true,false)==eUnknownOption);
+  assert(d.SetOptionItem(0,2,true,false)==eOptionOutOfRange && resizes==allocations);
+  assert(d.SetOptionItem(0,1,false,false)==eOK && resizes==allocations);
+  assert(d.SetOptionItem(2,40,true,false)==eOK);
+  assert(d.m_pCurrentLine->iMemoryAllocated==160 && d.windowSizes==1 && d.inputWraps==1);
+ }
+ {
+  CMUSHclientDoc d;d.m_pCurrentLine=nullptr;
+  assert(d.SetOptionItem(0,1,true,false)==eOK && d.m_bUTF_8);
+ }
+ {
+  CMUSHclientDoc d;d.m_pCurrentLine->ResizeText(400);
+  int allocations=resizes;assert(d.SetOptionItem(0,1,true,false)==eOK);
+  assert(d.m_pCurrentLine->iMemoryAllocated==400 && resizes==allocations);
+ }
+ cout<<"UTF-8: 2/3/4-byte boundary appends, allocation failure/retry, option validation, disable/repeat, missing line, existing capacity, and wrap change passed\n";
+}
+'''
+    return shim + flags + options + resize + body + main
+
+
+def plugin_program(read):
+    methods = read('scripting/methods/methods_plugins.cpp')
+    plugins = read('plugins.cpp')
+    prefix = r'''
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <list>
+#include <stdexcept>
+#include <string>
+using namespace std;
+using LPCTSTR=const char*;
+#define ASSERT assert
+#define TRUE true
+#define NORMAL 0
+struct CString:string {
+ using string::string;CString(const string& s):string(s){}
+ void Empty(){clear();}
+};
+enum {eOK,eNoSuchPlugin,eBadParameter,ePluginFileNotFound,eProblemsLoadingPlugin};
+const string ON_PLUGIN_LIST_CHANGED="OnPluginListChanged";
+struct CFileException{static int deleted;void Delete(){++deleted;delete this;}};
+struct CArchiveException{static int deleted;void Delete(){++deleted;delete this;}};
+int CFileException::deleted=0;int CArchiveException::deleted=0;
+struct CPlugin {
+ static int deleted;CString m_strSource="plugin.xml",m_strID="id",m_strName="name",m_strCallingPluginID;
+ int m_iActiveScriptCalls=0;~CPlugin(){++deleted;}
+};
+int CPlugin::deleted=0;
+using PluginListIterator=list<CPlugin*>::iterator;
+struct compare_plugin_name {
+ bool operator()(CPlugin* p,LPCTSTR name)const{return p->m_strName==name;}
+};
+template<class F,class A>auto bind2nd(F f,A a){return [=](CPlugin* p){return f(p,a);};}
+struct CMUSHclientDoc {
+ CPlugin* m_CurrentPlugin=nullptr;unsigned short m_iNoteStyle=17;
+ list<CPlugin*>m_PluginList;int mode=0,modified=0,events=0,loads=0;
+ bool m_bInPluginListChanged=false,m_bPluginListChangedPending=false,m_bPluginListChangedDeferred=false;
+ int m_iPluginListChangedDeferralDepth=0;function<void()> observer;
+ ~CMUSHclientDoc(){for(auto* p:m_PluginList)delete p;}
+ CPlugin* GetPlugin(LPCTSTR id){for(auto* p:m_PluginList)if(p->m_strID==id)return p;return nullptr;}
+ void InternalLoadPlugin(const CString& name){
+  ++loads;assert(m_CurrentPlugin==nullptr && name=="plugin.xml");
+  if(mode==1)throw new CFileException;
+  if(mode==2)throw new CArchiveException;
+  if(mode==3)throw runtime_error("unexpected load failure");
+  m_PluginList.push_back(new CPlugin);SetModifiedFlag(TRUE);
+ }
+ void SetModifiedFlag(bool){++modified;}
+ void SendToAllPluginCallbacks(const string& name){assert(name==ON_PLUGIN_LIST_CHANGED);++events;observer();}
+ void PluginListChanged();long ReloadPlugin(LPCTSTR);
+};
+'''
+    guard = block(read('plugins.h'), 'class CPluginContextGuard') + ';\n'
+    body = block(plugins, 'CPluginContextGuard::CPluginContextGuard (')
+    body += block(plugins, 'CPluginContextGuard::~CPluginContextGuard ()')
+    body += block(plugins, 'void  CMUSHclientDoc::PluginListChanged (')
+    body += block(methods, 'long CMUSHclientDoc::ReloadPlugin(')
+    main = r'''
+int main(){
+ for(int mode=0;mode<3;++mode)for(bool callerContext:{false,true})for(bool byName:{false,true}){
+  CMUSHclientDoc d;CPlugin caller;d.m_CurrentPlugin=callerContext?&caller:nullptr;
+  auto* expectedContext=d.m_CurrentPlugin;d.mode=mode;d.m_PluginList.push_back(new CPlugin);
+  int deleted=CPlugin::deleted,files=CFileException::deleted,archives=CArchiveException::deleted;
+  d.observer=[&]{
+   assert(d.m_CurrentPlugin==expectedContext && d.m_iNoteStyle==17 && d.modified==1);
+   assert(d.m_PluginList.size()==(mode?0:1));assert(CPlugin::deleted==deleted+1);
+  };
+  long result=d.ReloadPlugin(byName?"name":"id");
+  assert(result==(mode==1?ePluginFileNotFound:mode==2?eProblemsLoadingPlugin:eOK));
+  assert(d.events==1 && d.loads==1 && d.modified==1 && d.m_CurrentPlugin==expectedContext);
+  assert(CFileException::deleted==files+(mode==1));
+  assert(CArchiveException::deleted==archives+(mode==2));
+ }
+ for(int guard=0;guard<3;++guard){
+  CMUSHclientDoc d;auto* target=new CPlugin;d.m_PluginList.push_back(target);
+  if(guard==1)d.m_CurrentPlugin=target;if(guard==2)target->m_iActiveScriptCalls=1;
+  assert(d.ReloadPlugin(guard==0?"missing":"id")== (guard==0?eNoSuchPlugin:eBadParameter));
+  assert(d.loads==0 && d.events==0 && !d.modified && d.m_PluginList.size()==1);
+ }
+ {
+  CMUSHclientDoc d;CPlugin caller;d.m_CurrentPlugin=&caller;d.mode=1;
+  d.m_PluginList.push_back(new CPlugin);d.m_iPluginListChangedDeferralDepth=1;
+  assert(d.ReloadPlugin("id")==ePluginFileNotFound);
+  assert(d.modified==1 && d.events==0 && d.m_bPluginListChangedDeferred && d.m_CurrentPlugin==&caller);
+ }
+ {
+  CMUSHclientDoc d;CPlugin caller;d.m_CurrentPlugin=&caller;d.mode=2;d.m_PluginList.push_back(new CPlugin);
+  d.observer=[&]{assert(d.m_CurrentPlugin==&caller && d.modified==1);throw runtime_error("notification failure");};
+  bool caught=false;try{d.ReloadPlugin("id");}catch(const runtime_error& e){caught=string(e.what())=="notification failure";}
+  assert(caught && d.events==1 && !d.m_bInPluginListChanged && d.m_CurrentPlugin==&caller);
+ }
+ {
+  CMUSHclientDoc d;CPlugin caller;d.m_CurrentPlugin=&caller;d.mode=3;d.m_PluginList.push_back(new CPlugin);
+  bool caught=false;try{d.ReloadPlugin("id");}catch(const runtime_error& e){caught=string(e.what())=="unexpected load failure";}
+  assert(caught && d.m_CurrentPlugin==&caller);
+ }
+ cout<<"Plugins: 12 success/file/archive context/name cases, self/active/missing guards, deferred notification, and exception propagation passed\n";
+}
+'''
+    return prefix + guard + body + main
+
+
+def run(args, output):
+    def read(path):
+        if args.baseline_ref:
+            return subprocess.check_output(['git', '-C', str(args.source), 'show',
+                                            args.baseline_ref + ':' + path], text=True)
+        return (args.source / path).read_text()
+    reports = []
+    for name, make in [('utf8', utf8_program), ('plugins', plugin_program)]:
+        if args.case and args.case != name:
+            continue
+        cpp = output / (name + '.cpp')
+        cpp.write_text(make(read))
+        command = ['clang++', '-std=c++17', '-fsanitize=address,undefined',
+                   '-fno-sanitize-recover=all', '-g', '-O1',
+                   str(cpp), '-o', str(output / name)]
+        subprocess.run(command, check=True)
+        result = subprocess.run([str(output / name)], text=True, capture_output=True)
+        (output / (name + '.log')).write_text(result.stdout + result.stderr)
+        print(result.stdout + result.stderr, end='', flush=True)
+        result.check_returncode()
+        reports.append({'case': name, 'result': 'pass', 'command': command})
+    (output / 'runtime-validation.json').write_text(json.dumps(reports, indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source', type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--output', type=Path)
+    parser.add_argument('--baseline-ref')
+    parser.add_argument('--case', choices=['utf8', 'plugins'])
+    args = parser.parse_args()
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=True)
+        run(args, args.output)
+    else:
+        with tempfile.TemporaryDirectory(prefix='mushclient-option-plugin-reload-') as directory:
+            run(args, Path(directory))

--- a/tests/check_option_and_plugin_reload.py
+++ b/tests/check_option_and_plugin_reload.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import subprocess
 import tempfile
 
-from output_callbacks import line_buffer_header, replace_once
+from output_callbacks import line_buffer_header, replace_once, section
 
 
 def block(text, start):
@@ -23,10 +23,6 @@ def block(text, start):
             return text[begin:end + 1]
     raise ValueError(start)
 
-
-def section(text, start, end):
-    begin = text.index(start)
-    return text[begin:text.index(end, begin)]
 
 
 def utf8_program(read, line_buffer):
@@ -70,7 +66,7 @@ struct CMUSHView:CView {
 '''
     patch(' struct CTriggerLineSnapshot', declarations + '\n struct CTriggerLineSnapshot')
     header = read('doc.h')
-    flags = section(header, '#define OPT_CUSTOM_COLOUR', '// for debug.options')
+    flags = section(header, '#define OPT_CUSTOM_COLOUR', '// for debug.options', 'doc.h')
     options = r'''
 #define NUMITEMS(x) (sizeof(x)/sizeof((x)[0]))
 enum {eOK,eUnknownOption,eOptionOutOfRange};
@@ -104,7 +100,7 @@ void AfxThrowMemoryException(){throw new CMemoryException;}
         ('bool CMUSHclientDoc::StartNewLine (', 'const bool CMUSHclientDoc::CheckScriptingAvailable'),
         (' void CMUSHclientDoc::RemoveChunk (void)', 'void CMUSHclientDoc::ShowStatusLine'),
     ]:
-        body += section(doc, start, end)
+        body += section(doc, start, end, 'doc.cpp')
     main = r'''
 int main() {
  // At byte 79, each multibyte character must stay on the first line.

--- a/tests/check_option_and_plugin_reload.py
+++ b/tests/check_option_and_plugin_reload.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import subprocess
 import tempfile
 
+from output_callbacks import line_buffer_header, replace_once
+
 
 def block(text, start):
     begin = text.index(start)
@@ -27,17 +29,23 @@ def section(text, start, end):
     return text[begin:text.index(end, begin)]
 
 
-def utf8_program(read):
+def utf8_program(read, line_buffer):
     source = read('scriptingoptions.cpp')
     doc = read('doc.cpp')
-    shim = read('tests/output_test_shim.h')
+    shim_path = 'tests/output_test_shim.h'
+    shim = read(shim_path)
+
+    def patch(expected, replacement):
+        nonlocal shim
+        shim = replace_once(shim, expected, replacement, shim_path)
+
     # Use the actual option field size and the Windows MAX macro semantics.
-    shim = shim.replace('#define MAX std::max', '#define MAX(a,b) ((a)>(b)?(a):(b))')
-    shim = shim.replace('bool m_bUTF_8=false,m_wrap=true,',
-                        'unsigned short m_bUTF_8=false;bool m_wrap=true,')
+    patch('#define MAX std::max', '#define MAX(a,b) ((a)>(b)?(a):(b))')
+    patch('bool m_bUTF_8=false,m_wrap=true,',
+          'unsigned short m_bUTF_8=false;bool m_wrap=true,')
     resize = block(shim, ' void ResizeText(int n)')
-    shim = shim.replace(resize, ' void ResizeText(int);')
-    shim = shim.replace('struct CMUSHView:CView {', '''
+    patch(resize, ' void ResizeText(int);')
+    patch('struct CMUSHView:CView {', '''
 struct CMUSHView:CView {
  struct {bool m_hWnd=false;void SendMessage(int,int,int){assert(false);}} m_ToolTip;
 ''')
@@ -60,7 +68,7 @@ struct CMUSHView:CView {
  void UpdateAllViews(void*){assert(false);}
  long SetOptionItem(int,long,bool,bool);
 '''
-    shim = shim.replace(' struct CTriggerLineSnapshot', declarations + '\n struct CTriggerLineSnapshot')
+    patch(' struct CTriggerLineSnapshot', declarations + '\n struct CTriggerLineSnapshot')
     header = read('doc.h')
     flags = section(header, '#define OPT_CUSTOM_COLOUR', '// for debug.options')
     options = r'''
@@ -145,7 +153,7 @@ int main() {
  cout<<"UTF-8: 2/3/4-byte boundary appends, allocation failure/retry, option validation, disable/repeat, missing line, existing capacity, and wrap change passed\n";
 }
 '''
-    return shim + flags + options + resize + body + main
+    return shim + flags + options + line_buffer + resize + body + main
 
 
 def plugin_program(read):
@@ -264,7 +272,8 @@ def run(args, output):
         if args.case and args.case != name:
             continue
         cpp = output / (name + '.cpp')
-        cpp.write_text(make(read))
+        program = make(read, line_buffer_header(args.source, args.baseline_ref, memory_exception_defined=True)) if name == 'utf8' else make(read)
+        cpp.write_text(program)
         command = ['clang++', '-std=c++17', '-fsanitize=address,undefined',
                    '-fno-sanitize-recover=all', '-g', '-O1',
                    str(cpp), '-o', str(output / name)]

--- a/tests/check_wrap_callback_style.cpp.in
+++ b/tests/check_wrap_callback_style.cpp.in
@@ -1,0 +1,102 @@
+// Keep callback style changes on both hard-column and trailing-space wraps.
+static void CheckANSIStyle()
+{
+ for (bool trailingSpace : {false, true}) {
+  CMUSHclientDoc d;
+  string prefix(80, 'A');
+  if (trailingSpace) prefix[79] = ' ';
+  assert(d.AddToLine(prefix.c_str(), 0));
+  int deliveries = 0;
+  d.callback = [&] {
+   ++deliveries;
+   d.InterpretANSIcode(ANSI_TEXT_RED);
+   d.InterpretANSIcode(ANSI_BACK_BLUE);
+   d.InterpretANSIcode(ANSI_BOLD);
+  };
+  assert(d.AddToLine("Z", 0));
+  assert(deliveries == 1);
+  assert(string(d.m_pCurrentLine->text, d.m_pCurrentLine->len) == "Z");
+  auto previous = d.m_LineList.GetHead()->styleList.GetTail();
+  auto current = d.m_pCurrentLine->styleList.GetTail();
+  assert(previous->iForeColour == RED && d.m_iForeColour == RED);
+  assert(current->iForeColour == RED);
+  assert(current->iBackColour == BLUE);
+  assert(current->iFlags & HILITE);
+ }
+}
+
+// A changed or removed action must not retain the old action on the new line.
+static void CheckActionReplacement()
+{
+ for (bool removeAction : {false, true}) {
+  auto oldAction = new CAction;
+  auto newAction = new CAction;
+  {
+   CMUSHclientDoc d;
+   assert(d.AddToLine(string(80, 'A').c_str(), 0));
+   d.AddStyle(HILITE, WHITE, BLACK, 0, oldAction);
+   d.callback = [&] {
+    d.AddStyle(COLOUR_RGB | UNDERLINE | INVERSE, 123, 456, 0,
+               removeAction ? nullptr : newAction);
+   };
+   assert(d.AddToLine("Z", 0));
+   auto current = d.m_pCurrentLine->styleList.GetTail();
+   assert(current->iFlags == (COLOUR_RGB | UNDERLINE | INVERSE));
+   assert(current->iForeColour == 123 && current->iBackColour == 456);
+   assert(current->pAction == (removeAction ? nullptr : newAction));
+   assert(oldAction->refs == 1);
+   assert(newAction->refs == (removeAction ? 1 : 3));
+  }
+  assert(oldAction->refs == 1 && newAction->refs == 1);
+  oldAction->Release();
+  newAction->Release();
+ }
+}
+
+// Pruning can remove the old line during FinishNewLine. The retained snapshot
+// must remain valid, including its action, after that line is destroyed.
+static void CheckPrunedLine()
+{
+ auto action = new CAction;
+ {
+  CMUSHclientDoc d;
+  for (int i = 1; i < JUMP_SIZE; ++i)
+   assert(d.StartNewLine(true, COMMENT));
+  d.m_maxlines = JUMP_SIZE;
+  d.AddStyle(UNDERLINE, RED, BLUE, 0, action);
+  bool created = false;
+  assert(d.StartNewLine_KeepPreviousStyle(0, &created));
+  assert(created && d.m_LineList.GetCount() == 1);
+  auto current = d.m_pCurrentLine->styleList.GetTail();
+  assert(current->iFlags == UNDERLINE);
+  assert(current->iForeColour == RED && current->iBackColour == BLUE);
+  assert(current->pAction == action && action->refs == 2);
+ }
+ assert(action->refs == 1);
+ action->Release();
+}
+
+static void CheckCallbackException()
+{
+ auto action = new CAction;
+ {
+  CMUSHclientDoc d;
+  d.AddStyle(UNDERLINE, RED, BLUE, 0, action);
+  d.callback = [] { throw runtime_error("callback failure"); };
+  bool caught = false, created = true;
+  try { d.StartNewLine_KeepPreviousStyle(0, &created); }
+  catch (const runtime_error&) { caught = true; }
+  assert(caught && !created && action->refs == 2);
+ }
+ assert(action->refs == 1);
+ action->Release();
+}
+
+int main()
+{
+ CheckANSIStyle();
+ CheckActionReplacement();
+ CheckPrunedLine();
+ CheckCallbackException();
+ cout << "wrap callback style checks passed\n";
+}

--- a/tests/check_wrap_callback_style.py
+++ b/tests/check_wrap_callback_style.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Check soft-wrap style changes made by a partial-line callback.
+
+Compile the production append, ANSI, style, and line-transition functions with
+focused MFC substitutes. The callback calls InterpretANSIcode directly, as
+Simulate's ANSI parser does. This check does not run the Windows UI or Lua.
+"""
+import argparse
+from pathlib import Path
+import subprocess
+import tempfile
+
+from output_callbacks import replace_once, section
+
+
+def run(source, output, revision):
+    def read(path):
+        if revision:
+            return subprocess.check_output(
+                ['git', '-C', str(source), 'show', f'{revision}:{path}'], text=True)
+        return (source / path).read_text()
+
+    doc = read('doc.cpp')
+    shim = (Path(__file__).parent / 'output_test_shim.h').read_text()
+    shim = replace_once(shim, ' bool StartNewLine(bool,int,bool=true,bool * =nullptr);', '''
+ int m_phase=0;
+ bool m_bAlternativeInverse=false;
+ COLORREF m_boldcolour[16]={},m_normalcolour[16]={},m_customtext[16]={},m_customback[16]={};
+ CStyle* AddStyle(unsigned short,COLORREF,COLORREF,int,CAction*,CLine* =nullptr);
+ void InterpretANSIcode(int);
+ void RememberStyle(const CStyle*);
+ bool StartNewLine(bool,int,bool=true,bool * =nullptr);''',
+                        'output_test_shim.h ANSI declarations')
+    defines = '\n'.join(line for line in read('stdafx.h').splitlines() if line.startswith('#define ANSI_'))
+    defines += r"""
+#define RED 1
+#define GREEN 2
+#define YELLOW 3
+#define BLUE 4
+#define MAGENTA 5
+#define CYAN 6
+#define ACTIONTYPE 0x0C00
+#define STRIKEOUT 0x0020
+#define MAX_CUSTOM 16
+#define HAVE_FOREGROUND_256_START 100
+#define HAVE_BACKGROUND_256_START 101
+"""
+    body = section(doc, 'bool CMUSHclientDoc::StartNewLine_KeepPreviousStyle',
+                   'COutputAppendTransaction::COutputAppendTransaction')
+    body += section(doc, 'bool CMUSHclientDoc::AddToLine (',
+                    '// called when starting a new line to get colours right')
+    body += section(doc, 'bool CMUSHclientDoc::StartNewLine (',
+                    'const bool CMUSHclientDoc::CheckScriptingAvailable')
+    body += section(doc, ' void CMUSHclientDoc::RemoveChunk (void)',
+                    'void CMUSHclientDoc::ShowStatusLine')
+    style_end = doc.index('void CMUSHclientDoc::RefreshMXPMissingTagAnchors')
+    style_start = doc.rindex('CStyle * CMUSHclientDoc::AddStyle', 0, style_end)
+    body += doc[style_start:style_end]
+    body += section(doc, 'void CMUSHclientDoc::RememberStyle',
+                    'void CMUSHclientDoc::OnDebugWorldInput')
+    body += section(read('ansi.cpp'), 'void CMUSHclientDoc::InterpretANSIcode',
+                    'void CMUSHclientDoc::Interpret256ANSIcode')
+    fixture = Path(__file__).with_suffix('.cpp.in').read_text()
+    cpp = output / 'wrap_callback_style.cpp'
+    cpp.write_text(defines + shim + body + fixture)
+    binary = output / 'wrap_callback_style'
+    subprocess.run(['clang++', '-std=c++17', '-fsanitize=address,undefined',
+                    '-fno-sanitize-recover=all', '-g', '-O1', str(cpp),
+                    '-o', str(binary)], check=True)
+    subprocess.run([str(binary)], check=True)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source', type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--revision', help='Read production functions from this Git revision')
+    parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=True)
+        run(args.source, args.output, args.revision)
+    else:
+        with tempfile.TemporaryDirectory(prefix='mushclient-wrap-style-') as directory:
+            run(args.source, Path(directory), args.revision)

--- a/tests/check_wrap_callback_style.py
+++ b/tests/check_wrap_callback_style.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import subprocess
 import tempfile
 
-from output_callbacks import replace_once, section
+from output_callbacks import line_buffer_header, replace_once, section
 
 
 def run(source, output, revision):
@@ -62,7 +62,7 @@ def run(source, output, revision):
                     'void CMUSHclientDoc::Interpret256ANSIcode')
     fixture = Path(__file__).with_suffix('.cpp.in').read_text()
     cpp = output / 'wrap_callback_style.cpp'
-    cpp.write_text(defines + shim + body + fixture)
+    cpp.write_text(defines + shim + line_buffer_header(source, revision) + body + fixture)
     binary = output / 'wrap_callback_style'
     subprocess.run(['clang++', '-std=c++17', '-fsanitize=address,undefined',
                     '-fno-sanitize-recover=all', '-g', '-O1', str(cpp),

--- a/tests/mxp_start_identity_test.cpp.in
+++ b/tests/mxp_start_identity_test.cpp.in
@@ -13,6 +13,10 @@ using __int64 = long long;
 using COLORREF = unsigned;
 using POSITION = void*;
 using std::vector;
+using std::exception_ptr;
+using std::current_exception;
+using std::rethrow_exception;
+constexpr int DISPID_UNKNOWN=-1;
 #define ASSERT assert
 #define COLOURTYPE 0x0300
 #define COLOUR_CUSTOM 0x0100
@@ -90,11 +94,20 @@ struct CActiveTag {
   bool bOpeningInParagraph=false, bOpeningPreMode=false, bOpeningMXPScript=false;
   int iOpeningListMode=0, iOpeningListCount=0;
   CString strVariable;
+  vector<int> closeActions;
 };
+struct CPreparedMXPClose : CActiveTag { __int64 iActiveTagCreationNumber=0; };
 struct CDeferredMXPMessage { int iLevel, iMessageNumber; CString strMessage; CDeferredMXPMessage(int l,int n,CString s):iLevel(l),iMessageNumber(n),strMessage(s){} };
 using CArgumentList=vector<int>;
 struct CAtomicElement { int iAction; CString strName="test"; };
 struct CElementItem { CAtomicElement* pAtomicElement; CArgumentList ArgumentList; };
+struct CElement {
+  List<CElementItem> ElementItemList;
+  ~CElement() { while(!ElementItemList.IsEmpty()) delete ElementItemList.RemoveTail(); }
+};
+struct CMUSHclientDoc;
+static bool BuildCustomAtomicArguments(CMUSHclientDoc*,CString,CElement*,CElementItem*,CArgumentList&,CArgumentList&);
+static CString BuildAtomicCallbackArguments(CArgumentList&) { return "arguments"; }
 struct Socket { std::string m_outstanding_data; int sends=0; void OnSend(int) { ++sends; } };
 struct CMUSHclientDoc;
 struct COutputAppendTransaction {
@@ -131,13 +144,30 @@ struct CMUSHclientDoc {
   std::function<void()> callback;
   bool outputCreatesLine=true;
   CString m_name="fixture-user";
-  static constexpr int eOrderedList=1;
+  static constexpr int eOrderedList=1, eUnorderedList=2;
+  int m_cLastChar=0, m_dispidOnMXP_OpenTag=DISPID_UNKNOWN;
+  bool m_bPluginProcessesOpenTag=false;
+  vector<int> customActions;
+  vector<bool> itemWanted;
+  vector<std::string> events;
+  size_t hookIndex=0;
+  int failOpenAction=-1, throwOpenAction=-1, throwCloseAction=-1;
+  bool throwHook=false;
+  bool MXP_StartTagScript(CString name,CString,CArgumentList&) {
+    events.push_back("hook:"+name);
+    if(throwHook) throw std::runtime_error("hook failure");
+    return !itemWanted.at(hookIndex++);
+  }
+  bool StartNewLine(bool,int) { events.push_back("newline"); newLine(); return true; }
+  void MXP_CloseAtomicTag(int,const CPreparedMXPClose&);
+  void FinishCustomClose(const CPreparedMXPClose&,bool=false);
   CMUSHclientDoc() { newLine(); }
   ~CMUSHclientDoc() { while(!m_LineList.IsEmpty()) delete m_LineList.RemoveTail(); while(!m_ActiveTagList.IsEmpty()) delete m_ActiveTagList.RemoveTail(); }
   CStyle* tail() { return m_pCurrentLine->styleList.GetTail(); }
   void newLine() { auto* l=new CLine; l->styleList.AddTail(new CStyle); m_LineList.AddTail(l); m_pCurrentLine=l; }
   CStyle* AddStyle(int f,int fore,int back,int len,CString action,CString,CString) { auto* s=new CStyle; s->iFlags=f; s->iForeColour=fore; s->iBackColour=back; s->iLength=len; s->pAction=new CAction(action); m_pCurrentLine->styleList.AddTail(s); return s; }
   CAction* GetAction(CString a,CString,CString) { return new CAction(a); }
+  CStyle* NoteStyle(unsigned short,COLORREF,COLORREF,int,CString,CString,CString,CLine* = nullptr);
   void RememberStyle(const CStyle*);
   void SendPacket(const char*,int);
   void Debug_Packets(const char*,const char*,int,__int64) { if(callback) callback(); }
@@ -151,17 +181,26 @@ struct CMUSHclientDoc {
 COutputAppendTransaction::COutputAppendTransaction(CMUSHclientDoc* d,int):m_pDoc(d) { TrackLine(d->m_pCurrentLine); }
 bool COutputAppendTransaction::StartNewLine(bool,int,bool,bool* created) { if(m_pDoc->callback) m_pDoc->callback(); *created=m_pDoc->outputCreatesLine; if(*created) m_pDoc->newLine(); return true; }
 void COutputAppendTransaction::SetListCount(int n) { m_pDoc->m_iListCount=n; }
+static bool BuildCustomAtomicArguments(CMUSHclientDoc* d,CString,CElement*,CElementItem* item,CArgumentList&,CArgumentList&) {
+  d->events.push_back("build:"+item->pAtomicElement->strName); return true;
+}
 @PREPARE_STYLE@
 @SEND_PACKET@
 @REMEMBER_STYLE@
+@NOTE_ADD_STYLE@
 @TRANSACTION@
 static void ReportDeferredMXPMessages(CMUSHclientDoc* d,vector<CDeferredMXPMessage>& ms) { for(auto& m:ms) d->MXP_error(m.iLevel,m.iMessageNumber,m.strMessage); ms.clear(); }
 static void QueueMXPMessage(vector<CDeferredMXPMessage>& ms,int l,int n,CString s) { ms.emplace_back(l,n,s); }
-bool CMUSHclientDoc::MXP_OpenAtomicTag(CString,int iAction,CStyle* pStyle,__int64& iResultStyleCreationNumber,CString& strAction,CString& strHint,CString& strVariable,CArgumentList&,__int64,COutputAppendTransaction* pOutputTransaction,vector<CDeferredMXPMessage>& deferredMessages) {
+bool CMUSHclientDoc::MXP_OpenAtomicTag(CString,int iAction,CStyle* pStyle,__int64& iResultStyleCreationNumber,CString& strAction,CString& strHint,CString& strVariable,CArgumentList&,__int64 iStateOwner,COutputAppendTransaction* pOutputTransaction,vector<CDeferredMXPMessage>& deferredMessages) {
+  events.push_back("open:"+std::to_string(iAction));
+  if(iAction==throwOpenAction) throw std::runtime_error("open failure");
+  if(iAction==failOpenAction) return false;
   @RESULT_INIT@
   bool bIgnoreUnusedArgs=false;
   switch(iAction) {
     @PACKET_CASES@
+    @PARAGRAPH_OPEN@
+    @LIST_OPEN@
     @BR_CASE@
     @HR_CASE@
     @LI_CASE@
@@ -182,18 +221,46 @@ void CMUSHclientDoc::Run(bool custom,bool paired,int action,bool followBold) {
   CAtomicElement* pAtomicElement=custom?nullptr:&element;
   vector<std::unique_ptr<CElementItem>> expandedItems;
   vector<bool> expandedItemsWanted;
-  if(custom) { expandedItems.emplace_back(new CElementItem{&element}); expandedItemsWanted.push_back(true); if(followBold) { expandedItems.emplace_back(new CElementItem{&bold}); expandedItemsWanted.push_back(true); } }
-  vector<CDeferredMXPMessage> deferredMessages;
   CArgumentList ArgumentList;
+  CElement definition;
+  CElement* pElement=&definition;
+  vector<CAtomicElement> atoms;
+  if(custom) {
+    if(customActions.empty()) { atoms.push_back(element); if(followBold) atoms.push_back(bold); }
+    else for(int value:customActions) atoms.push_back(CAtomicElement{value,std::to_string(value)});
+    for(auto& atom:atoms) definition.ElementItemList.AddTail(new CElementItem{&atom});
+    bool bPreparedExpandedItems=false;
+    @CUSTOM_PREPARATION@
+  }
+  vector<CDeferredMXPMessage> deferredMessages;
   __int64 iStateOwner=++serial, iOpeningMXPGeneration=m_iMXPGeneration;
   CMXPStartTransaction transaction(this,iStateOwner);
   transaction.PreserveStyle(tail());
   CActiveTag* pPublishedTag=nullptr;
-  if(paired) { pPublishedTag=new CActiveTag; pPublishedTag->nCreationNumber=iStateOwner; m_ActiveTagList.AddTail(pPublishedTag); transaction.SetActiveTag(pPublishedTag); auto* marker=AddStyle(START_TAG,7,0,0,"marker","",""); transaction.SetMarker(marker); }
+  if(paired) { pPublishedTag=new CActiveTag; pPublishedTag->nCreationNumber=iStateOwner;
+    auto* pTag=pPublishedTag;
+    @CLOSE_ACTIONS@
+    m_ActiveTagList.AddTail(pPublishedTag); transaction.SetActiveTag(pPublishedTag); auto* marker=AddStyle(START_TAG,7,0,0,"marker","",""); transaction.SetMarker(marker); }
   CStyle* pNewStyle=AddStyle(0,7,0,0,strAction,strHint,strVariable);
   transaction.SetStyle(pNewStyle);
   bool bWarnOutstandingTags=false;
   @FINALIZATION@
+}
+void CMUSHclientDoc::MXP_CloseAtomicTag(int iAction,const CPreparedMXPClose& preparedClose) {
+  events.push_back("close:"+std::to_string(iAction));
+  if(iAction==throwCloseAction) throw std::runtime_error("close failure");
+  switch(iAction) {
+    @PARAGRAPH_LIST_CLOSE@
+    default: break;
+  }
+}
+void CMUSHclientDoc::FinishCustomClose(const CPreparedMXPClose& preparedClose,bool throwCallback) {
+  // Only callback dispatch is a substitute. The close loop and error handling
+  // below come from production MXP_FinishCloseTag.
+  exception_ptr pendingException;
+  try { events.push_back("close callback"); if(throwCallback) throw std::runtime_error("callback failure"); }
+  catch(...) { pendingException=current_exception(); }
+  @CLOSE_DISPATCH@
 }
 static void deleteOutput(CMUSHclientDoc& d) {
   // Same lifetime boundary as DeleteLines: replace current line and styles,
@@ -315,11 +382,45 @@ static void lookupChecks() {
     styleVisits=lineVisits=0;
     assert(tx.ResolveStyle(0)==nullptr && styleVisits==0 && lineVisits==0);
     auto* oldest=d.m_LineList.GetHead()->styleList.GetHead();
+    assert(tx.ResolveStyle(oldest->nCreationNumber)==nullptr);
+    assert(lineVisits==2);
+    styleVisits=lineVisits=0;
+    assert(tx.ResolveStyle(-1)==nullptr && lineVisits==2);
+    // Deletion can resume a retained line older than this transaction.
+    ++d.m_iOutputGeneration;
+    styleVisits=lineVisits=0;
     assert(tx.ResolveStyle(oldest->nCreationNumber)==oldest);
     assert(lineVisits==static_cast<unsigned>(count));
     assert(tx.ResolveStyle(-1)==nullptr);
     tx.Commit();
     std::printf("lines=%d, styles visited for two marker checks and result=%llu\n",count,static_cast<unsigned long long>(recentVisits));
+  }
+}
+static void missingResultChecks() {
+  for(int retained:{5000,500000}) {
+    CMUSHclientDoc d;
+    for(int i=1;i<retained;++i) d.newLine();
+    d.callback=[&]{
+      // Run the exact AddStyle body used by note output. It replaces the empty
+      // result of the packet action without deleting the retained history.
+      d.NoteStyle(4,2,3,8,"callback","",""); d.m_pCurrentLine->len+=8;
+    };
+    styleVisits=lineVisits=0;
+    for(int i=0;i<100;++i) d.Run(false,false,MXP_ACTION_VERSION);
+    assert(lineVisits==200);
+    assert(d.m_LineList.GetCount()==static_cast<size_t>(retained));
+    std::printf("missing packet result: history=%d, operations=100, line visits=%llu\n",retained,static_cast<unsigned long long>(lineVisits));
+  }
+  // Rollback must still find an older preserved style when no deletion occurs.
+  {
+    CMUSHclientDoc d; auto* old=d.tail(); old->iLength=4;
+    auto identity=old->nCreationNumber;
+    d.newLine(); CMXPStartTransaction tx(&d,++serial); tx.PreserveStyle(old);
+    auto* marker=d.AddStyle(START_TAG,7,0,0,"marker","",""); tx.SetMarker(marker);
+    auto* result=d.AddStyle(0,7,0,0,"result","",""); tx.SetStyle(result);
+    tx.Rollback();
+    assert(d.m_LineList.GetHead()->styleList.GetHead()==old&&old->nCreationNumber==identity);
+    assert(d.m_pCurrentLine->styleList.GetCount()==1);
   }
 }
 static void rollbackChecks() {
@@ -365,4 +466,78 @@ static void rollbackChecks() {
   }
   std::puts("MXP rollback contracts: restored identities, repurposed marker, pruned styles passed");
 }
-int main() { packetChecks(); outputChecks(); rollbackChecks(); lookupChecks(); }
+static void customCloseChecks() {
+  int cases=0;
+  for(int action:{MXP_ACTION_P,MXP_ACTION_UL,MXP_ACTION_OL})
+    for(bool wanted:{false,true}) for(bool nonempty:{false,true}) {
+      CMUSHclientDoc d;
+      d.customActions={action,MXP_ACTION_PRE,action};
+      d.itemWanted={wanted,true,false}; d.m_bPluginProcessesOpenTag=true;
+      d.Run(true,true,action);
+      vector<std::string> expected;
+      for(int value:d.customActions) { expected.push_back("build:"+std::to_string(value)); expected.push_back("hook:"+std::to_string(value)); }
+      if(wanted) expected.push_back("open:"+std::to_string(action));
+      expected.push_back("open:"+std::to_string(MXP_ACTION_PRE));
+      assert(d.events==expected && d.hookIndex==3);
+      assert(d.argumentChecks==2+int(wanted));
+      auto* tag=d.m_ActiveTagList.GetTail();
+      vector<int> accepted;
+      if(wanted) accepted.push_back(action);
+      accepted.push_back(MXP_ACTION_PRE);
+      assert(tag->closeActions==accepted);
+      CPreparedMXPClose close; close.closeActions=tag->closeActions;
+      close.iActiveTagCreationNumber=tag->nCreationNumber;
+      d.m_pCurrentLine->len=nonempty?4:0;
+      d.events.clear(); auto lines=d.m_LineList.GetCount();
+      d.FinishCustomClose(close);
+      expected={"close callback"};
+      if(wanted) {
+        expected.push_back("close:"+std::to_string(action));
+        if(action==MXP_ACTION_P||nonempty) expected.push_back("newline");
+      }
+      expected.push_back("close:"+std::to_string(MXP_ACTION_PRE));
+      assert(d.events==expected);
+      assert(d.m_LineList.GetCount()==lines+size_t(wanted&&(action==MXP_ACTION_P||nonempty)));
+      assert(!d.m_bInParagraph&&!d.m_bPreMode&&d.m_iListMode==0);
+      ++cases;
+    }
+  // All items are declined, or no hook is installed.
+  for(bool hooks:{false,true}) {
+    CMUSHclientDoc d; d.customActions={MXP_ACTION_P,MXP_ACTION_UL,MXP_ACTION_OL};
+    d.m_bPluginProcessesOpenTag=hooks; d.itemWanted={false,false,false}; d.Run(true,true,MXP_ACTION_P);
+    assert(d.hookIndex==(hooks?3:0));
+    assert(d.m_ActiveTagList.GetTail()->closeActions==(hooks?vector<int>{}:d.customActions));
+    if(hooks) { assert(!d.m_bInParagraph&&d.m_iListMode==0); assert(d.argumentChecks==1); }
+  }
+  // Failed open actions remove the published tag and restore prior mode owners.
+  for(bool throws:{false,true}) {
+    CMUSHclientDoc d; d.customActions={MXP_ACTION_P,MXP_ACTION_PRE};
+    d.m_bInParagraph=true; d.m_iMXPParagraphOwner=55;
+    if(throws) d.throwOpenAction=MXP_ACTION_PRE; else d.failOpenAction=MXP_ACTION_PRE;
+    bool caught=false; try { d.Run(true,true,MXP_ACTION_P); }
+    catch(const std::runtime_error& e) { assert(std::string(e.what())=="open failure"); caught=true; }
+    assert(caught==throws && d.m_ActiveTagList.IsEmpty());
+    assert(d.m_bInParagraph && d.m_iMXPParagraphOwner==55 && d.argumentChecks==0);
+  }
+  // A preparation hook exception must propagate before publication.
+  {
+    CMUSHclientDoc d; d.customActions={MXP_ACTION_P}; d.itemWanted={false};
+    d.m_bPluginProcessesOpenTag=true; d.throwHook=true;
+    bool caught=false; try { d.Run(true,true,MXP_ACTION_P); }
+    catch(const std::runtime_error& e) { assert(std::string(e.what())=="hook failure"); caught=true; }
+    assert(caught&&d.m_ActiveTagList.IsEmpty()&&!d.m_bInParagraph);
+  }
+  // Close actions continue after an exception and retain the first error.
+  for(bool callbackThrows:{false,true}) {
+    CMUSHclientDoc d; d.customActions={MXP_ACTION_P,MXP_ACTION_PRE}; d.Run(true,true,MXP_ACTION_P);
+    CPreparedMXPClose close; close.closeActions=d.m_ActiveTagList.GetTail()->closeActions;
+    close.iActiveTagCreationNumber=d.m_ActiveTagList.GetTail()->nCreationNumber;
+    d.throwCloseAction=MXP_ACTION_P; d.events.clear(); bool caught=false;
+    try { d.FinishCustomClose(close,callbackThrows); }
+    catch(const std::runtime_error& e) { assert(std::string(e.what())==(callbackThrows?"callback failure":"close failure")); caught=true; }
+    assert(caught&&!d.m_bPreMode);
+    assert((d.events==vector<std::string>{"close callback","close:"+std::to_string(MXP_ACTION_P),"close:"+std::to_string(MXP_ACTION_PRE)}));
+  }
+  std::printf("custom close: %d paragraph/list cases, hook order, all-declined, no-hook, rollback, and exception contracts passed\n",cases);
+}
+int main() { packetChecks(); outputChecks(); rollbackChecks(); customCloseChecks(); lookupChecks(); missingResultChecks(); }

--- a/tests/mxp_start_identity_test.cpp.in
+++ b/tests/mxp_start_identity_test.cpp.in
@@ -1,0 +1,368 @@
+// Portable substitutes surround exact source excerpts inserted by the runner.
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <list>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+using __int64 = long long;
+using COLORREF = unsigned;
+using POSITION = void*;
+using std::vector;
+#define ASSERT assert
+#define COLOURTYPE 0x0300
+#define COLOUR_CUSTOM 0x0100
+#define COLOUR_ANSI 0
+#define MAX_CUSTOM 16
+#define STYLE_BITS 0x0FFF
+#define START_TAG 0x1000
+#define HILITE 1
+#define HORIZ_RULE 8
+#define DBG_WARNING 1
+#define DBG_INFO 2
+#define DELETE_LIST(x) (x).clear()
+#define NEWSTYLE new CStyle
+#define DELETESTYLE(x) delete (x)
+#define LPCTSTR const char*
+@ENUMS@
+struct CString : std::string {
+  using std::string::string;
+  CString(const std::string& s) : std::string(s) {}
+  operator const char*() const { return c_str(); }
+  int GetLength() const { return size(); }
+  CString Mid(size_t n) const { return substr(n); }
+  void Format(const char* fmt, int n) { char b[100]; std::snprintf(b, sizeof(b), fmt, n); assign(b); }
+};
+template<class... T> CString TFormat(const char* s, T...) { return s; }
+static __int64 serial = 100;
+struct CAction {
+  int refs = 1;
+  CString value;
+  explicit CAction(CString s) : value(s) {}
+  void AddRef() { ++refs; }
+  void Release() { if (!--refs) delete this; }
+};
+struct CStyle {
+  unsigned short iFlags=0, iLength=0;
+  COLORREF iForeColour=7, iBackColour=0;
+  __int64 nCreationNumber=++serial, nRangeCreationNumber=++serial;
+  __int64 nOutputAppendCreationNumber=0;
+  CAction* pAction=nullptr;
+  ~CStyle() { if (pAction) pAction->Release(); }
+};
+static std::uint64_t styleVisits=0, lineVisits=0;
+template<class T> class List {
+  struct Node { T* value; Node* prev; Node* next; };
+  Node* head=nullptr; Node* tail=nullptr; size_t count=0;
+  T* visit(Node* n) {
+    if constexpr (std::is_same_v<T,CStyle>) ++styleVisits;
+    else ++lineVisits;
+    return n->value;
+  }
+public:
+  ~List() { while (head) RemoveAt(head); }
+  POSITION GetHeadPosition() { return head; }
+  POSITION GetTailPosition() { return tail; }
+  T* GetNext(POSITION& p) { Node* n=static_cast<Node*>(p); p=n->next; return visit(n); }
+  T* GetPrev(POSITION& p) { Node* n=static_cast<Node*>(p); p=n->prev; return visit(n); }
+  T* GetTail() { assert(tail); return tail->value; }
+  T* GetHead() { assert(head); return head->value; }
+  bool IsEmpty() { return !head; }
+  size_t GetCount() { return count; }
+  void AddTail(T* p) { Node* n=new Node{p,tail,nullptr}; if(tail) tail->next=n; else head=n; tail=n; ++count; }
+  void RemoveAt(POSITION p) { Node* n=static_cast<Node*>(p); if(n->prev) n->prev->next=n->next; else head=n->next; if(n->next) n->next->prev=n->prev; else tail=n->prev; delete n; --count; }
+  T* RemoveTail() { T* p=GetTail(); RemoveAt(tail); return p; }
+};
+struct CLine {
+  List<CStyle> styleList;
+  __int64 nCreationNumber=++serial;
+  int len=0, flags=0;
+  CString text;
+  ~CLine() { while(!styleList.IsEmpty()) delete styleList.RemoveTail(); }
+};
+struct CActiveTag {
+  __int64 nCreationNumber=++serial;
+  __int64 iOpeningParagraphOwner=0, iOpeningPreOwner=0, iOpeningScriptOwner=0, iOpeningListOwner=0;
+  bool bOpeningInParagraph=false, bOpeningPreMode=false, bOpeningMXPScript=false;
+  int iOpeningListMode=0, iOpeningListCount=0;
+  CString strVariable;
+};
+struct CDeferredMXPMessage { int iLevel, iMessageNumber; CString strMessage; CDeferredMXPMessage(int l,int n,CString s):iLevel(l),iMessageNumber(n),strMessage(s){} };
+using CArgumentList=vector<int>;
+struct CAtomicElement { int iAction; CString strName="test"; };
+struct CElementItem { CAtomicElement* pAtomicElement; CArgumentList ArgumentList; };
+struct Socket { std::string m_outstanding_data; int sends=0; void OnSend(int) { ++sends; } };
+struct CMUSHclientDoc;
+struct COutputAppendTransaction {
+  CMUSHclientDoc* m_pDoc;
+  __int64 m_iAppendCreationNumber=++serial;
+  __int64 m_iFirstAffectedLineCreationNumber=m_iAppendCreationNumber;
+  bool committed=false;
+  COutputAppendTransaction(CMUSHclientDoc* d,int);
+  void Reserve(size_t) {}
+  void TrackLine(const CLine*);
+  void MarkCurrentLineStyles();
+  CStyle* PrepareAppendStyle();
+  void OwnStyle(CStyle*);
+  void Rollback() {} // PR #25 output rollback is outside this focused check.
+  void Commit() { committed=true; }
+  bool StartNewLine(bool,int,bool,bool*);
+  void SetLineFlags(CLine* l,int f) { l->flags=f; }
+  void SetListCount(int);
+};
+struct CMUSHclientDoc {
+  List<CLine> m_LineList;
+  List<CActiveTag> m_ActiveTagList;
+  CLine* m_pCurrentLine=nullptr;
+  bool m_bInParagraph=false, m_bPreMode=false, m_bMXP_script=false, m_bMXP=true;
+  int m_iListMode=0, m_iListCount=0, m_iLastOutstandingTagCount=0;
+  __int64 m_iMXPParagraphOwner=0, m_iMXPPreOwner=0, m_iMXPScriptOwner=0, m_iMXPListOwner=0;
+  __int64 m_iMXPGeneration=1, m_iOutputGeneration=1;
+  unsigned short m_iFlags=0;
+  unsigned m_iForeColour=7, m_iBackColour=0;
+  bool m_bDebugIncomingPackets=true;
+  int m_iOutputPacketCount=0, m_nBytesOut=0, diagnostics=0, argumentChecks=0;
+  Socket socket;
+  Socket* m_pSocket=&socket;
+  std::function<void()> callback;
+  bool outputCreatesLine=true;
+  CString m_name="fixture-user";
+  static constexpr int eOrderedList=1;
+  CMUSHclientDoc() { newLine(); }
+  ~CMUSHclientDoc() { while(!m_LineList.IsEmpty()) delete m_LineList.RemoveTail(); while(!m_ActiveTagList.IsEmpty()) delete m_ActiveTagList.RemoveTail(); }
+  CStyle* tail() { return m_pCurrentLine->styleList.GetTail(); }
+  void newLine() { auto* l=new CLine; l->styleList.AddTail(new CStyle); m_LineList.AddTail(l); m_pCurrentLine=l; }
+  CStyle* AddStyle(int f,int fore,int back,int len,CString action,CString,CString) { auto* s=new CStyle; s->iFlags=f; s->iForeColour=fore; s->iBackColour=back; s->iLength=len; s->pAction=new CAction(action); m_pCurrentLine->styleList.AddTail(s); return s; }
+  CAction* GetAction(CString a,CString,CString) { return new CAction(a); }
+  void RememberStyle(const CStyle*);
+  void SendPacket(const char*,int);
+  void Debug_Packets(const char*,const char*,int,__int64) { if(callback) callback(); }
+  void SetNewLineColour(int) {}
+  bool AddToLineInternal(CString s,int,COutputAppendTransaction*) { tail()->iLength+=s.size(); m_pCurrentLine->len+=s.size(); m_pCurrentLine->text+=s; if(callback) callback(); return true; }
+  void MXP_error(int,int,CString) { ++diagnostics; }
+  void CheckArgumentsUsed(CString,CArgumentList&) { ++argumentChecks; }
+  bool MXP_OpenAtomicTag(CString,int,CStyle*,__int64&,CString&,CString&,CString&,CArgumentList&,__int64,COutputAppendTransaction*,vector<CDeferredMXPMessage>&);
+  void Run(bool custom,bool paired,int action,bool followBold=false);
+};
+COutputAppendTransaction::COutputAppendTransaction(CMUSHclientDoc* d,int):m_pDoc(d) { TrackLine(d->m_pCurrentLine); }
+bool COutputAppendTransaction::StartNewLine(bool,int,bool,bool* created) { if(m_pDoc->callback) m_pDoc->callback(); *created=m_pDoc->outputCreatesLine; if(*created) m_pDoc->newLine(); return true; }
+void COutputAppendTransaction::SetListCount(int n) { m_pDoc->m_iListCount=n; }
+@PREPARE_STYLE@
+@SEND_PACKET@
+@REMEMBER_STYLE@
+@TRANSACTION@
+static void ReportDeferredMXPMessages(CMUSHclientDoc* d,vector<CDeferredMXPMessage>& ms) { for(auto& m:ms) d->MXP_error(m.iLevel,m.iMessageNumber,m.strMessage); ms.clear(); }
+static void QueueMXPMessage(vector<CDeferredMXPMessage>& ms,int l,int n,CString s) { ms.emplace_back(l,n,s); }
+bool CMUSHclientDoc::MXP_OpenAtomicTag(CString,int iAction,CStyle* pStyle,__int64& iResultStyleCreationNumber,CString& strAction,CString& strHint,CString& strVariable,CArgumentList&,__int64,COutputAppendTransaction* pOutputTransaction,vector<CDeferredMXPMessage>& deferredMessages) {
+  @RESULT_INIT@
+  bool bIgnoreUnusedArgs=false;
+  switch(iAction) {
+    @PACKET_CASES@
+    @BR_CASE@
+    @HR_CASE@
+    @LI_CASE@
+    case MXP_ACTION_BOLD: pStyle->iFlags|=HILITE; break;
+    case MXP_ACTION_IMG:
+    case MXP_ACTION_IMAGE: {
+      CString strOldAction=strAction, strOldHint=strHint, strOldVariable=strVariable;
+      @IMAGE_RESULT@
+      break;
+    }
+    default: throw std::runtime_error("Unexpected fixture action");
+  }
+  return true;
+}
+void CMUSHclientDoc::Run(bool custom,bool paired,int action,bool followBold) {
+  CString strName="fixture", strAction="outer", strHint="", strVariable="";
+  CAtomicElement element{action}, bold{MXP_ACTION_BOLD};
+  CAtomicElement* pAtomicElement=custom?nullptr:&element;
+  vector<std::unique_ptr<CElementItem>> expandedItems;
+  vector<bool> expandedItemsWanted;
+  if(custom) { expandedItems.emplace_back(new CElementItem{&element}); expandedItemsWanted.push_back(true); if(followBold) { expandedItems.emplace_back(new CElementItem{&bold}); expandedItemsWanted.push_back(true); } }
+  vector<CDeferredMXPMessage> deferredMessages;
+  CArgumentList ArgumentList;
+  __int64 iStateOwner=++serial, iOpeningMXPGeneration=m_iMXPGeneration;
+  CMXPStartTransaction transaction(this,iStateOwner);
+  transaction.PreserveStyle(tail());
+  CActiveTag* pPublishedTag=nullptr;
+  if(paired) { pPublishedTag=new CActiveTag; pPublishedTag->nCreationNumber=iStateOwner; m_ActiveTagList.AddTail(pPublishedTag); transaction.SetActiveTag(pPublishedTag); auto* marker=AddStyle(START_TAG,7,0,0,"marker","",""); transaction.SetMarker(marker); }
+  CStyle* pNewStyle=AddStyle(0,7,0,0,strAction,strHint,strVariable);
+  transaction.SetStyle(pNewStyle);
+  bool bWarnOutstandingTags=false;
+  @FINALIZATION@
+}
+static void deleteOutput(CMUSHclientDoc& d) {
+  // Same lifetime boundary as DeleteLines: replace current line and styles,
+  // advance output generation, and retain MXP generation.
+  while(!d.m_LineList.IsEmpty()) delete d.m_LineList.RemoveTail();
+  d.newLine(); ++d.m_iOutputGeneration;
+}
+static void callbackText(CMUSHclientDoc& d,bool nested) {
+  if(nested) { auto* tag=new CActiveTag; d.m_ActiveTagList.AddTail(tag); }
+  auto* s=d.AddStyle(4,2,3,8,"callback","","");
+  d.m_pCurrentLine->text="callback"; d.m_pCurrentLine->len=8;
+  d.RememberStyle(s);
+}
+static void packetChecks() {
+  int cases=0;
+  for(int action:{MXP_ACTION_VERSION,MXP_ACTION_AFK,MXP_ACTION_SUPPORT,MXP_ACTION_OPTION,MXP_ACTION_USER,MXP_ACTION_PASSWORD})
+    for(bool custom:{false,true}) for(bool paired:{false,true}) for(int mode=0;mode<6;++mode) {
+      CMUSHclientDoc d;
+      CStyle* callbackStyle=nullptr; CLine* callbackLine=nullptr;
+      __int64 styleIdentity=0, rangeIdentity=0, lineIdentity=0, nestedTagIdentity=0;
+      int callbacks=0;
+      d.callback=[&] {
+        ++callbacks;
+        if(mode==1||mode==3||mode==4) deleteOutput(d);
+        if(mode>=2) callbackText(d,mode>=3);
+        if(mode==4) ++d.m_iMXPGeneration;
+        if(mode>=3) nestedTagIdentity=d.m_ActiveTagList.GetTail()->nCreationNumber;
+        callbackStyle=d.tail(); callbackLine=d.m_pCurrentLine;
+        styleIdentity=callbackStyle->nCreationNumber; rangeIdentity=callbackStyle->nRangeCreationNumber; lineIdentity=callbackLine->nCreationNumber;
+      };
+      d.Run(custom,paired,action,custom);
+      assert(callbacks==1 && d.m_iOutputPacketCount==1 && d.socket.sends==1);
+      assert(d.m_nBytesOut==static_cast<int>(d.socket.m_outstanding_data.size()));
+      assert(d.socket.m_outstanding_data.find("response-")==0);
+      assert(d.diagnostics==1); // Deferred packet message is retained on rollback.
+      assert(d.m_pCurrentLine==callbackLine && callbackLine->nCreationNumber==lineIdentity);
+      if(mode>=2) {
+        assert(d.m_pCurrentLine->text=="callback");
+        assert(callbackStyle->nCreationNumber==styleIdentity && callbackStyle->nRangeCreationNumber==rangeIdentity);
+        assert(callbackStyle->iFlags==4 && callbackStyle->iForeColour==2 && callbackStyle->iBackColour==3);
+        assert(callbackStyle->pAction->value=="callback");
+        if(mode>=3) {
+          bool found=false;
+          for(POSITION pos=d.m_ActiveTagList.GetHeadPosition();pos;)
+            if(d.m_ActiveTagList.GetNext(pos)->nCreationNumber==nestedTagIdentity) found=true;
+          assert(found);
+        }
+      }
+      if(custom&&!paired&&(mode==1||mode==3)) {
+        assert(d.tail()!=callbackStyle && (d.tail()->iFlags&HILITE));
+        assert(d.tail()->pAction->value=="outer");
+      }
+      if(!custom&&(mode==1||mode==3)) assert(d.tail()==callbackStyle);
+      ++cases;
+    }
+  // No socket and disabled packet debugging retain their existing behavior.
+  for(int mode=0;mode<2;++mode) {
+    CMUSHclientDoc d; int calls=0; d.callback=[&]{++calls;};
+    if(mode==0) d.m_pSocket=nullptr; else d.m_bDebugIncomingPackets=false;
+    d.Run(false,false,MXP_ACTION_VERSION);
+    assert(calls==0 && d.diagnostics==1);
+    assert(d.m_iOutputPacketCount==(mode==0?0:1));
+  }
+  // Disabling MXP in a callback retains output and its response diagnostic.
+  {
+    CMUSHclientDoc d;
+    d.callback=[&]{deleteOutput(d); callbackText(d,true); d.m_bMXP=false;};
+    d.Run(false,true,MXP_ACTION_VERSION);
+    assert(!d.m_bMXP && d.diagnostics==1 && d.m_ActiveTagList.GetCount()==1);
+    assert(d.m_pCurrentLine->text=="callback" && d.tail()->pAction->value=="callback");
+  }
+  // Callback failure must propagate. Opening rollback must preserve its output.
+  CMUSHclientDoc d;
+  d.callback=[&]{callbackText(d,true); throw std::runtime_error("callback failure");};
+  bool threw=false;
+  try { d.Run(false,true,MXP_ACTION_VERSION); } catch(const std::runtime_error& e) { threw=std::string(e.what())=="callback failure"; }
+  assert(threw && d.m_ActiveTagList.GetCount()==1 && d.m_pCurrentLine->text=="callback");
+  assert(d.tail()->pAction->value=="callback");
+  std::printf("packet callback contracts: %d variants plus socket/debug/error cases passed\n",cases);
+}
+static void outputChecks() {
+  for(int action:{MXP_ACTION_BR,MXP_ACTION_HR,MXP_ACTION_LI,MXP_ACTION_IMG,MXP_ACTION_IMAGE}) {
+    for(bool custom:{false,true}) for(bool created:{false,true}) {
+      CMUSHclientDoc d; d.outputCreatesLine=created;
+      // Force HR and LI through the newline path.
+      d.m_pCurrentLine->len=1;
+      d.Run(custom,false,action,custom);
+      assert(d.tail());
+      if(custom) assert(d.tail()->iFlags&HILITE);
+    }
+  }
+  // A callback-supplied continuation is not an action-owned result.
+  for(int action:{MXP_ACTION_BR,MXP_ACTION_HR,MXP_ACTION_LI})
+    for(bool custom:{false,true}) {
+      CMUSHclientDoc d; d.outputCreatesLine=false; d.m_pCurrentLine->len=1;
+      CStyle* callbackStyle=nullptr;
+      d.callback=[&]{callbackText(d,true); callbackStyle=d.tail();};
+      d.Run(custom,false,action,custom);
+      assert(callbackStyle && callbackStyle->pAction->value=="callback");
+      assert(callbackStyle->iFlags==4 && d.m_pCurrentLine->text=="callback");
+      assert(d.m_ActiveTagList.GetCount()==1);
+      if(custom) assert(d.tail()!=callbackStyle && (d.tail()->iFlags&HILITE));
+      else assert(d.tail()==callbackStyle);
+    }
+  std::puts("output result contracts: new line, absent result, list and image identities passed");
+}
+static void lookupChecks() {
+  for(int count:{5000,500000}) {
+    CMUSHclientDoc d;
+    for(int i=1;i<count;++i) d.newLine();
+    auto* marker=d.AddStyle(START_TAG,7,0,0,"marker","","");
+    auto* result=d.AddStyle(0,7,0,0,"result","","");
+    CMXPStartTransaction tx(&d,++serial); tx.SetMarker(marker);
+    styleVisits=lineVisits=0;
+    assert(tx.IsPublishedStatePresent()); assert(tx.IsPublishedStatePresent());
+    assert(tx.ResolveStyle(result->nCreationNumber)==result);
+    assert(styleVisits==5 && lineVisits==3);
+    auto recentVisits=styleVisits;
+    styleVisits=lineVisits=0;
+    assert(tx.ResolveStyle(0)==nullptr && styleVisits==0 && lineVisits==0);
+    auto* oldest=d.m_LineList.GetHead()->styleList.GetHead();
+    assert(tx.ResolveStyle(oldest->nCreationNumber)==oldest);
+    assert(lineVisits==static_cast<unsigned>(count));
+    assert(tx.ResolveStyle(-1)==nullptr);
+    tx.Commit();
+    std::printf("lines=%d, styles visited for two marker checks and result=%llu\n",count,static_cast<unsigned long long>(recentVisits));
+  }
+}
+static void rollbackChecks() {
+  // Restore an empty preserved style via the opening marker. Retain identities.
+  for(bool repurposed:{false,true}) {
+    CMUSHclientDoc d;
+    auto* preserved=d.tail();
+    preserved->pAction=new CAction("preserved");
+    auto id=preserved->nCreationNumber, range=preserved->nRangeCreationNumber;
+    preserved->nOutputAppendCreationNumber=77;
+    CMXPStartTransaction tx(&d,++serial); tx.PreserveStyle(preserved);
+    delete d.m_pCurrentLine->styleList.RemoveTail();
+    auto* marker=d.AddStyle(START_TAG,1,2,0,"marker","",""); tx.SetMarker(marker);
+    auto* result=d.AddStyle(1,1,2,0,"result","",""); tx.SetStyle(result);
+    if(repurposed) { marker->iFlags=0; marker->iLength=4; d.m_pCurrentLine->text="kept"; }
+    tx.Rollback();
+    assert(d.tail()==marker && marker->nCreationNumber==id && marker->nRangeCreationNumber==range);
+    assert(marker->nOutputAppendCreationNumber==77 && marker->pAction->value=="preserved");
+    assert(marker->pAction->refs==1);
+    if(repurposed) assert(marker->iLength==4 && d.m_pCurrentLine->text=="kept");
+  }
+  // The same address with a new creation number is a different style.
+  {
+    CMUSHclientDoc d; CMXPStartTransaction tx(&d,++serial);
+    CStyle* s=d.tail(); auto oldIdentity=s->nCreationNumber;
+    tx.SetStyle(s); s->nCreationNumber=++serial;
+    assert(tx.ResolveStyle(oldIdentity)==nullptr);
+    assert(tx.ResolveStyle(s->nCreationNumber)==s);
+    tx.Rollback(); assert(d.tail()==s);
+  }
+  // Missing marker with surviving result, and a missing result after pruning.
+  for(bool pruneResult:{false,true}) {
+    CMUSHclientDoc d; CMXPStartTransaction tx(&d,++serial);
+    auto* s=d.tail(); auto id=s->nCreationNumber, range=s->nRangeCreationNumber;
+    tx.PreserveStyle(s); delete d.m_pCurrentLine->styleList.RemoveTail();
+    auto* marker=d.AddStyle(START_TAG,7,0,0,"marker","",""); tx.SetMarker(marker);
+    delete d.m_pCurrentLine->styleList.RemoveTail();
+    auto* result=d.AddStyle(0,7,0,0,"result","",""); tx.SetStyle(result);
+    if(pruneResult) deleteOutput(d);
+    tx.Rollback();
+    assert(d.tail());
+    if(!pruneResult) assert(d.tail()->nCreationNumber==id && d.tail()->nRangeCreationNumber==range);
+  }
+  std::puts("MXP rollback contracts: restored identities, repurposed marker, pruned styles passed");
+}
+int main() { packetChecks(); outputChecks(); rollbackChecks(); lookupChecks(); }

--- a/tests/output_callbacks.py
+++ b/tests/output_callbacks.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Compile production output functions with focused MFC substitutes.
+
+Run with Python 3 and clang++ on macOS or Linux. This check does not build MFC.
+The C++ assertions check output, styles, callback delivery, and failure returns.
+"""
+import argparse
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def section(source, start, end):
+    begin = source.index(start)
+    return source[begin:source.index(end, begin)]
+
+
+def replace_once(source, expected, replacement, context):
+    count = source.count(expected)
+    if count != 1:
+        raise ValueError(f'{context}: expected one occurrence of {expected!r}, found {count}')
+    return source.replace(expected, replacement)
+
+
+def run(source_root, output, append_only):
+    doc = (source_root / 'doc.cpp').read_text()
+    trigger = (source_root / 'ProcessPreviousLine.cpp').read_text()
+    shim_path = Path(__file__).parent / 'output_test_shim.h'
+    shim = shim_path.read_text()
+    header = (source_root / 'doc.h').read_text()
+    if not append_only:
+        snapshot_type = section(header, '  struct CTriggerLineSnapshot',
+                                '  void ProcessOneTriggerSequence')
+        shim = replace_once(shim, ' struct CTriggerLineSnapshot {long long iCreationNumber;int iColumn,iLength;};',
+                            snapshot_type, shim_path)
+    shim = replace_once(shim, 'template<class T> struct List',
+                        'size_t listReadCount=0;\ntemplate<class T> struct List', shim_path)
+    shim = replace_once(shim, 'T GetNext(POSITION& p)const{',
+                        'T GetNext(POSITION& p)const{++listReadCount;', shim_path)
+    body = '\n'.join([
+        section(doc, 'bool CMUSHclientDoc::StartNewLine_KeepPreviousStyle',
+                'COutputAppendTransaction::COutputAppendTransaction'),
+        section(doc, 'bool CMUSHclientDoc::AddToLine (',
+                '// called when starting a new line to get colours right'),
+        section(doc, 'bool CMUSHclientDoc::StartNewLine (',
+                'const bool CMUSHclientDoc::CheckScriptingAvailable'),
+        section(doc, ' void CMUSHclientDoc::RemoveChunk (void)',
+                'void CMUSHclientDoc::ShowStatusLine'),
+    ])
+    if not append_only:
+        body += section(doc, 'bool CMUSHclientDoc::FindStyle (',
+                        '// find RGB equivalents for a particular style of text')
+        body += section(trigger, 'static vector<CLine *> ResolveTriggerLines (',
+                        '// here when a newline is reached')
+        # Include the production generation refresh, colour predicate, and full
+        # output style-splitting loop. Pane copies and regex dispatch are outside
+        # this fixture; repeated match ranges are supplied by the test.
+        colour = section(trigger, '      // Pruning can remove old lines',
+                         '          // cool new feature in version 4.43')
+        body += r'''
+void CMUSHclientDoc::Colour(const vector<CTriggerLineSnapshot>& triggerLines,
+ const CString& strCurrentLine,int iStartCol,int iEndCol,function<void()> send,
+ int colourValue,bool multiline,int styleValue) {
+ struct Trigger {int colour,iStyle;bool bMultiLine;COLORREF iOtherForeground=11,
+ iOtherBackground=12;int iColourChangeType=TRIGGER_COLOUR_CHANGE_BOTH;};
+ Trigger trigger{colourValue,styleValue,multiline};auto trigger_item=&trigger;
+ bool bChangedColour=false;
+ auto outputLines=ResolveTriggerLines(this,triggerLines);
+ auto iOutputGeneration=m_iOutputGeneration;
+ send();
+''' + colour + '\n break;\n }\n }\n }\n'
+    if not append_only:
+        body += section(trigger, 'static inline unsigned short get_foreground',
+                        '// Resolve the original paragraph')
+        # Compile the actual matching block, including its local POSITION scope.
+        matching = section(trigger, '      if (trigger_item->iMatch && !trigger_item->bMultiLine)',
+                           '    // copy the wildcard contents to the clipboard')
+        body += r'''
+bool CMUSHclientDoc::Match(const vector<CTriggerLineSnapshot>& triggerLines,
+ const CString& strCurrentLine,int iStartCol,int condition,function<void()> send) {
+ struct Trigger {int iMatch;bool bMultiLine=false;};
+ Trigger item{condition};auto trigger_item=&item;
+ auto outputLines=ResolveTriggerLines(this,triggerLines);
+ auto iOutputGeneration=m_iOutputGeneration;
+ send();
+''' + section(trigger, '      if (iOutputGeneration != m_iOutputGeneration)',
+                '      if (trigger_item->iMatch && !trigger_item->bMultiLine)') + \
+            '\nfor(int fixture=0;fixture<1;++fixture) {\n' + matching + \
+            '\nreturn true;\n}\nreturn false;\n}\n'
+        # Keep the full logging and omission paths. View invalidation is outside
+        # this fixture. Deferred note replay is observed through its staged text.
+        body += r'''
+void CMUSHclientDoc::Finalize(const vector<CTriggerLineSnapshot>& triggerLines,
+ long long iParagraphGeneration,POSITION prevpos,bool omit,bool bNoLog,
+ const CString& strCurrentLine,long iParagraphReceivedNumber) {
+ POSITION pos;
+ m_bLineOmittedFromOutput=omit;
+''' + section(trigger, '  // Keep the original identity boundary',
+                '// if we have changed the colour of this trigger') + \
+            section(trigger, '  // logging wanted?',
+                    '  // display any stuff sent to output window') + '\n}\n'
+    main = (Path(__file__).parent / 'output_callbacks_main.cpp').read_text()
+    if not append_only:
+        main += (Path(__file__).parent / 'output_callbacks_followup.cpp').read_text()
+    defines = '#define APPEND_ONLY\n' if append_only else ''
+    cpp = output / 'output_callbacks.cpp'
+    cpp.write_text(defines + shim + body + main)
+    binary = output / 'output_callbacks'
+    subprocess.run(['clang++', '-std=c++17', '-fsanitize=address,undefined',
+                    '-fno-sanitize-recover=all', '-g', '-O1', str(cpp),
+                    '-o', str(binary)], check=True)
+    subprocess.run([str(binary)], check=True)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source', type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--output', type=Path)
+    parser.add_argument('--append-only', action='store_true')
+    args = parser.parse_args()
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=True)
+        run(args.source, args.output, args.append_only)
+    else:
+        with tempfile.TemporaryDirectory(prefix='mushclient-output-') as directory:
+            run(args.source, Path(directory), args.append_only)

--- a/tests/output_callbacks.py
+++ b/tests/output_callbacks.py
@@ -10,9 +10,14 @@ import subprocess
 import tempfile
 
 
-def section(source, start, end):
-    begin = source.index(start)
-    return source[begin:source.index(end, begin)]
+def section(source, start, end, context='section'):
+    begin = source.find(start)
+    if begin < 0:
+        raise ValueError(f'{context}: start anchor not found: {start!r}')
+    finish = source.find(end, begin)
+    if finish < 0:
+        raise ValueError(f'{context}: end anchor not found: {end!r}')
+    return source[begin:finish]
 
 
 def replace_once(source, expected, replacement, context):
@@ -20,6 +25,23 @@ def replace_once(source, expected, replacement, context):
     if count != 1:
         raise ValueError(f'{context}: expected one occurrence of {expected!r}, found {count}')
     return source.replace(expected, replacement)
+
+
+def line_buffer_header(source_root, revision=None, *, memory_exception_defined=False):
+    path = 'output_line_buffer.h'
+    if revision:
+        names = subprocess.check_output(
+            ['git', '-C', str(source_root), 'ls-tree', '--name-only', revision, '--', path],
+            text=True).splitlines()
+        if not names:
+            return ''
+        contents = subprocess.check_output(
+            ['git', '-C', str(source_root), 'show', revision + ':' + path], text=True)
+    else:
+        contents = (source_root / path).read_text()
+    if not memory_exception_defined:
+        contents = 'void AfxThrowMemoryException(){throw new CMemoryException;}\n' + contents
+    return contents + '\n'
 
 
 def run(source_root, output, append_only):
@@ -30,33 +52,38 @@ def run(source_root, output, append_only):
     header = (source_root / 'doc.h').read_text()
     if not append_only:
         snapshot_type = section(header, '  struct CTriggerLineSnapshot',
-                                '  void ProcessOneTriggerSequence')
+                                '  void ProcessOneTriggerSequence', 'doc.h')
         shim = replace_once(shim, ' struct CTriggerLineSnapshot {long long iCreationNumber;int iColumn,iLength;};',
                             snapshot_type, shim_path)
     shim = replace_once(shim, 'template<class T> struct List',
                         'size_t listReadCount=0;\ntemplate<class T> struct List', shim_path)
     shim = replace_once(shim, 'T GetNext(POSITION& p)const{',
                         'T GetNext(POSITION& p)const{++listReadCount;', shim_path)
+    shim = replace_once(shim, 'T GetPrev(POSITION& p){',
+                        'T GetPrev(POSITION& p){++listReadCount;', shim_path)
+    shim = replace_once(shim, 'POSITION m_pLinePositions[11]={};',
+                        'vector<POSITION> positionStorage=vector<POSITION>(200000 / JUMP_SIZE + 1);'
+                        'POSITION* m_pLinePositions=positionStorage.data();', shim_path)
     body = '\n'.join([
         section(doc, 'bool CMUSHclientDoc::StartNewLine_KeepPreviousStyle',
-                'COutputAppendTransaction::COutputAppendTransaction'),
+                'COutputAppendTransaction::COutputAppendTransaction', 'doc.cpp'),
         section(doc, 'bool CMUSHclientDoc::AddToLine (',
-                '// called when starting a new line to get colours right'),
+                '// called when starting a new line to get colours right', 'doc.cpp'),
         section(doc, 'bool CMUSHclientDoc::StartNewLine (',
-                'const bool CMUSHclientDoc::CheckScriptingAvailable'),
+                'const bool CMUSHclientDoc::CheckScriptingAvailable', 'doc.cpp'),
         section(doc, ' void CMUSHclientDoc::RemoveChunk (void)',
-                'void CMUSHclientDoc::ShowStatusLine'),
+                'void CMUSHclientDoc::ShowStatusLine', 'doc.cpp'),
     ])
     if not append_only:
         body += section(doc, 'bool CMUSHclientDoc::FindStyle (',
-                        '// find RGB equivalents for a particular style of text')
+                        '// find RGB equivalents for a particular style of text', 'doc.cpp')
         body += section(trigger, 'static vector<CLine *> ResolveTriggerLines (',
-                        '// here when a newline is reached')
+                        '// here when a newline is reached', 'ProcessPreviousLine.cpp')
         # Include the production generation refresh, colour predicate, and full
         # output style-splitting loop. Pane copies and regex dispatch are outside
         # this fixture; repeated match ranges are supplied by the test.
         colour = section(trigger, '      // Pruning can remove old lines',
-                         '          // cool new feature in version 4.43')
+                         '          // cool new feature in version 4.43', 'ProcessPreviousLine.cpp')
         body += r'''
 void CMUSHclientDoc::Colour(const vector<CTriggerLineSnapshot>& triggerLines,
  const CString& strCurrentLine,int iStartCol,int iEndCol,function<void()> send,
@@ -71,10 +98,10 @@ void CMUSHclientDoc::Colour(const vector<CTriggerLineSnapshot>& triggerLines,
 ''' + colour + '\n break;\n }\n }\n }\n'
     if not append_only:
         body += section(trigger, 'static inline unsigned short get_foreground',
-                        '// Resolve the original paragraph')
+                        '// Resolve the original paragraph', 'ProcessPreviousLine.cpp')
         # Compile the actual matching block, including its local POSITION scope.
         matching = section(trigger, '      if (trigger_item->iMatch && !trigger_item->bMultiLine)',
-                           '    // copy the wildcard contents to the clipboard')
+                           '    // copy the wildcard contents to the clipboard', 'ProcessPreviousLine.cpp')
         body += r'''
 bool CMUSHclientDoc::Match(const vector<CTriggerLineSnapshot>& triggerLines,
  const CString& strCurrentLine,int iStartCol,int condition,function<void()> send) {
@@ -84,7 +111,7 @@ bool CMUSHclientDoc::Match(const vector<CTriggerLineSnapshot>& triggerLines,
  auto iOutputGeneration=m_iOutputGeneration;
  send();
 ''' + section(trigger, '      if (iOutputGeneration != m_iOutputGeneration)',
-                '      if (trigger_item->iMatch && !trigger_item->bMultiLine)') + \
+                '      if (trigger_item->iMatch && !trigger_item->bMultiLine)', 'ProcessPreviousLine.cpp') + \
             '\nfor(int fixture=0;fixture<1;++fixture) {\n' + matching + \
             '\nreturn true;\n}\nreturn false;\n}\n'
         # Keep the full logging and omission paths. View invalidation is outside
@@ -96,15 +123,15 @@ void CMUSHclientDoc::Finalize(const vector<CTriggerLineSnapshot>& triggerLines,
  POSITION pos;
  m_bLineOmittedFromOutput=omit;
 ''' + section(trigger, '  // Keep the original identity boundary',
-                '// if we have changed the colour of this trigger') + \
+                '// if we have changed the colour of this trigger', 'ProcessPreviousLine.cpp') + \
             section(trigger, '  // logging wanted?',
-                    '  // display any stuff sent to output window') + '\n}\n'
+                    '  // display any stuff sent to output window', 'ProcessPreviousLine.cpp') + '\n}\n'
     main = (Path(__file__).parent / 'output_callbacks_main.cpp').read_text()
     if not append_only:
         main += (Path(__file__).parent / 'output_callbacks_followup.cpp').read_text()
     defines = '#define APPEND_ONLY\n' if append_only else ''
     cpp = output / 'output_callbacks.cpp'
-    cpp.write_text(defines + shim + body + main)
+    cpp.write_text(defines + shim + line_buffer_header(source_root) + body + main)
     binary = output / 'output_callbacks'
     subprocess.run(['clang++', '-std=c++17', '-fsanitize=address,undefined',
                     '-fno-sanitize-recover=all', '-g', '-O1', str(cpp),

--- a/tests/output_callbacks_followup.cpp
+++ b/tests/output_callbacks_followup.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 // The ASCII fixture retains DisplayMsg's newline and final partial-line delivery.
 // Packet transformations, MXP, and unrelated triggers are disabled in these tests.
 static void simulateASCII(CMUSHclientDoc& d,const string& input) {
@@ -140,6 +141,7 @@ static void omissionCases() {
  // The previous unterminated note remains the continuation, as before.
  {
   CMUSHclientDoc d;assert(d.AddToLine("note",COMMENT));auto note=d.m_pCurrentLine;note->flags=COMMENT;
+  d.m_pLinePositions[0]=d.m_LineList.GetHeadPosition();
   assert(d.StartNewLine(false,0));assert(d.AddToLine("matched",0));auto original=d.m_pCurrentLine;
   auto first=d.m_LineList.GetTailPosition();auto saved=snapshot({original});original->hard_return=true;
   d.m_OutstandingLines.push_back(CPaneStyle(" deferred",13,0,HILITE));
@@ -154,6 +156,90 @@ static void omissionCases() {
   assert(d.replayedText=="note\r\n");checkPositions(d);
  }
  cout<<"Omission: 24 callback/pruning cases, current lines, positions, history, failures, and deferred replay passed\n";
+}
+static void omissionTailContinuationCases() {
+ for(int kind:{0,COMMENT,USER_INPUT})for(bool ended:{false,true}) {
+  CMUSHclientDoc d;assert(d.AddToLine("matched",0));
+  auto original=d.m_pCurrentLine;auto first=d.m_LineList.GetTailPosition();
+  auto saved=snapshot({original});original->hard_return=true;
+  assert(d.StartNewLine(false,kind));assert(d.AddToLine("callback",kind));
+  auto callback=d.m_pCurrentLine;
+  // Use the production line transition to complete callback output.
+  if(ended)assert(d.StartNewLine(true,kind));
+  auto continuation=d.m_pCurrentLine;
+  assert(!continuation->hard_return);
+  d.Finalize(saved,d.m_iOutputGeneration,first,true,true,"matched");
+  assert(d.m_pCurrentLine==continuation && continuation==d.m_LineList.GetTail());
+  assert(d.AddToLine(" next",kind));
+  assert(text(callback)==(ended?"callback":"callback next"));
+  assert(text(continuation)==(ended?" next":"callback next"));
+  assert(callback->hard_return==ended && !continuation->hard_return);
+  checkPositions(d);
+ }
+ cout<<"Omission continuation: output, note, and command callbacks with production line transitions passed\n";
+}
+// Build indexed history without running unrelated trigger callbacks.
+static void seedOmissionHistory(CMUSHclientDoc& d,int count) {
+ d.m_pCurrentLine->flags=COMMENT;
+ d.m_pLinePositions[0]=d.m_LineList.GetHeadPosition();
+ while(d.m_LineList.GetCount()<count)assert(d.StartNewLine(false,COMMENT));
+}
+static void omissionIndexBoundaryCases() {
+ for(int prefix:{0,1,98,99,100,101,198,199,200,249})
+  for(int omitted:{1,2,101})for(int later:{0,1,2,101}) {
+   CMUSHclientDoc d;seedOmissionHistory(d,prefix+1);
+   auto first=d.m_LineList.GetTailPosition();d.m_pCurrentLine->flags=0;
+   vector<CLine*> originals={d.m_pCurrentLine};
+   for(int i=1;i<omitted;++i) {
+    assert(d.StartNewLine(false,0));originals.push_back(d.m_pCurrentLine);
+   }
+   auto saved=snapshot(originals);d.m_pCurrentLine->hard_return=true;
+   vector<CLine*> callbacks;
+   for(int i=0;i<later;++i) {
+    assert(d.StartNewLine(false,COMMENT));assert(d.AddToLine("callback",COMMENT));
+    callbacks.push_back(d.m_pCurrentLine);
+   }
+   auto before=lines(d);vector<POSITION> prefixPositions;
+   for(int i=0;i*JUMP_SIZE<prefix;++i)prefixPositions.push_back(d.m_pLinePositions[i]);
+   auto oldTotal=d.m_total_lines;
+   d.Finalize(saved,d.m_iOutputGeneration,first,true,true,"");
+   auto after=lines(d);
+   // The old partial note remains current only when there is no later output.
+   const bool reuseNote=prefix>0 && later==0;
+   assert(d.m_LineList.GetCount()==prefix+later+(!reuseNote && later==0?1:0));
+   assert(d.m_total_lines==oldTotal-omitted+(!reuseNote && later==0?1:0));
+   for(int i=0;i<prefix;++i)assert(after[i]==before[i]);
+   for(size_t i=0;i<prefixPositions.size();++i)assert(d.m_pLinePositions[i]==prefixPositions[i]);
+   for(int i=0;i<later;++i)assert(after[prefix+i]==callbacks[i] && text(callbacks[i])=="callback");
+   checkPositions(d);
+  }
+ cout<<"Omission index boundaries: 120 prefix, paragraph, and callback suffix cases passed\n";
+}
+static void omissionBufferScalingCases() {
+ for(int history:{1000,100000}) {
+  CMUSHclientDoc d;d.m_maxlines=200000;seedOmissionHistory(d,history+1);
+  d.m_pCurrentLine->flags=0;
+  // Close the history so each omission supplies an empty output continuation.
+  auto previous=d.m_LineList.GetTailPosition();d.m_LineList.GetPrev(previous);
+  d.m_LineList.GetAt(previous)->hard_return=true;
+  size_t reads=0;constexpr int repetitions=256;
+  const auto start=chrono::steady_clock::now();
+  for(int i=0;i<repetitions;++i) {
+   assert(d.AddToLine("omitted",0));auto original=d.m_pCurrentLine;
+   auto saved=snapshot({original});original->hard_return=true;
+   auto first=d.m_LineList.GetTailPosition();
+   listReadCount=0;
+   d.Finalize(saved,d.m_iOutputGeneration,first,true,true,"omitted");
+   reads+=listReadCount;
+   assert(d.m_pCurrentLine!=original && !d.m_pCurrentLine->hard_return);
+   assert(d.m_pCurrentLine->len==0 && d.m_LineList.GetCount()==history+1);
+  }
+  auto elapsed=chrono::duration_cast<chrono::microseconds>(chrono::steady_clock::now()-start).count();
+  cout<<"Omission buffer scaling: history="<<history<<", repetitions="<<repetitions
+      <<", list reads="<<reads<<", microseconds="<<elapsed<<endl;
+  assert(reads<=static_cast<size_t>(repetitions)*4);
+  checkPositions(d);
+ }
 }
 static void loggingCases() {
  for(int mode:{0,1,2}) {
@@ -207,5 +293,7 @@ static void loggingBoundaryCases() {
  cout<<"Colour logging stops at the captured paragraph boundary\n";
 }
 static void followupCases() {
- callbackProgressCases();matchingCases();omissionCases();loggingCases();loggingBoundaryCases();
+ callbackProgressCases();matchingCases();omissionCases();omissionTailContinuationCases();
+ omissionIndexBoundaryCases();
+ omissionBufferScalingCases();loggingCases();loggingBoundaryCases();
 }

--- a/tests/output_callbacks_followup.cpp
+++ b/tests/output_callbacks_followup.cpp
@@ -1,0 +1,211 @@
+// The ASCII fixture retains DisplayMsg's newline and final partial-line delivery.
+// Packet transformations, MXP, and unrelated triggers are disabled in these tests.
+static void simulateASCII(CMUSHclientDoc& d,const string& input) {
+ auto original=d.m_pCurrentLine;string old=text(original);
+ for(char c:input) {
+  if(c=='\n')assert(d.StartNewLine(true,0));
+  else {char one[2]={c,0};assert(d.AddToLine(one,0));}
+ }
+ if(original!=d.m_pCurrentLine || old!=text(d.m_pCurrentLine))d.SendLineToPlugin();
+}
+static CLine* findLine(CMUSHclientDoc& d,long long id) {
+ for(auto line:lines(d))if(line->nCreationNumber==id)return line;
+ return nullptr;
+}
+static void checkPositions(CMUSHclientDoc& d) {
+ int index=0;
+ for(auto pos=d.m_LineList.GetHeadPosition();pos;++index) {
+  auto current=pos;auto line=d.m_LineList.GetNext(pos);
+  if(index%JUMP_SIZE==0)assert(d.m_pLinePositions[index/JUMP_SIZE]==current);
+  assert(line->m_nLineNumber==d.m_total_lines-d.m_LineList.GetCount()+index+1);
+ }
+ for(int i=(index+JUMP_SIZE-1)/JUMP_SIZE;i<=d.m_maxlines/JUMP_SIZE;++i)
+  assert(!d.m_pLinePositions[i]);
+ assert(d.m_pCurrentLine==d.m_LineList.GetTail());checkStyles(d);
+}
+static vector<CMUSHclientDoc::CTriggerLineSnapshot> capture(CMUSHclientDoc& d,POSITION p) {
+ vector<CLine*> result;while(p)result.push_back(d.m_LineList.GetNext(p));return snapshot(result);
+}
+static void callbackProgressCases() {
+ for(bool prune:{false,true}) {
+  CMUSHclientDoc d;d.m_maxlines=200;
+  if(prune)while(d.m_LineList.GetCount()<200)assert(d.StartNewLine(true,COMMENT));
+  assert(d.AddToLine(string(80,'A').c_str(),0));
+  bool entered=false;int outerCalls=0;
+  vector<string> trace;
+  d.callback=[&] {
+   trace.push_back(string(entered?"nested ":"outer ")+text(d.m_pCurrentLine));
+   assert(trace.size()<=6); // A repeated outer wrap must fail this regression check.
+   if(entered)return;
+   ++outerCalls;entered=true;simulateASCII(d,"\n"+string(80,'B'));entered=false;
+  };
+  assert(d.AddToLine("Z",0));
+  assert(outerCalls==1);assert(trace.size()==3);assert(text(d.m_pCurrentLine)=="Z");
+  d.SendLineToPlugin(); // DisplayMsg completion for the original input.
+  vector<string> expected={"outer "+string(80,'A'),"nested "+string(80,'A'),
+   "nested "+string(80,'B'),"outer Z","nested Z","nested "+string(80,'B')};
+  assert(trace==expected);assert(outerCalls==2);
+  assert(allText(d)==string(80,'A')+string(80,'B')+"Z"+string(80,'B'));
+  assert(d.m_iOutputGeneration==(prune?1:0));checkStyles(d);
+ }
+ // The callback's full line must retain its own normal word-wrap boundary.
+ for(int originalShape:{0,1,2})for(int callbackShape:{0,1,2})for(bool utf:{false,true}) {
+  CMUSHclientDoc d;d.m_bUTF_8=utf;
+  string original(80,'A'),replacement(80,'B');
+  if(originalShape)original[originalShape==1?72:79]=' ';
+  if(callbackShape)replacement[callbackShape==1?72:79]=' ';
+  assert(d.AddToLine(original.c_str(),0));bool entered=false,done=false;int deliveries=0;
+  CAction* action=nullptr;
+  d.callback=[&]{++deliveries;if(entered||done)return;done=true;entered=true;
+   assert(d.StartNewLine(true,0));auto style=d.m_pCurrentLine->styleList.GetTail();
+   style->iForeColour=13;style->pAction=action=new CAction;
+   assert(d.AddToLine(replacement.c_str(),0));d.SendLineToPlugin();entered=false;};
+  COutputAppendTransaction transaction;
+  assert(d.AddToLineInternal("Z",0,&transaction));
+  assert(allText(d)==original+replacement+"Z");assert(deliveries==3);
+  assert(text(d.m_pCurrentLine)==(callbackShape==1?string(7,'B')+"Z":"Z"));
+  assert(d.m_pCurrentLine->styleList.GetTail()->pAction==action);
+  assert(d.m_pCurrentLine->styleList.GetTail()->iForeColour==13);
+  assert(transaction.created==1);assert(transaction.wraps==(callbackShape==1?1:0));checkStyles(d);
+ }
+ // Restoration must retain saved word bytes when the callback throws after shrinking.
+ {
+  CMUSHclientDoc d;string original=string(72,'A')+" "+string(7,'B');
+  assert(d.AddToLine(original.c_str(),0));auto originalLine=d.m_pCurrentLine;bool entered=false;
+  d.callback=[&]{if(entered)return;entered=true;assert(d.StartNewLine(true,0));
+   throw runtime_error("restore word");};
+  bool caught=false;try{d.AddToLine("Z",0);}catch(const runtime_error& e){caught=string(e.what())=="restore word";}
+  assert(caught);assert(text(originalLine)==original);checkStyles(d);
+ }
+ cout<<"Callback progress: exact six-delivery trace, pruning, replacement wrapping, and failure restoration passed\n";
+}
+static void matchingCases() {
+ CMUSHclientDoc d;assert(d.AddToLine("abcd",0));auto first=d.m_pCurrentLine;
+ assert(d.StartNewLine(false,0));assert(d.AddToLine("efgh",0));auto second=d.m_pCurrentLine;
+ second->styleList.GetTail()->iForeColour=2;
+ auto saved=snapshot({first,second});
+ assert(d.Match(saved,"abcdefgh",4,TRIGGER_MATCH_TEXT|(2<<4),[]{}));
+ assert(d.Match(saved,"abcdefgh",4,TRIGGER_MATCH_TEXT|(2<<4),[&]{
+  delete d.m_LineList.RemoveHead();++d.m_iOutputGeneration;
+  assert(d.StartNewLine(false,0));assert(d.AddToLine("callback",0));}));
+ assert(!d.Match(saved,"abcdefgh",4,TRIGGER_MATCH_TEXT|(3<<4),[]{}));
+ assert(!d.Match(saved,"abcdefgh",4,TRIGGER_MATCH_TEXT|(2<<4),[&]{second->text[0]='X';}));
+ cout<<"Production matching block: scope, generation refresh, offsets, and text checks passed\n";
+}
+static void omissionCases() {
+ // Modes: no pruning, old history pruned, partial paragraph pruned, all originals pruned.
+ for(int mode:{0,1,2,3})for(int kind:{0,COMMENT,USER_INPUT})for(bool ended:{false,true}) {
+  CMUSHclientDoc d;d.m_maxlines=200;POSITION first;
+  if(mode==2) {
+   while(d.m_LineList.GetCount()<100)assert(d.StartNewLine(true,COMMENT));
+   first=d.m_LineList.GetTailPosition();d.m_pCurrentLine->flags=0;
+   assert(d.AddToLine(string(8080,'A').c_str(),0));assert(d.m_LineList.GetCount()==200);
+  } else {
+   if(mode)while(d.m_LineList.GetCount()<200)assert(d.StartNewLine(true,COMMENT));
+   first=d.m_LineList.GetTailPosition();d.m_pCurrentLine->flags=0;
+   assert(d.AddToLine("matched",0));
+  }
+  d.m_pCurrentLine->hard_return=true;
+  auto saved=capture(d,first);auto generation=d.m_iOutputGeneration;
+  d.m_sRecentLines={"prior","matched"};d.m_newlines_received=2;
+  assert(d.StartNewLine(true,kind));assert(d.AddToLine("callback",kind));
+  auto callback=d.m_pCurrentLine;auto id=callback->nCreationNumber;
+  auto style=callback->styleList.GetTail();style->pAction=new CAction;style->iForeColour=13;
+  callback->hard_return=ended;
+  if(ended && kind==0){d.m_sRecentLines.push_back("callback");++d.m_newlines_received;}
+  if(mode==3)for(int i=0;i<100;++i)assert(d.StartNewLine(false,0));
+  auto last=d.m_pCurrentLine;
+  d.m_iStopTriggerEvaluation=d.eStopEvaluatingTriggersInAllPlugins;
+  d.m_logfile=true;
+  d.Finalize(saved,generation,first,true,false,"matched",2);
+  assert(findLine(d,id)==callback);assert(d.m_pCurrentLine==last);
+  assert(text(callback)=="callback");assert(callback->hard_return==ended);
+  assert(callback->styleList.GetTail()==style);assert(style->iForeColour==13 && style->pAction);
+  assert(!(callback->flags&LOG_LINE));assert(d.replayedText.empty());
+  for(auto span:saved)assert(!findLine(d,span.iCreationNumber));
+  assert(d.logText=="matched\n");
+  if(ended && kind==0)assert(d.m_sRecentLines.back()=="callback");
+  if(mode!=3)checkPositions(d);else checkStyles(d);
+ }
+ // Normal omission supplies an empty current line. Allocation failure keeps the old state.
+ for(bool fail:{false,true}) {
+  CMUSHclientDoc d;assert(d.AddToLine("matched",0));auto original=d.m_pCurrentLine;
+  auto first=d.m_LineList.GetTailPosition();auto saved=snapshot({original});original->hard_return=true;
+  fail_next_line=fail;bool caught=false;
+  try{d.Finalize(saved,0,first,true,true,"matched");}catch(CMemoryException* e){caught=true;e->Delete();}
+  assert(caught==fail);
+  if(fail){assert(d.m_pCurrentLine==original);assert(text(original)=="matched");assert(d.m_iOutputGeneration==0);}
+  else {assert(d.m_pCurrentLine!=original);assert(d.m_pCurrentLine->len==0);checkPositions(d);}
+ }
+ // The previous unterminated note remains the continuation, as before.
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("note",COMMENT));auto note=d.m_pCurrentLine;note->flags=COMMENT;
+  assert(d.StartNewLine(false,0));assert(d.AddToLine("matched",0));auto original=d.m_pCurrentLine;
+  auto first=d.m_LineList.GetTailPosition();auto saved=snapshot({original});original->hard_return=true;
+  d.m_OutstandingLines.push_back(CPaneStyle(" deferred",13,0,HILITE));
+  d.Finalize(saved,0,first,true,true,"matched");
+  assert(d.m_pCurrentLine==note);assert(text(note)=="note");assert(d.replayedText==" deferred");checkPositions(d);
+ }
+ // Keep the existing replay branch when an original span carries note styles.
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("note",COMMENT));auto original=d.m_pCurrentLine;
+  original->flags=COMMENT;original->hard_return=true;auto saved=snapshot({original});
+  d.Finalize(saved,0,d.m_LineList.GetTailPosition(),true,true,"note");
+  assert(d.replayedText=="note\r\n");checkPositions(d);
+ }
+ cout<<"Omission: 24 callback/pruning cases, current lines, positions, history, failures, and deferred replay passed\n";
+}
+static void loggingCases() {
+ for(int mode:{0,1,2}) {
+  CMUSHclientDoc d;assert(d.AddToLine("a&b",0));auto first=d.m_LineList.GetHeadPosition();
+  auto original=d.m_pCurrentLine;auto saved=snapshot({original});original->hard_return=true;
+  assert(d.AddToLine(" appended",0)); // Same identity, outside the saved byte extent.
+  assert(d.StartNewLine(false,COMMENT));assert(d.AddToLine("unlogged note",COMMENT));
+  auto note=d.m_pCurrentLine;note->hard_return=true;
+  d.m_logfile=true;d.m_bLogHTML=mode!=0;d.m_bLogInColour=mode==2;
+  d.m_strLogLinePreambleOutput="[";d.m_strLogLinePostambleOutput="]";
+  d.Finalize(saved,0,first,false,false,"a&b");
+  assert(original->flags&LOG_LINE);assert(!(note->flags&LOG_LINE));
+  assert(d.logText.find("unlogged")==string::npos && d.logText.find("appended")==string::npos);
+  assert(d.logText.find(mode?"a&amp;b":"a&b")!=string::npos);
+  if(mode<2)assert(d.logText==(mode?"[a&amp;b]\n":"[a&b]\n"));
+  assert(d.screenText=="a&b");
+  d.logText.clear();d.LogLineInHTMLcolour(first); // Existing unbounded caller contract.
+  assert(d.logText.find("appended")!=string::npos);
+ }
+ // A pruned first span must not make a later callback line part of the HTML log.
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("abcd",0));auto first=d.m_LineList.GetHeadPosition();
+  auto a=d.m_pCurrentLine;assert(d.StartNewLine(false,0));assert(d.AddToLine("efgh",0));auto b=d.m_pCurrentLine;
+  auto saved=snapshot({a,b});
+  assert(d.StartNewLine(false,COMMENT));assert(d.AddToLine("callback",COMMENT));
+  delete d.m_LineList.RemoveHead();++d.m_iOutputGeneration;
+  d.m_logfile=d.m_bLogHTML=d.m_bLogInColour=true;
+  d.Finalize(saved,0,first,false,false,"abcdefgh");
+  assert(d.logText.find("efgh")!=string::npos);assert(d.logText.find("callback")==string::npos);
+ }
+ cout<<"Logging: plain text, HTML, colour HTML, byte bounds, pruning, and note flags passed\n";
+}
+static void loggingBoundaryCases() {
+ CMUSHclientDoc d;
+ assert(d.AddToLine("original",0));
+ auto first=d.m_LineList.GetHeadPosition();
+ map<__int64,int> lengths={{d.m_pCurrentLine->nCreationNumber,8}};
+ // A callback replaces the paragraph end with later output. None of those
+ // later lines belongs to the captured log entry, even without a hard return.
+ for(int i=0;i<1000;++i) {
+  auto line=new CLine(++d.m_total_lines,80,0,7,0,false);
+  d.m_LineList.AddTail(line);d.m_pCurrentLine=line;
+ }
+ listReadCount=0;
+ d.LogLineInHTMLcolour(first,&lengths);
+ assert(d.logText.find("original")!=string::npos);
+ assert(listReadCount<=3);
+ d.logText.clear();lengths.clear();listReadCount=0;
+ d.LogLineInHTMLcolour(first,&lengths);
+ assert(d.logText.empty() && listReadCount==0);
+ cout<<"Colour logging stops at the captured paragraph boundary\n";
+}
+static void followupCases() {
+ callbackProgressCases();matchingCases();omissionCases();loggingCases();loggingBoundaryCases();
+}

--- a/tests/output_callbacks_main.cpp
+++ b/tests/output_callbacks_main.cpp
@@ -1,0 +1,194 @@
+// Regression scenarios for the production append and trigger colour loops.
+static string text(CLine* line) { return string(line->text,line->len); }
+static vector<CLine*> lines(CMUSHclientDoc& d) {
+ vector<CLine*> result;
+ for(auto p=d.m_LineList.GetHeadPosition();p;)result.push_back(d.m_LineList.GetNext(p));
+ return result;
+}
+static string allText(CMUSHclientDoc& d) {
+ string result;for(auto line:lines(d))result+=text(line);return result;
+}
+static void checkStyles(CMUSHclientDoc& d) {
+ for(auto line:lines(d)) {
+  assert(line->len<=line->iMemoryAllocated);int count=0;
+  for(auto p=line->styleList.GetHeadPosition();p;)count+=line->styleList.GetNext(p)->iLength;
+  assert(count==line->len);
+ }
+}
+static void appendCases() {
+ for(int shape=0;shape<3;++shape)for(int fill:{0,7,79,80})for(bool utf:{false,true}) {
+  CMUSHclientDoc d;d.m_bUTF_8=utf;
+  string original(80,'A');
+  if(shape==1)original[72]=' '; // move a word to the next line
+  if(shape==2)original[79]=' '; // no saved word
+  assert(d.AddToLine(original.c_str(),0));
+  CLine* supplied=nullptr;bool done=false;int deliveries=0;
+  d.callback=[&]{++deliveries;if(done)return;done=true;
+   assert(d.StartNewLine(true,0));supplied=d.m_pCurrentLine;
+   auto style=supplied->styleList.GetTail();style->iForeColour=13;
+   style->pAction=new CAction;
+   assert(d.AddToLine(string(fill,'B').c_str(),0));
+  };
+  assert(d.AddToLine("Z",0));
+  assert(allText(d)==original+string(fill,'B')+"Z");
+  assert(d.m_pCurrentLine->styleList.GetTail()->iForeColour==13);
+  assert(d.m_pCurrentLine->styleList.GetTail()->pAction==supplied->styleList.GetTail()->pAction);
+  assert(text(supplied)==string(fill,'B')+(fill<80?"Z":""));
+  assert(deliveries==2);checkStyles(d);
+ }
+ cout<<"24 callback width, word-wrap, style, and action cases passed\n";
+ for(int shape=0;shape<3;++shape) {
+  CMUSHclientDoc d;string original(80,'A');
+  if(shape==1)original[72]=' ';
+  if(shape==2){original[78]=char(0x81);original[79]=char(0x40);}
+  assert(d.AddToLine(original.c_str(),0));assert(d.AddToLine("Z",0));
+  assert(allText(d)==original+"Z");checkStyles(d);
+ }
+ for(int repeats:{1,3}) {
+  CMUSHclientDoc d;assert(d.AddToLine(string(80,'A').c_str(),0));
+  int remaining=repeats;bool entered=false;
+  d.callback=[&]{if(entered||!remaining)return;--remaining;entered=true;
+   assert(d.StartNewLine(true,0));assert(d.AddToLine(string(80,'B').c_str(),0));entered=false;};
+  assert(d.AddToLine(string((repeats-1)*80+1,'Z').c_str(),0));assert(remaining==0);
+  string expected(80,'A');
+  for(int i=0;i<repeats;++i)expected+=string(80,'B')+string(i+1==repeats?1:80,'Z');
+  assert(allText(d)==expected);checkStyles(d);
+ }
+ for(int failure:{0,1,2}) {
+  CMUSHclientDoc d;assert(d.AddToLine(string(80,'A').c_str(),0));bool done=false;
+  d.callback=[&]{if(done)return;done=true;assert(d.StartNewLine(true,0));
+   assert(d.AddToLine(string(80,'B').c_str(),0));
+   if(failure==0)fail_next_line=true;
+   if(failure==1)throw runtime_error("callback failure");
+   if(failure==2){while(!d.m_LineList.IsEmpty())delete d.m_LineList.RemoveHead();d.m_pCurrentLine=nullptr;++d.m_iOutputGeneration;}
+  };
+  if(failure==1) {
+   bool caught=false;try{d.AddToLine("Z",0);}catch(const runtime_error& e){caught=string(e.what())=="callback failure";}
+   assert(caught);
+  } else assert(!d.AddToLine("Z",0));
+  if(failure!=2)assert(allText(d)==string(80,'A')+string(80,'B'));
+  assert(d.disconnects==(failure==0?1:0));checkStyles(d);
+ }
+ {
+  CMUSHclientDoc d;assert(d.AddToLine(string(80,'A').c_str(),0));bool done=false;
+  d.callback=[&]{if(done)return;done=true;assert(d.StartNewLine(true,0));assert(d.AddToLine(string(80,'B').c_str(),0));};
+  COutputAppendTransaction transaction;
+  assert(d.AddToLineInternal("Z",0,&transaction));assert(transaction.created==1);
+  auto output=lines(d);assert(output[1]->styleList.GetTail()->nOutputAppendCreationNumber==0);
+  assert(output[2]->styleList.GetTail()->nOutputAppendCreationNumber==4242);checkStyles(d);
+ }
+ {
+  CMUSHclientDoc d;d.m_bUTF_8=true;assert(d.StartNewLine(false,COMMENT));
+  string original;for(int i=0;i<80;++i)original+="\xc3\xa9";
+  assert(d.AddToLine(original.c_str(),0));bool done=false;
+  d.callback=[&]{if(done)return;done=true;assert(d.StartNewLine(true,0));assert(d.AddToLine(original.c_str(),0));};
+  assert(d.AddToLine("\xc3\xa9",0));assert(allText(d)==original+original+"\xc3\xa9");
+  assert(text(d.m_pCurrentLine)=="\xc3\xa9");checkStyles(d);
+ }
+ {
+  CMUSHclientDoc d;assert(d.AddToLine(string(80,'A').c_str(),0));int callbacks=d.callbacks;
+  assert(d.AddToLine("Z",COMMENT));assert(d.callbacks==callbacks);checkStyles(d);
+ }
+ {
+  CMUSHclientDoc d;string prefix=string(72,'A')+" BB";
+  assert(d.AddToLine(prefix.c_str(),0));
+  auto marker=new CStyle;marker->iFlags=START_TAG;
+  d.m_pCurrentLine->styleList.AddTail(marker);
+  d.m_pCurrentLine->styleList.AddTail(new CStyle);
+  CActiveTag tag;tag.nOpeningStyleCreationNumber=marker->nCreationNumber;
+  tag.nOpeningLineCreationNumber=d.m_pCurrentLine->nCreationNumber;
+  d.m_ActiveTagList.AddTail(&tag);
+  assert(d.AddToLine("BBBBBZ",0));
+  assert(allText(d)==prefix+"BBBBBZ");
+  assert(tag.nOpeningLineCreationNumber==d.m_pCurrentLine->nCreationNumber);
+  bool found=false;for(auto p=d.m_pCurrentLine->styleList.GetHeadPosition();p;) {
+   auto style=d.m_pCurrentLine->styleList.GetNext(p);
+   if(style->nCreationNumber==tag.nOpeningStyleCreationNumber) {
+    assert(style->iFlags&START_TAG);found=true;
+   }
+  }
+  assert(found);checkStyles(d);d.m_ActiveTagList.RemoveHead();
+ }
+ cout<<"Repeated callbacks, visible failures, null output, transaction ownership, UTF-8, and note controls passed\n";
+}
+#ifndef APPEND_ONLY
+static vector<CMUSHclientDoc::CTriggerLineSnapshot> snapshot(const vector<CLine*>& ls) {
+ vector<CMUSHclientDoc::CTriggerLineSnapshot> result;int column=0;
+ for(auto line:ls){result.push_back({line->nCreationNumber,column,line->len});column+=line->len;}
+ return result;
+}
+static vector<int> changed(CLine* line) {
+ vector<int> result;for(auto p=line->styleList.GetHeadPosition();p;){auto style=line->styleList.GetNext(p);
+ for(int i=0;i<style->iLength;++i)result.push_back((style->iFlags&CHANGED)!=0);}
+ return result;
+}
+static void colourCases() {
+ // Note reaches the pruning threshold while the matched line survives.
+ {
+  CMUSHclientDoc d;d.m_maxlines=200;
+  while(d.m_LineList.GetCount()<200)assert(d.StartNewLine(true,COMMENT));
+  assert(d.AddToLine("matched",0));auto matched=d.m_pCurrentLine;auto saved=snapshot({matched});
+  d.Colour(saved,"matched",1,6,[&]{assert(d.StartNewLine(true,COMMENT));assert(d.AddToLine("note",COMMENT));});
+  assert(d.m_iOutputGeneration==1);assert(changed(matched)==vector<int>({0,1,1,1,1,1,0}));
+  assert(changed(d.m_pCurrentLine)==vector<int>(4,0));checkStyles(d);
+ }
+ // Prune the first wrapped span. Keep the offsets of the second and third spans.
+ for(int removal:{0,1,2,3}) {
+  CMUSHclientDoc d;vector<CLine*> matched;
+  for(auto word:{"abcd","efgh","ijkl"}){assert(d.AddToLine(word,0));matched.push_back(d.m_pCurrentLine);assert(d.StartNewLine(false,COMMENT));}
+  auto saved=snapshot(matched);
+  d.Colour(saved,"abcdefghijkl",2,10,[&]{
+   for(int i=0;i<removal;++i)delete d.m_LineList.RemoveHead();
+   if(removal)++d.m_iOutputGeneration;
+   assert(d.AddToLine("callback",COMMENT));
+  });
+  vector<vector<int>> expected={{0,0,1,1},{1,1,1,1},{1,1,0,0}};
+  for(int i=removal;i<3;++i)assert(changed(matched[i])==expected[i]);
+  assert(changed(d.m_pCurrentLine)==vector<int>(8,0));checkStyles(d);
+ }
+ // Repeated matches, subsequent trigger calls, unchanged generation, and tail growth.
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("ab ab ab",0));auto line=d.m_pCurrentLine;auto saved=snapshot({line});
+  for(int offset:{0,3,6})d.Colour(saved,"ab ab ab",offset,offset+2,[&]{if(offset==0)assert(d.AddToLine(" appended",0));});
+  assert(changed(line)==vector<int>({1,1,0,1,1,0,1,1,0,0,0,0,0,0,0,0,0}));checkStyles(d);
+ }
+ // Deleted text and changed text are not replaced by new callback text.
+ for(bool truncate:{false,true}) {
+  CMUSHclientDoc d;assert(d.AddToLine("abcdef",0));auto line=d.m_pCurrentLine;auto saved=snapshot({line});
+  d.Colour(saved,"abcdef",0,6,[&]{++d.m_iOutputGeneration;
+   if(truncate){line->len=3;line->styleList.GetTail()->iLength=3;}
+   else line->text[0]='X';});
+  assert(changed(line)==vector<int>(truncate?3:6,truncate?1:0));checkStyles(d);
+ }
+ for(int variant:{0,1,2}) {
+  CMUSHclientDoc d;assert(d.AddToLine("abcdef",0));auto line=d.m_pCurrentLine;auto saved=snapshot({line});
+  d.Colour(saved,"abcdef",1,4,[]{},SAMECOLOUR,variant==0,variant==2?HILITE:NORMAL);
+  assert(changed(line)==(variant==2?vector<int>({0,1,1,1,0,0}):vector<int>(6,0)));checkStyles(d);
+ }
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("abcdef",0));auto line=d.m_pCurrentLine;
+  auto original=line->styleList.GetTail();auto range=original->nRangeCreationNumber;
+  original->nOutputAppendCreationNumber=4242;original->pAction=new CAction;
+  auto action=original->pAction;auto saved=snapshot({line});
+  d.Colour(saved,"abcdef",1,4,[]{});
+  assert(line->styleList.GetCount()==3);
+  for(auto p=line->styleList.GetHeadPosition();p;) {
+   auto style=line->styleList.GetNext(p);
+   assert(style->nRangeCreationNumber==range);
+   assert(style->nOutputAppendCreationNumber==4242);
+   assert(style->pAction==action);
+  }
+  assert(action->refs==3);checkStyles(d);
+ }
+ cout<<"Colour pruning, removed spans, repeated matches, callback output, invalidation, and style-only controls passed\n";
+}
+#endif
+static void followupCases();
+int main() {
+ appendCases();
+#ifndef APPEND_ONLY
+ colourCases();
+ followupCases();
+#endif
+ cout<<"All output regression checks passed\n";
+}

--- a/tests/output_test_shim.h
+++ b/tests/output_test_shim.h
@@ -100,8 +100,7 @@ struct CLine {bool hard_return=false;int len=0,iMemoryAllocated,m_nLineNumber,m_
  void ResizeText(int n){assert(n>=len);if(fail_text_resize)throw new CMemoryException;auto p=new char[n];memcpy(p,text,len);delete[]text;text=p;iMemoryAllocated=n;}
 };
 struct CActiveTag{long long nOpeningStyleCreationNumber=0,nOpeningLineCreationNumber=0;};
-class COutputLineBuffer;
-struct COutputAppendTransaction {int created=0,wraps=0;long long Identity(){return 4242;}void TrackLine(const CLine*){}void RecordCreatedLine(){++created;}size_t PrepareWrap(CLine*,int){return 0;}void PublishWrap(size_t,long long,std::unique_ptr<COutputLineBuffer>){++wraps;}};
+struct COutputAppendTransaction {int created=0,wraps=0;long long Identity(){return 4242;}void TrackLine(const CLine*){}void RecordCreatedLine(){++created;}size_t PrepareWrap(CLine*,int){return 0;}template<class... T>void PublishWrap(size_t,long long,T&&...){++wraps;}};
 struct CView {bool IsKindOf(int){return false;}};struct CMUSHView:CView {void did_jump(){}};
 struct AppType {bool m_bUpdateActivity=false;} App;
 void TMessageBox(const char*s){cerr<<s<<'\n';}

--- a/tests/output_test_shim.h
+++ b/tests/output_test_shim.h
@@ -86,7 +86,7 @@ CString FixHTMLString(CString s){s.Replace("&","&amp;");s.Replace("<","&lt;");s.
 CString FormatTime(int,const CString&s,bool){return s;}
 struct CPaneStyle {string m_sText;COLORREF m_cText,m_cBack;int m_iStyle;
  CPaneStyle(const char*s,COLORREF a,COLORREF b,int f):m_sText(s),m_cText(a),m_cBack(b),m_iStyle(f){}};
-long long seq=0; bool fail_next_line=false;
+long long seq=0; bool fail_next_line=false; bool fail_text_resize=false;
 struct CAction {int refs=1;void AddRef(){++refs;} void Release(){if(!--refs)delete this;}};
 struct CStyle {unsigned short iFlags=0,iLength=0;COLORREF iForeColour=7,iBackColour=0;CAction*pAction=nullptr;long long nCreationNumber=++seq,nRangeCreationNumber=nCreationNumber,nOutputAppendCreationNumber=0;~CStyle(){if(pAction)pAction->Release();}};
 #define NEWSTYLE new CStyle
@@ -97,10 +97,11 @@ int MultiByteToWideChar(int,int,char* p,int n,void*,int){int count=0;for(int i=0
 struct CLine {bool hard_return=false;int len=0,iMemoryAllocated,m_nLineNumber,m_theTime=0,m_lineHighPerformanceTime=0;long long nCreationNumber=++seq;char*text;unsigned char flags=0;List<CStyle*>styleList;
  CLine(int number,int wrap,unsigned short f,COLORREF a,COLORREF b,bool utf){m_nLineNumber=number;if(fail_next_line){fail_next_line=false;throw new CMemoryException;}iMemoryAllocated=wrap*(utf?4:1);text=new char[iMemoryAllocated];auto s=new CStyle;s->iFlags=f;s->iForeColour=a;s->iBackColour=b;styleList.AddTail(s);}
  ~CLine(){delete[]text;while(!styleList.IsEmpty())delete styleList.RemoveHead();}
- void ResizeText(int n){assert(n>=len);auto p=new char[n];memcpy(p,text,len);delete[]text;text=p;iMemoryAllocated=n;}
+ void ResizeText(int n){assert(n>=len);if(fail_text_resize)throw new CMemoryException;auto p=new char[n];memcpy(p,text,len);delete[]text;text=p;iMemoryAllocated=n;}
 };
 struct CActiveTag{long long nOpeningStyleCreationNumber=0,nOpeningLineCreationNumber=0;};
-struct COutputAppendTransaction {int created=0,wraps=0;long long Identity(){return 4242;}void TrackLine(const CLine*){}void RecordCreatedLine(){++created;}size_t PrepareWrap(CLine*,int){return 0;}void PublishWrap(size_t,long long){++wraps;}};
+class COutputLineBuffer;
+struct COutputAppendTransaction {int created=0,wraps=0;long long Identity(){return 4242;}void TrackLine(const CLine*){}void RecordCreatedLine(){++created;}size_t PrepareWrap(CLine*,int){return 0;}void PublishWrap(size_t,long long,std::unique_ptr<COutputLineBuffer>){++wraps;}};
 struct CView {bool IsKindOf(int){return false;}};struct CMUSHView:CView {void did_jump(){}};
 struct AppType {bool m_bUpdateActivity=false;} App;
 void TMessageBox(const char*s){cerr<<s<<'\n';}

--- a/tests/output_test_shim.h
+++ b/tests/output_test_shim.h
@@ -1,0 +1,148 @@
+#ifdef NDEBUG
+#error Output regression checks require assertions to be enabled.
+#endif
+
+#define ENDLINE "\r\n"
+#define LOG_LINE 4
+#define NO_COLOUR 0xffffffff
+#define TRIGGER_MATCH_TEXT 0x0080
+#define TRIGGER_MATCH_BACK 0x0800
+#define TRIGGER_MATCH_HILITE 0x1000
+#define TRIGGER_MATCH_BLINK 0x4000
+#define TRIGGER_MATCH_INVERSE 0x8000
+#define NORMAL 0
+#define HILITE 1
+#define UNDERLINE 2
+#define BLINK 4
+#define INVERSE 8
+#define CHANGED 0x10
+#define COLOURTYPE 0x300
+#define COLOUR_RGB 0x200
+#define OTHER_CUSTOM 16
+#define TRIGGER_COLOUR_CHANGE_BOTH 0
+#define TRIGGER_COLOUR_CHANGE_FOREGROUND 1
+#define TRIGGER_COLOUR_CHANGE_BACKGROUND 2
+// Focused MFC substitutes for the extracted output regression checks.
+// These substitutes do not model the Windows UI or transaction rollback.
+
+#include <cassert>
+#include <list>
+#include <deque>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <memory>
+#include <functional>
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <map>
+#include <set>
+#include <stdexcept>
+using namespace std;
+using __int64 = long long; using COLORREF = unsigned; using LPCTSTR = const char*;
+#define ASSERT assert
+#define MAX std::max
+#define MIN std::min
+#define TRUE true
+#define STYLE_BITS 0x0fff
+#define START_TAG 0x1000
+#define COMMENT 1
+#define USER_INPUT 2
+#define NOTE_OR_COMMAND 3
+#define SAMECOLOUR 65535
+#define COLOUR_CUSTOM 0x100
+#define COLOUR_ANSI 0
+#define WHITE 7
+#define BLACK 0
+#define JUMP_SIZE 100
+#define CP_UTF8 65001
+#define NOSOUNDLIT "(No sound)"
+#define RUNTIME_CLASS(x) 0
+struct CMemoryException { void Delete(){delete this;} };
+struct Node {void* value; Node *prev=nullptr,*next=nullptr;}; using POSITION=Node*;
+template<class T> struct List {
+ Node *head=nullptr,*tail=nullptr; int count=0;
+ POSITION GetHeadPosition()const{return head;} POSITION GetTailPosition()const{return tail;}
+ T GetAt(POSITION p){assert(p);return (T)p->value;}
+ T GetHead(){assert(head);return (T)head->value;} T GetTail(){assert(tail);return (T)tail->value;}
+ int GetCount(){return count;} bool IsEmpty(){return !count;}
+ T GetNext(POSITION& p)const{assert(p);T v=(T)p->value;p=p->next;return v;}
+ T GetPrev(POSITION& p){assert(p);T v=(T)p->value;p=p->prev;return v;}
+ POSITION AddTail(T v){auto p=new Node{v,tail,nullptr}; if(tail)tail->next=p;else head=p;tail=p;++count;return p;}
+ void RemoveAt(POSITION p){if(p->prev)p->prev->next=p->next;else head=p->next;if(p->next)p->next->prev=p->prev;else tail=p->prev;delete p;--count;}
+ POSITION InsertAfter(POSITION p,T v){auto n=new Node{v,p,p->next};if(p->next)p->next->prev=n;else tail=n;p->next=n;++count;return n;}
+ T RemoveTail(){T v=GetTail();RemoveAt(tail);return v;} T RemoveHead(){T v=GetHead();RemoveAt(head);return v;}
+};
+struct CString: string {using string::string; CString(const char*p,int n):string(p,n){} CString(const string&s):string(s){}
+ CString Mid(int start,int n)const{return substr(start,n);}
+ int Find(char c)const{auto p=find(c);return p==npos?-1:static_cast<int>(p);}
+ void Replace(const char* from,const char* to){size_t p=0;while((p=find(from,p))!=npos){replace(p,strlen(from),to);p+=strlen(to);}}
+ operator const char*()const{return c_str();} bool IsEmpty()const{return empty();} int GetLength()const{return size();}};
+CString CFormat(const char* fmt,...) {char buf[1024];va_list ap;va_start(ap,fmt);vsnprintf(buf,sizeof(buf),fmt,ap);va_end(ap);return buf;}
+int GetRValue(COLORREF c){return c&255;}int GetGValue(COLORREF c){return (c>>8)&255;}int GetBValue(COLORREF c){return (c>>16)&255;}
+CString FixHTMLString(CString s){s.Replace("&","&amp;");s.Replace("<","&lt;");s.Replace(">","&gt;");return s;}
+CString FormatTime(int,const CString&s,bool){return s;}
+struct CPaneStyle {string m_sText;COLORREF m_cText,m_cBack;int m_iStyle;
+ CPaneStyle(const char*s,COLORREF a,COLORREF b,int f):m_sText(s),m_cText(a),m_cBack(b),m_iStyle(f){}};
+long long seq=0; bool fail_next_line=false;
+struct CAction {int refs=1;void AddRef(){++refs;} void Release(){if(!--refs)delete this;}};
+struct CStyle {unsigned short iFlags=0,iLength=0;COLORREF iForeColour=7,iBackColour=0;CAction*pAction=nullptr;long long nCreationNumber=++seq,nRangeCreationNumber=nCreationNumber,nOutputAppendCreationNumber=0;~CStyle(){if(pAction)pAction->Release();}};
+#define NEWSTYLE new CStyle
+#define DELETESTYLE(x) delete (x)
+struct CTime {static int GetCurrentTime(){return 0;}};
+void QueryPerformanceCounter(int*){}
+int MultiByteToWideChar(int,int,char* p,int n,void*,int){int count=0;for(int i=0;i<n;++i)if((p[i]&0xc0)!=0x80)++count;return count;}
+struct CLine {bool hard_return=false;int len=0,iMemoryAllocated,m_nLineNumber,m_theTime=0,m_lineHighPerformanceTime=0;long long nCreationNumber=++seq;char*text;unsigned char flags=0;List<CStyle*>styleList;
+ CLine(int number,int wrap,unsigned short f,COLORREF a,COLORREF b,bool utf){m_nLineNumber=number;if(fail_next_line){fail_next_line=false;throw new CMemoryException;}iMemoryAllocated=wrap*(utf?4:1);text=new char[iMemoryAllocated];auto s=new CStyle;s->iFlags=f;s->iForeColour=a;s->iBackColour=b;styleList.AddTail(s);}
+ ~CLine(){delete[]text;while(!styleList.IsEmpty())delete styleList.RemoveHead();}
+ void ResizeText(int n){assert(n>=len);auto p=new char[n];memcpy(p,text,len);delete[]text;text=p;iMemoryAllocated=n;}
+};
+struct CActiveTag{long long nOpeningStyleCreationNumber=0,nOpeningLineCreationNumber=0;};
+struct COutputAppendTransaction {int created=0,wraps=0;long long Identity(){return 4242;}void TrackLine(const CLine*){}void RecordCreatedLine(){++created;}size_t PrepareWrap(CLine*,int){return 0;}void PublishWrap(size_t,long long){++wraps;}};
+struct CView {bool IsKindOf(int){return false;}};struct CMUSHView:CView {void did_jump(){}};
+struct AppType {bool m_bUpdateActivity=false;} App;
+void TMessageBox(const char*s){cerr<<s<<'\n';}
+struct CMUSHclientDoc {
+ CLine*m_pCurrentLine=nullptr;List<CLine*>m_LineList;List<CActiveTag*>m_ActiveTagList;
+ int m_nWrapColumn=80,m_total_lines=0,m_maxlines=1000,m_iFlags=0,m_echo_colour=SAMECOLOUR,m_iNoteTextColour=SAMECOLOUR,m_new_lines=0;
+ COLORREF m_iForeColour=7,m_iBackColour=0;bool m_bUTF_8=false,m_wrap=true,m_indent_paras=false,m_bCustom16isDefaultColour=false;
+ void*m_pActiveCommandView=this,*m_pActiveOutputView=this;POSITION m_pLinePositions[11]={};CString m_new_activity_sound;
+ function<void()> callback;int processed=0,callbacks=0,disconnects=0;
+ CMUSHclientDoc(){m_pCurrentLine=new CLine(++m_total_lines,80,0,7,0,false);m_LineList.AddTail(m_pCurrentLine);}
+ ~CMUSHclientDoc(){while(!m_LineList.IsEmpty())delete m_LineList.RemoveHead();}
+ void SendLineToPlugin(){++callbacks;if(callback)callback();}bool ProcessPreviousLine(){++processed;m_pCurrentLine->hard_return=true;return false;}
+ POSITION GetFirstViewPosition(){return nullptr;}CView*GetNextView(POSITION&){abort();}
+ long long m_iOutputGeneration=0; struct {int m_nCurrentLine=0;} m_DisplayFindInfo;
+ void RemoveChunk();void OnConnectionDisconnect(){++disconnects;}void PlaySoundFile(const CString&){}
+ struct CTriggerLineSnapshot {long long iCreationNumber;int iColumn,iLength;};
+ bool m_bLineOmittedFromOutput=false;
+ bool m_logfile=false,m_bLogRaw=false,m_bLogHTML=false,m_bLogInColour=false;
+ CString m_strLogLinePreambleOutput,m_strLogLinePostambleOutput;
+ int m_iStopTriggerEvaluation=0;long m_newlines_received=0;
+ static constexpr int eStopEvaluatingTriggersInAllPlugins=2;
+ deque<string> m_sRecentLines;list<CPaneStyle> m_OutstandingLines;
+ string logText,screenText,replayedText;
+ void WriteToLog(const char*s,size_t n){logText.append(s,n);}void WriteToLog(const CString&s){logText+=s;}
+ void RefreshMXPMissingTagAnchors(){}
+ void Screendraw(int,bool,const CString&s){screenText+=s;}
+ void OutputOutstandingLines(){for(const auto& s:m_OutstandingLines)replayedText+=s.m_sText;m_OutstandingLines.clear();}
+ void LogLineInHTMLcolour(POSITION,const map<__int64,int>* =nullptr);
+ void Finalize(const vector<CTriggerLineSnapshot>&,long long,POSITION,bool,bool,const CString&,long=0);
+ bool Match(const vector<CTriggerLineSnapshot>&,const CString&,int,int,function<void()>);
+ bool FindStyle(const CLine*,int,int&,CStyle*&,POSITION&)const;
+ void GetStyleRGB(CStyle* s,COLORREF& a,COLORREF& b)const{a=s->iForeColour;b=s->iBackColour;}
+ void Colour(const vector<CTriggerLineSnapshot>&,const CString&,int,int,function<void()>,int=1,bool=false,int=0);
+ bool StartNewLine(bool,int,bool=true,bool * =nullptr);
+ bool FinishNewLine(int,bool,bool*);
+ bool StartNewLine_KeepPreviousStyle(int,bool * =nullptr,bool=false);
+ bool AddToLine(LPCTSTR,int);bool AddToLineInternal(LPCTSTR,int,COutputAppendTransaction*);
+ void SimulateNewlineAndFill(){
+  const bool started=StartNewLine(true,0);
+  assert(started);
+  string s(80,'B');
+  const bool added=AddToLine(s.c_str(),0);
+  assert(added);
+ }
+};

--- a/tests/output_transactions.py
+++ b/tests/output_transactions.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Check complete production output transactions and count retained-style visits."""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+from output_callbacks import section, replace_once
+
+
+def run(source, output, revision):
+    def read(path):
+        if revision:
+            return subprocess.check_output(
+                ['git', '-C', str(source), 'show', revision + ':' + path], text=True)
+        return (source / path).read_text()
+    doc = read('doc.cpp')
+    header = read('doc.h')
+    shim_path = Path(__file__).parent / 'output_test_shim.h'
+    shim = shim_path.read_text()
+
+    def patch(expected, replacement):
+        nonlocal shim
+        shim = replace_once(shim, expected, replacement, shim_path)
+    begin = shim.index('struct COutputAppendTransaction {')
+    end = shim.index('\nstruct CView', begin)
+    shim = shim[:begin] + 'class COutputAppendTransaction;\n' + shim[end:]
+    patch('#include <cassert>', '#include <cassert>\n#include <type_traits>')
+    patch('template<class T> struct List', '''
+struct CLine;struct CStyle;
+long long lineReads=0,styleReads=0;
+template<class T> void countRead() {
+ if constexpr (is_same<T,CLine*>::value)++lineReads;
+ if constexpr (is_same<T,CStyle*>::value)++styleReads;
+}
+template<class T> struct List''')
+    patch('T GetNext(POSITION& p)const{', 'T GetNext(POSITION& p)const{countRead<T>();')
+    patch('T GetPrev(POSITION& p){', 'T GetPrev(POSITION& p){countRead<T>();')
+    patch('struct AppType {', 'struct AppType {long long GetUniqueNumber(){return ++seq;}')
+    patch('POSITION m_pLinePositions[11]={};',
+                        'POSITION positionStorage[10002]={};POSITION* m_pLinePositions=positionStorage;')
+    patch(' long long m_iOutputGeneration=0;',
+                        ' int m_iListMode=0,m_iListCount=0;long long m_iMXPListOwner=0;\n long long m_iOutputGeneration=0;')
+    declaration = section(header, 'class COutputAppendTransaction\n',
+                          '/////////////////////////////////////////////////////////////////////////////\n\nclass CAliasExecutionGuard')
+    body = '\n'.join([
+        section(doc, 'bool CMUSHclientDoc::StartNewLine_KeepPreviousStyle',
+                '// called when starting a new line to get colours right'),
+        section(doc, 'bool CMUSHclientDoc::StartNewLine (',
+                'const bool CMUSHclientDoc::CheckScriptingAvailable'),
+        section(doc, ' void CMUSHclientDoc::RemoveChunk (void)',
+                'void CMUSHclientDoc::ShowStatusLine'),
+    ])
+    main = (Path(__file__).parent / 'output_transactions_main.cpp').read_text()
+    cpp = output / 'output_transactions.cpp'
+    cpp.write_text(('#define EXPECT_HISTORY_SCAN\n' if revision else '') + shim + declaration + body + main)
+    binary = output / 'output_transactions'
+    subprocess.run(['clang++', '-std=c++17', '-fsanitize=address,undefined',
+                    '-fno-sanitize-recover=all', '-g', '-O1', str(cpp), '-o', str(binary)], check=True)
+    result = subprocess.run([str(binary)], text=True, capture_output=True)
+    (output / 'run.log').write_text(result.stdout + result.stderr)
+    print(result.stdout + result.stderr, end='')
+    result.check_returncode()
+    (output / 'result.json').write_text(json.dumps({
+        'revision': revision or 'working tree', 'exit_code': result.returncode,
+        'output': result.stdout.splitlines(),
+        'method': 'Complete extracted transaction and append functions. List substitutes count GetNext/GetPrev calls. No native timing claim.'
+    }, indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source', type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--output', type=Path)
+    parser.add_argument('--baseline-ref')
+    args = parser.parse_args()
+    if args.output:
+        args.output.mkdir(parents=True, exist_ok=True)
+        run(args.source, args.output, args.baseline_ref)
+    else:
+        with tempfile.TemporaryDirectory(prefix='mushclient-transactions-') as temp:
+            run(args.source, Path(temp), args.baseline_ref)

--- a/tests/output_transactions.py
+++ b/tests/output_transactions.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 import subprocess
 import tempfile
-from output_callbacks import section, replace_once
+from output_callbacks import line_buffer_header, section, replace_once
 
 
 def run(source, output, revision):
@@ -42,18 +42,18 @@ template<class T> struct List''')
     patch(' long long m_iOutputGeneration=0;',
                         ' int m_iListMode=0,m_iListCount=0;long long m_iMXPListOwner=0;\n long long m_iOutputGeneration=0;')
     declaration = section(header, 'class COutputAppendTransaction\n',
-                          '/////////////////////////////////////////////////////////////////////////////\n\nclass CAliasExecutionGuard')
+                          '/////////////////////////////////////////////////////////////////////////////\n\nclass CAliasExecutionGuard', 'doc.h')
     body = '\n'.join([
         section(doc, 'bool CMUSHclientDoc::StartNewLine_KeepPreviousStyle',
-                '// called when starting a new line to get colours right'),
+                '// called when starting a new line to get colours right', 'doc.cpp'),
         section(doc, 'bool CMUSHclientDoc::StartNewLine (',
-                'const bool CMUSHclientDoc::CheckScriptingAvailable'),
+                'const bool CMUSHclientDoc::CheckScriptingAvailable', 'doc.cpp'),
         section(doc, ' void CMUSHclientDoc::RemoveChunk (void)',
-                'void CMUSHclientDoc::ShowStatusLine'),
+                'void CMUSHclientDoc::ShowStatusLine', 'doc.cpp'),
     ])
     main = (Path(__file__).parent / 'output_transactions_main.cpp').read_text()
     cpp = output / 'output_transactions.cpp'
-    cpp.write_text(('#define EXPECT_HISTORY_SCAN\n' if revision else '') + shim + declaration + body + main)
+    cpp.write_text(('#define EXPECT_HISTORY_SCAN\n' if revision else '') + shim + line_buffer_header(source, revision) + declaration + body + main)
     binary = output / 'output_transactions'
     subprocess.run(['clang++', '-std=c++17', '-fsanitize=address,undefined',
                     '-fno-sanitize-recover=all', '-g', '-O1', str(cpp), '-o', str(binary)], check=True)

--- a/tests/output_transactions_main.cpp
+++ b/tests/output_transactions_main.cpp
@@ -1,0 +1,160 @@
+static string txText(CMUSHclientDoc& d) {
+ string result;for(auto p=d.m_LineList.GetHeadPosition();p;){auto line=d.m_LineList.GetNext(p);result.append(line->text,line->len);}return result;
+}
+static void txCheck(CMUSHclientDoc& d) {
+ for(auto p=d.m_LineList.GetHeadPosition();p;) {
+  auto line=d.m_LineList.GetNext(p);int total=0;
+  assert(line->len<=line->iMemoryAllocated);
+  for(auto s=line->styleList.GetHeadPosition();s;)total+=line->styleList.GetNext(s)->iLength;
+  assert(total==line->len);
+ }
+}
+static bool hasOwner(CMUSHclientDoc& d,long long owner) {
+ for(auto p=d.m_LineList.GetHeadPosition();p;){auto line=d.m_LineList.GetNext(p);
+  for(auto s=line->styleList.GetHeadPosition();s;)if(line->styleList.GetNext(s)->nOutputAppendCreationNumber==owner)return true;}
+ return false;
+}
+static void history(CMUSHclientDoc& d,int count) {
+ d.m_maxlines=count+1000;
+ while(d.m_LineList.GetCount()<count){auto line=new CLine(++d.m_total_lines,80,0,7,0,false);d.m_LineList.AddTail(line);d.m_pCurrentLine=line;}
+}
+static void performanceCases() {
+ for (bool rollback : {false, true})
+  for(int count:{1000,10000,100000})for(int mode:{0,1,2}) {
+   CMUSHclientDoc d;history(d,count);
+   if(mode==2) {
+    assert(d.AddToLine((string(72,'A')+" ").c_str(),0));
+    auto style=new CStyle;style->iForeColour=2;d.m_pCurrentLine->styleList.AddTail(style);
+    assert(d.AddToLine(string(7,'B').c_str(),0));
+   } else assert(d.AddToLine("base",0));
+   auto before=txText(d);
+   COutputAppendTransaction tx(&d,1);tx.MarkCurrentLineStyles();tx.PrepareAppendStyle();
+   if(mode==1){bool created=false;assert(tx.StartNewLine(false,0,true,&created));assert(created);}
+   else assert(d.AddToLineInternal("Z",0,&tx));
+   lineReads=styleReads=0;
+   if(rollback)tx.Rollback();else tx.Commit();
+   auto visitedLines=lineReads,visitedStyles=styleReads;
+   cout<<(rollback?"rollback":"commit")<<" history="<<count<<" mode="<<mode
+       <<" lines="<<visitedLines<<" styles="<<visitedStyles<<"\n";
+#ifdef EXPECT_HISTORY_SCAN
+   assert(visitedStyles>=count);
+#else
+   // Removing a line still rebuilds the sparse position array once. Style
+   // processing and individual identity lookups must not scan old history.
+   assert(visitedLines <= (rollback && mode != 0 ? count + 20 : 5));
+   assert(visitedStyles<=12);
+#endif
+   assert(!hasOwner(d,tx.Identity()) && !hasOwner(d,-tx.Identity()));
+   assert(txText(d)==before+(rollback || mode==1?"":"Z"));txCheck(d);
+  }
+}
+static void unseenLineCases() {
+ for(bool commandActive:{false,true})for(bool outputActive:{false,true})
+  for(bool rollback:{false,true}) {
+   CMUSHclientDoc d;
+   d.m_pActiveCommandView=commandActive?&d:nullptr;
+   d.m_pActiveOutputView=outputActive?&d:nullptr;
+   assert(d.AddToLine("base",0));
+   COutputAppendTransaction tx(&d,4);tx.MarkCurrentLineStyles();
+   bool created=false;
+   assert(tx.StartNewLine(false,0,true,&created) && created);
+   assert(d.m_new_lines==(!commandActive && !outputActive?1:0));
+   assert(d.AddToLineInternal("new",0,&tx));
+   if(rollback)tx.Rollback();else tx.Commit();
+   assert(d.m_new_lines==(!rollback && !commandActive && !outputActive?1:0));
+   assert(txText(d)==(rollback?"base":"basenew"));txCheck(d);
+  }
+ cout<<"Unseen-line commit and rollback: all four active-view states passed\n";
+}
+static void ownerCases() {
+ // Inner commit must not clear either sign of the outer owner.
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("base ",0));
+  COutputAppendTransaction outer(&d,16);outer.MarkCurrentLineStyles();outer.PrepareAppendStyle();
+  assert(d.AddToLineInternal("outer",0,&outer));
+  COutputAppendTransaction inner(&d,16);inner.MarkCurrentLineStyles();inner.PrepareAppendStyle();
+  assert(d.AddToLineInternal("inner",0,&inner));inner.Commit();
+  assert(hasOwner(d,outer.Identity()) && hasOwner(d,-outer.Identity()));
+  assert(!hasOwner(d,inner.Identity()));outer.Rollback();
+  assert(txText(d)=="base inner");txCheck(d);
+ }
+ // An outer commit must leave an active inner owner for its own rollback.
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("base ",0));
+  COutputAppendTransaction outer(&d,16);outer.MarkCurrentLineStyles();outer.PrepareAppendStyle();
+  assert(d.AddToLineInternal("outer",0,&outer));
+  COutputAppendTransaction inner(&d,16);inner.MarkCurrentLineStyles();inner.PrepareAppendStyle();
+  assert(d.AddToLineInternal("inner",0,&inner));outer.Commit();
+  assert(hasOwner(d,inner.Identity()));inner.Rollback();assert(txText(d)=="base outer");txCheck(d);
+ }
+ // Real word wrapping splits one preserved style and moves another completely.
+ for(bool rollback:{false,true}) {
+  CMUSHclientDoc d;assert(d.AddToLine((string(72,'A')+" ").c_str(),0));
+  auto style=new CStyle;style->pAction=new CAction;auto action=style->pAction;
+  d.m_pCurrentLine->styleList.AddTail(style);assert(d.AddToLine("BBBBBBB",0));
+  string before=txText(d);COutputAppendTransaction tx(&d,4);tx.MarkCurrentLineStyles();tx.PrepareAppendStyle();
+  assert(d.AddToLineInternal("Z",0,&tx));assert(hasOwner(d,tx.Identity()) && hasOwner(d,-tx.Identity()));
+  if(rollback)tx.Rollback();else tx.Commit();
+  assert(txText(d)==before+(rollback?"":"Z"));assert(action->refs==(rollback?1:2));
+  assert(!hasOwner(d,tx.Identity()) && !hasOwner(d,-tx.Identity()));txCheck(d);
+ }
+ // A callback's nested committed output survives the outer append rollback.
+ {
+  CMUSHclientDoc d;assert(d.AddToLine(string(80,'A').c_str(),0));
+  COutputAppendTransaction outer(&d,4);outer.MarkCurrentLineStyles();outer.PrepareAppendStyle();bool done=false;
+  long long callbackId=0;
+  d.callback=[&]{if(done)return;done=true;assert(d.StartNewLine(true,0));callbackId=d.m_pCurrentLine->nCreationNumber;
+   COutputAppendTransaction inner(&d,80);inner.MarkCurrentLineStyles();inner.PrepareAppendStyle();
+   assert(d.AddToLineInternal(string(80,'B').c_str(),0,&inner));inner.Commit();};
+  assert(d.AddToLineInternal("Z",0,&outer));outer.Rollback();
+  assert(txText(d)==string(80,'A')+string(80,'B'));assert(d.m_pCurrentLine->nCreationNumber==callbackId);txCheck(d);
+ }
+ // Explicit ownership of an older style remains supported.
+ {
+  CMUSHclientDoc d;auto old=d.m_pCurrentLine->styleList.GetTail();history(d,1000);
+  COutputAppendTransaction tx(&d,1);tx.OwnStyle(old);tx.Commit();assert(old->nOutputAppendCreationNumber==0);
+ }
+ // A style owned before list publication remains supported.
+ {
+  CMUSHclientDoc d;auto old=d.m_pCurrentLine;history(d,1000);
+  COutputAppendTransaction tx(&d,1);auto style=new CStyle;tx.OwnStyle(style);old->styleList.AddTail(style);
+  tx.Commit();assert(style->nOutputAppendCreationNumber==0);
+ }
+ // Losing the original boundary must not retain an invalid pointer or stale owner.
+ for(bool appendAgain:{false,true}) {
+  CMUSHclientDoc d;history(d,1000);COutputAppendTransaction tx(&d,1);tx.MarkCurrentLineStyles();
+  delete d.m_LineList.RemoveTail();--d.m_total_lines;d.m_pCurrentLine=d.m_LineList.GetTail();++d.m_iOutputGeneration;
+  if(appendAgain){tx.PrepareAppendStyle();assert(d.AddToLineInternal("Z",0,&tx));}
+  tx.Commit();assert(!hasOwner(d,tx.Identity()) && !hasOwner(d,-tx.Identity()));txCheck(d);
+ }
+ // Callback pruning removes the boundary; later styles and their owners are still visited.
+ {
+  CMUSHclientDoc d;COutputAppendTransaction tx(&d,4);tx.MarkCurrentLineStyles();
+  history(d,200);d.RemoveChunk();tx.PrepareAppendStyle();assert(d.AddToLineInternal("Z",0,&tx));
+  tx.Commit();assert(!hasOwner(d,tx.Identity()) && !hasOwner(d,-tx.Identity()));txCheck(d);
+ }
+ // Colour-style splitting retains ownership on all fragments in the affected line.
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("abcdef",0));COutputAppendTransaction tx(&d,4);tx.MarkCurrentLineStyles();
+  auto first=d.m_pCurrentLine->styleList.GetTail();first->iLength=2;
+  auto middle=new CStyle;middle->iLength=2;middle->nRangeCreationNumber=first->nRangeCreationNumber;
+  middle->nOutputAppendCreationNumber=first->nOutputAppendCreationNumber;d.m_pCurrentLine->styleList.AddTail(middle);
+  auto last=new CStyle;last->iLength=2;last->nRangeCreationNumber=first->nRangeCreationNumber;
+  last->nOutputAppendCreationNumber=first->nOutputAppendCreationNumber;d.m_pCurrentLine->styleList.AddTail(last);
+  tx.Commit();assert(first->nOutputAppendCreationNumber==0 && middle->nOutputAppendCreationNumber==0 && last->nOutputAppendCreationNumber==0);txCheck(d);
+ }
+ // Rollback retains line/list state restoration and visible allocation failures.
+ {
+  CMUSHclientDoc d;assert(d.AddToLine("base",0));auto original=d.m_pCurrentLine;
+  COutputAppendTransaction tx(&d,1);tx.SetLineFlags(original,COMMENT);tx.SetListCount(7);
+  tx.PrepareAppendStyle();assert(d.AddToLineInternal("x",0,&tx));tx.Rollback();
+  assert(txText(d)=="base" && original->flags==0 && d.m_iListCount==0);txCheck(d);
+ }
+ {
+  CMUSHclientDoc d;assert(d.AddToLine(string(80,'A').c_str(),0));COutputAppendTransaction tx(&d,1);
+  tx.MarkCurrentLineStyles();tx.PrepareAppendStyle();fail_next_line=true;
+  assert(!d.AddToLineInternal("Z",0,&tx));tx.Rollback();assert(txText(d)==string(80,'A'));txCheck(d);
+ }
+ cout<<"Complete transaction ownership, nested commit/rollback, moved/split styles, callbacks, pruning, and failures passed\n";
+}
+int main(){performanceCases();ownerCases();unseenLineCases();}

--- a/tests/output_transactions_main.cpp
+++ b/tests/output_transactions_main.cpp
@@ -157,4 +157,62 @@ static void ownerCases() {
  }
  cout<<"Complete transaction ownership, nested commit/rollback, moved/split styles, callbacks, pruning, and failures passed\n";
 }
-int main(){performanceCases();ownerCases();unseenLineCases();}
+static void restorationCases() {
+ // A partial-line callback can shrink the old line before wrap publication.
+ for(bool failCallback:{false,true}) {
+  CMUSHclientDoc d;
+  const string before=string(72,'A')+" "+string(7,'B');
+  assert(d.AddToLine(before.c_str(),0));
+  auto old=d.m_pCurrentLine;
+  COutputAppendTransaction tx(&d,1);tx.MarkCurrentLineStyles();tx.PrepareAppendStyle();
+  bool called=false;
+  d.callback=[&]{if(called)return;called=true;
+   d.m_nWrapColumn=20;old->ResizeText(old->len);
+   if(failCallback){fail_text_resize=true;throw 37;}};
+  bool caught=false;
+  try {assert(d.AddToLineInternal("Z",0,&tx));}
+  catch(int error){assert(error==37);caught=true;}
+  assert(called && caught==failCallback);
+  // Rollback must also work when another resize allocation cannot succeed.
+  fail_text_resize=true;tx.Rollback();fail_text_resize=false;
+  assert(txText(d)==before && d.m_pCurrentLine==old);txCheck(d);
+ }
+ // Restore a nontransactional append before rethrowing the original callback error.
+ {
+  CMUSHclientDoc d;const string before=string(72,'A')+" "+string(7,'B');
+  assert(d.AddToLine(before.c_str(),0));
+  d.callback=[&]{d.m_pCurrentLine->ResizeText(d.m_pCurrentLine->len);
+   fail_text_resize=true;throw 41;};
+  bool caught=false;
+  try{d.AddToLine("Z",0);}catch(int error){assert(error==41);caught=true;}
+  fail_text_resize=false;assert(caught && txText(d)==before);txCheck(d);
+ }
+ // The callback can make the continuation narrower than the saved word.
+ for(bool failContinuation:{false,true}) {
+  CMUSHclientDoc d;const string before=string(20,'A')+" "+string(59,'B');
+  assert(d.AddToLine(before.c_str(),0));
+  COutputAppendTransaction tx(&d,1);tx.MarkCurrentLineStyles();tx.PrepareAppendStyle();
+  bool called=false;
+  d.callback=[&]{if(called)return;called=true;d.m_nWrapColumn=20;
+   d.m_pCurrentLine->ResizeText(d.m_pCurrentLine->len);
+   fail_text_resize=failContinuation;};
+  bool caught=false;
+  try{assert(d.AddToLineInternal("Z",0,&tx));}
+  catch(CMemoryException* error){caught=true;error->Delete();}
+  assert(caught==failContinuation);txCheck(d);
+  tx.Rollback();fail_text_resize=false;assert(txText(d)==before);txCheck(d);
+ }
+ // Allocation cleanup can delete every buffered line at exactly JUMP_SIZE.
+ for(int count:{JUMP_SIZE-1,JUMP_SIZE,JUMP_SIZE+1}) {
+  CMUSHclientDoc d;history(d,count);fail_next_line=true;
+  assert(!d.FinishNewLine(0,true,nullptr));
+  assert(d.disconnects==1);
+  assert(d.m_pCurrentLine==(d.m_LineList.IsEmpty()?nullptr:d.m_LineList.GetTail()));
+  if(d.m_pCurrentLine)assert(d.AddToLine("after failure",0));
+  else {assert(!d.AddToLine("after failure",0));assert(d.StartNewLine(false,0));
+   assert(d.AddToLine("after recovery",0));}
+  txCheck(d);
+ }
+ cout<<"Shrunk-buffer restoration, original exceptions, narrow continuation, and empty-buffer allocation cleanup passed\n";
+}
+int main(){performanceCases();ownerCases();unseenLineCases();restorationCases();}


### PR DESCRIPTION
Preserve output lines, styles, and MXP tags by stable identities. Make appends and tag operations restore only their own changes after failure, keep later callback output, and allocate wrap buffers for the full UTF-8 text.

Depends on #71. Review and merge #71 first; #16 follows this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing MXP tags, including nested tags, callbacks, state restoration, and cleanup after errors.
  * Improved output handling during wrapping, pruning, trigger callbacks, and line updates to preserve text and styling.
  * Improved UTF-8 buffer resizing and handling of allocation failures.
  * Improved plugin-context restoration during entity processing and configuration updates.
  * Improved logging accuracy after output changes and line pruning.

* **Tests**
  * Added extensive regression coverage for MXP processing, output callbacks, wrapping, transactions, cleanup, and UTF-8 option changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->